### PR TITLE
Remove frontmatter from Ontos docs, update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,6 @@ jobs:
       - name: Validate context map
         run: python scripts/generate_context_map.py --strict --quiet
 
-      - name: Check for untagged files
-        run: python scripts/migrate_frontmatter.py --strict --quiet
-
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/CONTEXT_MAP.md
+++ b/CONTEXT_MAP.md
@@ -1,27 +1,8 @@
 # Ontos Context Map
-Generated on: 2025-11-30 21:47:35
+Generated on: 2025-11-30 21:56:14
 Scanned Directory: `docs`
 
 ## 1. Hierarchy Tree
-### KERNEL
-- **ontos_agent_instructions** (Ontos_Agent_Instructions.md)
-  - Status: active
-  - Depends On: ontos_manual
-- **ontos_manual** (Ontos_Manual.md)
-  - Status: active
-  - Depends On: None
-
-### PRODUCT
-- **ontos_initiation_guide** (Ontos_Initiation_Guide.md)
-  - Status: active
-  - Depends On: ontos_installation_guide
-- **ontos_installation_guide** (Ontos_Installation_Guide.md)
-  - Status: active
-  - Depends On: None
-- **ontos_migration_guide** (MIGRATION_GUIDE.md)
-  - Status: active
-  - Depends On: ontos_initiation_guide
-
 ### ATOM
 - **log_20251125_deployment_guide_update** (2025-11-25_deployment-guide-update.md)
   - Status: active
@@ -47,8 +28,3 @@ No issues found.
 | log_20251125_iteration_3_complete | [2025-11-25_iteration-3-complete.md](docs/logs/2025-11-25_iteration-3-complete.md) | atom |
 | log_20251125_refining_documentation | [2025-11-25_refining-documentation.md](docs/logs/2025-11-25_refining-documentation.md) | atom |
 | log_20251130_production_ready_fixes | [2025-11-30_production-ready-fixes.md](docs/logs/2025-11-30_production-ready-fixes.md) | atom |
-| ontos_agent_instructions | [Ontos_Agent_Instructions.md](docs/reference/Ontos_Agent_Instructions.md) | kernel |
-| ontos_initiation_guide | [Ontos_Initiation_Guide.md](docs/guides/Ontos_Initiation_Guide.md) | product |
-| ontos_installation_guide | [Ontos_Installation_Guide.md](docs/guides/Ontos_Installation_Guide.md) | product |
-| ontos_manual | [Ontos_Manual.md](docs/reference/Ontos_Manual.md) | kernel |
-| ontos_migration_guide | [MIGRATION_GUIDE.md](docs/guides/MIGRATION_GUIDE.md) | product |

--- a/docs/guides/MIGRATION_GUIDE.md
+++ b/docs/guides/MIGRATION_GUIDE.md
@@ -1,11 +1,3 @@
----
-id: ontos_migration_guide
-title: Ontos Migration Guide
-type: product
-status: active
-depends_on: [ontos_initiation_guide]
----
-
 # Migration Guide
 
 This guide explains how to tag existing documentation with Ontos frontmatter.

--- a/docs/guides/Ontos_Initiation_Guide.md
+++ b/docs/guides/Ontos_Initiation_Guide.md
@@ -1,11 +1,3 @@
----
-id: ontos_initiation_guide
-title: Ontos Initiation Guide
-type: product
-status: active
-depends_on: [ontos_installation_guide]
----
-
 # Ontos Initiation Guide
 
 **Welcome to Day 1.** You have installed the scripts, but your documentation is still "dumb" text files. This guide covers how to turn them into a **Knowledge Graph**.

--- a/docs/guides/Ontos_Installation_Guide.md
+++ b/docs/guides/Ontos_Installation_Guide.md
@@ -1,11 +1,3 @@
----
-id: ontos_installation_guide
-title: Ontos Installation Guide
-type: product
-status: active
-depends_on: []
----
-
 # Ontos Installation Guide
 
 This guide covers how to install and configure Project Ontos for your repository.

--- a/docs/reference/Ontos_Agent_Instructions.md
+++ b/docs/reference/Ontos_Agent_Instructions.md
@@ -1,11 +1,3 @@
----
-id: ontos_agent_instructions
-title: Ontos Agent Instructions
-type: kernel
-status: active
-depends_on: [ontos_manual]
----
-
 # Ontos Agent Instructions
 
 You are an intelligent agent operating within the **Ontos Protocol**. Your goal is to maintain context integrity and avoid hallucinations by strictly following the Context Map.

--- a/docs/reference/Ontos_Manual.md
+++ b/docs/reference/Ontos_Manual.md
@@ -1,11 +1,3 @@
----
-id: ontos_manual
-title: "Ontos: The Manual"
-type: kernel
-status: active
-depends_on: []
----
-
 # **Ontos: The Manual (v0.4 - Production Ready)**
 *Updated: 2025-11-29*
 


### PR DESCRIPTION
Ontos documentation files are reference material about the tool, not nodes in a knowledge graph. They shouldn't have frontmatter.

Changes:
- Remove YAML frontmatter from docs/guides/*.md and docs/reference/*.md
- Remove migrate_frontmatter.py check from CI (not applicable to Ontos itself)
- Keep generate_context_map.py check (validates actual knowledge graph)

The frontmatter enforcement is for projects USING Ontos, not for Project Ontos's own documentation.

## Summary

Brief description of changes.

## Changes

- Change 1
- Change 2

## Related Issues

Fixes #(issue number)

## Checklist

- [ ] Tests pass (`pytest tests/ -v`)
- [ ] Validation passes (`python3 scripts/generate_context_map.py --strict`)
- [ ] Documentation updated (if applicable)
- [ ] POCHANGELOG.md updated under `[Unreleased]`

## Testing

Describe how you tested these changes.
