### PR TITLE
Claude Add changelog automation: POCHANGELOG.md and end_session.py integration

### DIFF
--- a/CONTEXT_MAP.md
+++ b/CONTEXT_MAP.md
@@ -1,5 +1,5 @@
 # Ontos Context Map
-Generated on: 2025-11-30 01:59:26
+Generated on: 2025-11-30 21:10:09
 Scanned Directory: `docs`
 
 ## 1. Hierarchy Tree
@@ -13,6 +13,9 @@ Scanned Directory: `docs`
 - **log_20251125_refining_documentation** (2025-11-25_refining-documentation.md)
   - Status: active
   - Depends On: None
+- **log_20251130_production_ready_fixes** (2025-11-30_production-ready-fixes.md)
+  - Status: active
+  - Depends On: None
 
 
 ## 2. Dependency Audit
@@ -24,3 +27,4 @@ No issues found.
 | log_20251125_deployment_guide_update | [2025-11-25_deployment-guide-update.md](docs/logs/2025-11-25_deployment-guide-update.md) | atom |
 | log_20251125_iteration_3_complete | [2025-11-25_iteration-3-complete.md](docs/logs/2025-11-25_iteration-3-complete.md) | atom |
 | log_20251125_refining_documentation | [2025-11-25_refining-documentation.md](docs/logs/2025-11-25_refining-documentation.md) | atom |
+| log_20251130_production_ready_fixes | [2025-11-30_production-ready-fixes.md](docs/logs/2025-11-30_production-ready-fixes.md) | atom |

--- a/POCHANGELOG.md
+++ b/POCHANGELOG.md
@@ -1,11 +1,34 @@
-# Changelog
+---
+id: po-changelog
+title: Project Ontos Changelog
+type: kernel
+scope: ontos-tooling-only
+update_policy: |
+  IMPORTANT: Only update this file when making changes to Project Ontos ITSELF
+  (scripts/, protocol schema, agent instructions, Ontos documentation).
 
-All notable changes to Project Ontos will be documented in this file.
+  Do NOT update this file when working on projects that USE Ontos as their
+  documentation system. Those projects should have their own CHANGELOG.md.
+depends_on: []
+---
+
+# Project Ontos Changelog
+
+All notable changes to **Project Ontos itself** (the protocol and tooling) will be documented in this file.
+
+> **For AI Agents**: This changelog is for the Ontos tooling only. If you're working on a project that *uses* Ontos, update that project's `CHANGELOG.md` instead (via `end_session.py --changelog`).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+- Changelog integration in `end_session.py` (prompts for changelog entries)
+- `POCHANGELOG.md` for Project Ontos tooling changes (distinct from project changelogs)
+
+### Changed
+- Renamed `CHANGELOG.md` to `POCHANGELOG.md` with YAML frontmatter for agent clarity
 
 ## [0.4.0] - 2025-11-29
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Ontos is a lightweight protocol that turns your documentation folder into a stru
 - **[Agent Instructions](docs/reference/Ontos_Agent_Instructions.md)**: The system prompt for your AI agents.
 
 ### Meta
-- **[Changelog](CHANGELOG.md)**: Version history and changes.
+- **[Project Ontos Changelog](POCHANGELOG.md)**: Version history for Ontos tooling itself.
 
 ## Quick Start
 
@@ -85,4 +85,7 @@ python3 scripts/migrate_frontmatter.py
 
 # Create session log
 python3 scripts/end_session.py "session-name"
+
+# Create session log with changelog entry
+python3 scripts/end_session.py "session-name" --changelog
 ```

--- a/docs/reference/Ontos_Agent_Instructions.md
+++ b/docs/reference/Ontos_Agent_Instructions.md
@@ -36,10 +36,21 @@ If you create a new file or change dependencies:
 ### 3. Session Archival
 When the user says **"Ontos archive"** (or "Archive our session"):
 1.  **Final Polish**: Run `python3 scripts/generate_context_map.py` one last time to ensure the graph is clean and up-to-date. Fix any issues found.
-2.  Run `python3 scripts/end_session.py "slug-for-session"`.
+2.  Run `python3 scripts/end_session.py "slug-for-session" --changelog` to create a session log AND prompt for changelog entries.
 3.  **READ** the generated log file.
 4.  **OVERWRITE** the placeholders in the file with a high-quality summary of the session (Goal, Decisions, Changes, Next Steps).
 5.  Commit the changes.
+
+### Changelog Guidelines
+
+**Two types of changelogs exist:**
+
+| File | Purpose | When to Update |
+|------|---------|----------------|
+| `POCHANGELOG.md` | Changes to Project Ontos tooling itself | Only when modifying Ontos scripts, protocol, or docs |
+| `CHANGELOG.md` | Changes to the project using Ontos | During normal development sessions |
+
+**Important**: When working on a project that *uses* Ontos as its documentation system, update that project's `CHANGELOG.md` via the `--changelog` flag in `end_session.py`. **Never** update `POCHANGELOG.md` unless you are directly modifying Project Ontos itself.
 
 ### 4. Maintenance (Weekly Ritual)
 When the user says **"Maintain Ontos"** (or "Ontos maintenance"):

--- a/scripts/end_session.py
+++ b/scripts/end_session.py
@@ -1,4 +1,4 @@
-"""Scaffold a new session log file for Ontos."""
+"""Scaffold a new session log file for Ontos with optional changelog integration."""
 
 import os
 import re
@@ -12,6 +12,12 @@ from config import __version__, LOGS_DIR
 # Valid slug pattern: lowercase letters, numbers, and hyphens
 VALID_SLUG_PATTERN = re.compile(r'^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$')
 MAX_SLUG_LENGTH = 50
+
+# Changelog categories per Keep a Changelog spec
+CHANGELOG_CATEGORIES = ['added', 'changed', 'deprecated', 'removed', 'fixed', 'security']
+
+# Default changelog path (relative to project root)
+DEFAULT_CHANGELOG = 'CHANGELOG.md'
 
 
 def validate_topic_slug(slug: str) -> tuple[bool, str]:
@@ -72,6 +78,184 @@ def get_daily_git_log() -> str:
         return "Git is not installed or not in PATH."
     except Exception as e:
         return f"Error running git: {e}"
+
+
+def find_changelog() -> str:
+    """Find the project's CHANGELOG.md file.
+
+    Searches current directory and parent directories up to git root.
+
+    Returns:
+        Path to CHANGELOG.md or empty string if not found.
+    """
+    # Start from current directory
+    current = os.getcwd()
+
+    while True:
+        changelog_path = os.path.join(current, DEFAULT_CHANGELOG)
+        if os.path.exists(changelog_path):
+            return changelog_path
+
+        # Check if we're at git root or filesystem root
+        git_dir = os.path.join(current, '.git')
+        parent = os.path.dirname(current)
+
+        if os.path.exists(git_dir) or parent == current:
+            # We're at git root or filesystem root, stop searching
+            break
+
+        current = parent
+
+    return ""
+
+
+def create_changelog() -> str:
+    """Create a new CHANGELOG.md file with standard template.
+
+    Returns:
+        Path to created file or empty string on error.
+    """
+    changelog_path = DEFAULT_CHANGELOG
+
+    today = datetime.datetime.now().strftime("%Y-%m-%d")
+    content = f"""# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+"""
+
+    try:
+        with open(changelog_path, 'w', encoding='utf-8') as f:
+            f.write(content)
+        return changelog_path
+    except (IOError, OSError, PermissionError) as e:
+        print(f"Error: Failed to create CHANGELOG.md: {e}")
+        return ""
+
+
+def prompt_changelog_entry(quiet: bool = False) -> tuple[str, str]:
+    """Prompt user for changelog entry details.
+
+    Args:
+        quiet: If True, skip prompts and return empty.
+
+    Returns:
+        Tuple of (category, description) or empty strings if skipped.
+    """
+    if quiet:
+        return "", ""
+
+    print("\n--- Changelog Entry ---")
+    print("Categories: added, changed, deprecated, removed, fixed, security")
+    print("(Press Enter to skip)\n")
+
+    try:
+        category = input("Category: ").strip().lower()
+        if not category:
+            return "", ""
+
+        if category not in CHANGELOG_CATEGORIES:
+            print(f"Warning: '{category}' is not a standard category. Using anyway.")
+
+        description = input("Description: ").strip()
+        if not description:
+            print("Skipping changelog entry (no description).")
+            return "", ""
+
+        return category, description
+    except (EOFError, KeyboardInterrupt):
+        print("\nSkipping changelog entry.")
+        return "", ""
+
+
+def add_changelog_entry(category: str, description: str, quiet: bool = False) -> bool:
+    """Add an entry to the project's CHANGELOG.md under [Unreleased].
+
+    Args:
+        category: The changelog category (added, changed, fixed, etc.)
+        description: The changelog entry description.
+        quiet: Suppress output if True.
+
+    Returns:
+        True if entry was added successfully.
+    """
+    if not category or not description:
+        return False
+
+    changelog_path = find_changelog()
+
+    if not changelog_path:
+        if not quiet:
+            print("No CHANGELOG.md found. Creating one...")
+        changelog_path = create_changelog()
+        if not changelog_path:
+            return False
+
+    try:
+        with open(changelog_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+    except (IOError, OSError) as e:
+        print(f"Error: Failed to read {changelog_path}: {e}")
+        return False
+
+    # Capitalize category for display
+    category_title = category.capitalize()
+
+    # Find [Unreleased] section
+    unreleased_pattern = r'(## \[Unreleased\].*?)(\n## \[|\Z)'
+    unreleased_match = re.search(unreleased_pattern, content, re.DOTALL)
+
+    if not unreleased_match:
+        # No [Unreleased] section, add one after the header
+        header_end = content.find('\n\n')
+        if header_end == -1:
+            header_end = len(content)
+
+        new_section = f"\n\n## [Unreleased]\n\n### {category_title}\n- {description}\n"
+        content = content[:header_end] + new_section + content[header_end:]
+    else:
+        unreleased_section = unreleased_match.group(1)
+
+        # Check if category already exists in unreleased section
+        category_pattern = rf'(### {category_title}\n)(.*?)(\n### |\n## \[|\Z)'
+        category_match = re.search(category_pattern, unreleased_section, re.DOTALL | re.IGNORECASE)
+
+        if category_match:
+            # Add to existing category
+            insert_pos = unreleased_match.start(1) + category_match.end(2)
+            # Check if we need a newline
+            if not content[insert_pos-1:insert_pos] == '\n':
+                content = content[:insert_pos] + f"\n- {description}" + content[insert_pos:]
+            else:
+                content = content[:insert_pos] + f"- {description}\n" + content[insert_pos:]
+        else:
+            # Add new category section after [Unreleased] header
+            unreleased_header_end = unreleased_match.start(1) + len('## [Unreleased]')
+            # Find where to insert (after any existing content in unreleased)
+            insert_pos = unreleased_header_end
+
+            # Skip any whitespace after header
+            while insert_pos < len(content) and content[insert_pos] in '\n\r':
+                insert_pos += 1
+
+            new_category = f"\n### {category_title}\n- {description}\n"
+            content = content[:insert_pos] + new_category + content[insert_pos:]
+
+    try:
+        with open(changelog_path, 'w', encoding='utf-8') as f:
+            f.write(content)
+
+        if not quiet:
+            print(f"Added to {changelog_path}: [{category_title}] {description}")
+        return True
+    except (IOError, OSError, PermissionError) as e:
+        print(f"Error: Failed to write {changelog_path}: {e}")
+        return False
 
 
 def create_log_file(topic_slug: str, quiet: bool = False) -> str:
@@ -154,12 +338,20 @@ Date: {today}
 def main() -> None:
     """Main entry point."""
     parser = argparse.ArgumentParser(
-        description='Scaffold a new session log file.',
+        description='Scaffold a new session log file with optional changelog integration.',
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  python3 end_session.py auth-refactor       # Create log for auth refactor session
-  python3 end_session.py bug-fix --quiet     # Create log without output
+  python3 end_session.py auth-refactor           # Create log for auth refactor session
+  python3 end_session.py bug-fix --changelog     # Create log and prompt for changelog entry
+  python3 end_session.py feature-x -c            # Short form of --changelog
+  python3 end_session.py hotfix --quiet          # Create log without output
+
+Changelog Integration:
+  Use --changelog to be prompted for a changelog entry. The entry will be
+  added to your project's CHANGELOG.md under the [Unreleased] section.
+
+  Categories: added, changed, deprecated, removed, fixed, security
 
 Slug format:
   - Use lowercase letters, numbers, and hyphens
@@ -169,6 +361,12 @@ Slug format:
     parser.add_argument('--version', '-V', action='version', version=f'%(prog)s {__version__}')
     parser.add_argument('topic', type=str, nargs='?', help='Short slug describing the session (e.g. auth-refactor)')
     parser.add_argument('--quiet', '-q', action='store_true', help='Suppress non-error output')
+    parser.add_argument('--changelog', '-c', action='store_true',
+                        help='Prompt for a changelog entry to add to CHANGELOG.md')
+    parser.add_argument('--changelog-category', type=str, metavar='CAT',
+                        help='Changelog category (added/changed/fixed/etc.) - skips prompt')
+    parser.add_argument('--changelog-message', type=str, metavar='MSG',
+                        help='Changelog description - skips prompt')
     args = parser.parse_args()
 
     if not args.topic:
@@ -181,9 +379,21 @@ Slug format:
         print(f"Error: {error_msg}")
         sys.exit(1)
 
+    # Create session log
     result = create_log_file(args.topic, args.quiet)
     if not result:
         sys.exit(1)
+
+    # Handle changelog integration
+    if args.changelog or args.changelog_category or args.changelog_message:
+        if args.changelog_category and args.changelog_message:
+            # Non-interactive mode
+            add_changelog_entry(args.changelog_category, args.changelog_message, args.quiet)
+        else:
+            # Interactive mode
+            category, description = prompt_changelog_entry(args.quiet)
+            if category and description:
+                add_changelog_entry(category, description, args.quiet)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Rename CHANGELOG.md to POCHANGELOG.md with YAML frontmatter
  - scope: ontos-tooling-only field clarifies usage for AI agents
  - update_policy explains when to update this file vs project changelog
- Extend end_session.py with --changelog flag for project changelogs
  - Interactive prompts for category and description
  - Non-interactive mode via --changelog-category and --changelog-message
  - Auto-creates CHANGELOG.md if not found
  - Appends entries under [Unreleased] section
- Update Agent Instructions with changelog guidelines
  - Two-table explanation of POCHANGELOG.md vs CHANGELOG.md
  - Clear instructions for when to update each
- Update README.md references