### PR TITLE
v2.9.5: Quality Release - Fix pure/impure violation, add SessionContext tests

### DIFF
--- a/.ontos-internal/logs/2026-01-07_v2-9-5-quality-release.md
+++ b/.ontos-internal/logs/2026-01-07_v2-9-5-quality-release.md
@@ -1,0 +1,41 @@
+---
+id: log_20260107_v2_9_5_quality_release
+type: log
+status: active
+event_type: feature
+concepts: []
+impacts: []
+---
+
+# Session Log: V2 9 5 Quality Release
+Date: 2026-01-07 22:16 EST
+Source: Gemini CLI (Antigravity), powered by Gemini 2.5 Pro
+Event Type: feature
+
+## 1. Goal
+<!-- What was the primary objective? -->
+
+## 2. Key Decisions
+<!-- What choices were made? -->
+- 
+
+## 3. Changes Made
+<!-- Summary of changes -->
+- 
+
+## 4. Next Steps
+<!-- What should happen next? -->
+- 
+
+---
+## Raw Session History
+```text
+ee51d7b - Address review feedback: FutureWarning, cleanup test, SimpleNamespace
+7425368 - Address review feedback: Fix CHANGELOG year, remove unused import
+a00ab0d - v2.9.5: Quality Release - Fix pure/impure violation, add SessionContext tests
+3c465d1 - docs(v3.0): add security requirements from v2.9.4 Architecture Board
+342e837 - Merge pull request #36 from ohjona/v2.9.4
+1ec1e31 - fix: Address Codex security review for v2.9.4
+6767f6d - fix: Address PR #36 review feedback
+391bc29 - feat(docs): complete v2.9.4 documentation and polish
+```

--- a/.ontos/scripts/ontos/core/frontmatter.py
+++ b/.ontos/scripts/ontos/core/frontmatter.py
@@ -120,28 +120,3 @@ def load_common_concepts(docs_dir: str = None) -> set:
         pass
     
     return concepts
-
-
-def normalize_type(value) -> str:
-    """Normalize type field to a string.
-
-    Args:
-        value: Raw value from YAML frontmatter.
-
-    Returns:
-        Type string ('unknown' if invalid).
-    """
-    if value is None:
-        return 'unknown'
-    if isinstance(value, str):
-        stripped = value.strip()
-        if not stripped or '|' in stripped:
-            return 'unknown'
-        return stripped
-    if isinstance(value, list):
-        if value and value[0] is not None:
-            first = str(value[0]).strip()
-            if '|' in first:
-                return 'unknown'
-            return first if first else 'unknown'
-    return 'unknown'

--- a/.ontos/scripts/ontos/core/paths.py
+++ b/.ontos/scripts/ontos/core/paths.py
@@ -75,7 +75,7 @@ def _warn_deprecated(old_path: str, new_path: str) -> None:
         f"Using deprecated path '{old_path}'. "
         f"Expected: '{new_path}'. "
         f"Run 'python3 ontos_init.py' to update.",
-        DeprecationWarning,
+        FutureWarning,
         stacklevel=3  # Point to caller's caller
     )
 

--- a/.ontos/scripts/ontos/core/paths.py
+++ b/.ontos/scripts/ontos/core/paths.py
@@ -7,6 +7,7 @@ IMPURE: Many functions use os.path.exists() and imports from config modules.
 """
 
 import os
+import warnings
 from datetime import datetime
 from typing import Optional
 
@@ -62,13 +63,21 @@ _deprecation_warned = set()
 
 
 def _warn_deprecated(old_path: str, new_path: str) -> None:
-    """Issue deprecation warning (once per path per session)."""
+    """Issue deprecation warning using Python's warnings system.
+
+    Uses stdlib warnings module for proper filtering, deduplication,
+    and CLI suppression. No caller changes required.
+    """
     if old_path in _deprecation_warned:
         return
     _deprecation_warned.add(old_path)
-    print(f"[DEPRECATION WARNING] Using old path '{old_path}'.")
-    print(f"   Expected: '{new_path}'")
-    print("   Run 'python3 ontos_init.py' to update your project structure.")
+    warnings.warn(
+        f"Using deprecated path '{old_path}'. "
+        f"Expected: '{new_path}'. "
+        f"Run 'python3 ontos_init.py' to update.",
+        DeprecationWarning,
+        stacklevel=3  # Point to caller's caller
+    )
 
 
 def get_logs_dir() -> str:

--- a/.ontos/scripts/ontos_config_defaults.py
+++ b/.ontos/scripts/ontos_config_defaults.py
@@ -23,7 +23,7 @@ def is_ontos_repo() -> bool:
     return os.path.exists(os.path.join(PROJECT_ROOT, '.ontos-internal'))
 
 # Version - used by update script to check for newer versions
-ONTOS_VERSION = "2.9.4"
+ONTOS_VERSION = "2.9.5"
 
 # GitHub repository for updates
 ONTOS_REPO_URL = 'https://github.com/ohjona/project-ontos'

--- a/.ontos/scripts/tests/test_context.py
+++ b/.ontos/scripts/tests/test_context.py
@@ -14,7 +14,7 @@ Per v2.9.5 spec, tests focus on behavior, not internal mechanics.
 import os
 import time
 from pathlib import Path
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, patch
 import pytest
 
 from ontos.core.context import SessionContext, FileOperation, PendingWrite

--- a/.ontos/scripts/tests/test_context.py
+++ b/.ontos/scripts/tests/test_context.py
@@ -1,0 +1,279 @@
+"""Tests for SessionContext transaction system.
+
+This test suite validates the core SessionContext functionality:
+- Buffer operations (write/delete/move)
+- Two-phase commit with atomicity
+- Rollback behavior
+- Lock acquisition and timeout
+- Factory initialization
+- Diagnostic collection
+
+Per v2.9.5 spec, tests focus on behavior, not internal mechanics.
+"""
+
+import os
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch, PropertyMock
+import pytest
+
+from ontos.core.context import SessionContext, FileOperation, PendingWrite
+
+
+class TestBufferOperations:
+    """Tests for buffer_write, buffer_delete, buffer_move methods."""
+
+    def test_buffer_write_adds_to_pending(self, tmp_path):
+        """buffer_write adds a WRITE operation to pending_writes."""
+        ctx = SessionContext(repo_root=tmp_path, config={})
+        ctx.buffer_write(tmp_path / "test.txt", "content")
+        
+        assert len(ctx.pending_writes) == 1
+        assert ctx.pending_writes[0].operation == FileOperation.WRITE
+        assert ctx.pending_writes[0].content == "content"
+
+    def test_buffer_delete_adds_to_pending(self, tmp_path):
+        """buffer_delete adds a DELETE operation to pending_writes."""
+        ctx = SessionContext(repo_root=tmp_path, config={})
+        ctx.buffer_delete(tmp_path / "test.txt")
+        
+        assert len(ctx.pending_writes) == 1
+        assert ctx.pending_writes[0].operation == FileOperation.DELETE
+
+    def test_buffer_move_adds_to_pending(self, tmp_path):
+        """buffer_move adds a MOVE operation to pending_writes."""
+        ctx = SessionContext(repo_root=tmp_path, config={})
+        ctx.buffer_move(tmp_path / "src.txt", tmp_path / "dst.txt")
+        
+        assert len(ctx.pending_writes) == 1
+        assert ctx.pending_writes[0].operation == FileOperation.MOVE
+        assert ctx.pending_writes[0].destination == tmp_path / "dst.txt"
+
+    def test_multiple_operations_in_order(self, tmp_path):
+        """Multiple buffered operations maintain order."""
+        ctx = SessionContext(repo_root=tmp_path, config={})
+        ctx.buffer_write(tmp_path / "a.txt", "a")
+        ctx.buffer_delete(tmp_path / "b.txt")
+        ctx.buffer_write(tmp_path / "c.txt", "c")
+        
+        assert len(ctx.pending_writes) == 3
+        assert ctx.pending_writes[0].operation == FileOperation.WRITE
+        assert ctx.pending_writes[1].operation == FileOperation.DELETE
+        assert ctx.pending_writes[2].operation == FileOperation.WRITE
+
+
+class TestCommit:
+    """Tests for commit() method - file creation and atomicity."""
+
+    def test_commit_empty_buffer_returns_empty(self, tmp_path):
+        """Commit with no pending writes returns empty list."""
+        ctx = SessionContext(repo_root=tmp_path, config={})
+        result = ctx.commit()
+        assert result == []
+
+    def test_commit_creates_file(self, tmp_path):
+        """Commit creates file with correct content."""
+        ctx = SessionContext(repo_root=tmp_path, config={})
+        target = tmp_path / "test.txt"
+        ctx.buffer_write(target, "hello world")
+        
+        result = ctx.commit()
+        
+        assert target.exists()
+        assert target.read_text() == "hello world"
+        assert target in result
+
+    def test_commit_creates_nested_directories(self, tmp_path):
+        """Commit creates parent directories if needed."""
+        ctx = SessionContext(repo_root=tmp_path, config={})
+        target = tmp_path / "a" / "b" / "c" / "test.txt"
+        ctx.buffer_write(target, "nested")
+        
+        ctx.commit()
+        
+        assert target.exists()
+        assert target.read_text() == "nested"
+
+    def test_commit_clears_buffer(self, tmp_path):
+        """Commit clears pending_writes after success."""
+        ctx = SessionContext(repo_root=tmp_path, config={})
+        ctx.buffer_write(tmp_path / "test.txt", "content")
+        
+        ctx.commit()
+        
+        assert len(ctx.pending_writes) == 0
+
+    def test_commit_delete_removes_file(self, tmp_path):
+        """Commit with DELETE operation removes file."""
+        target = tmp_path / "to_delete.txt"
+        target.write_text("delete me")
+        
+        ctx = SessionContext(repo_root=tmp_path, config={})
+        ctx.buffer_delete(target)
+        
+        ctx.commit()
+        
+        assert not target.exists()
+
+    def test_commit_move_relocates_file(self, tmp_path):
+        """Commit with MOVE operation moves file."""
+        source = tmp_path / "source.txt"
+        dest = tmp_path / "dest.txt"
+        source.write_text("move me")
+        
+        ctx = SessionContext(repo_root=tmp_path, config={})
+        ctx.buffer_move(source, dest)
+        
+        ctx.commit()
+        
+        assert not source.exists()
+        assert dest.exists()
+        assert dest.read_text() == "move me"
+
+    def test_commit_returns_modified_paths(self, tmp_path):
+        """Commit returns list of all modified paths."""
+        ctx = SessionContext(repo_root=tmp_path, config={})
+        file1 = tmp_path / "a.txt"
+        file2 = tmp_path / "b.txt"
+        ctx.buffer_write(file1, "a")
+        ctx.buffer_write(file2, "b")
+        
+        result = ctx.commit()
+        
+        assert file1 in result
+        assert file2 in result
+
+
+class TestCommitFailure:
+    """Tests for commit() failure handling and cleanup."""
+
+    def test_commit_cleans_temp_on_failure(self, tmp_path):
+        """Commit cleans up temp files when rename fails."""
+        ctx = SessionContext(repo_root=tmp_path, config={})
+        target = tmp_path / "test.txt"
+        ctx.buffer_write(target, "content")
+        
+        # Mock rename to fail
+        with patch.object(Path, 'rename', side_effect=OSError("rename failed")):
+            with pytest.raises(OSError):
+                ctx.commit()
+        
+        # Temp file should be cleaned up
+        temp_file = target.with_suffix(".txt.tmp")
+        assert not temp_file.exists()
+
+    def test_commit_failure_records_error(self, tmp_path):
+        """Commit failure records error in context."""
+        ctx = SessionContext(repo_root=tmp_path, config={})
+        target = tmp_path / "test.txt"
+        ctx.buffer_write(target, "content")
+        
+        with patch.object(Path, 'rename', side_effect=OSError("rename failed")):
+            with pytest.raises(OSError):
+                ctx.commit()
+        
+        assert len(ctx.errors) == 1
+        assert "Commit failed" in ctx.errors[0]
+
+
+class TestRollback:
+    """Tests for rollback() method."""
+
+    def test_rollback_clears_buffer(self, tmp_path):
+        """Rollback discards all pending operations."""
+        ctx = SessionContext(repo_root=tmp_path, config={})
+        ctx.buffer_write(tmp_path / "a.txt", "a")
+        ctx.buffer_delete(tmp_path / "b.txt")
+        
+        ctx.rollback()
+        
+        assert len(ctx.pending_writes) == 0
+
+    def test_rollback_does_not_create_files(self, tmp_path):
+        """Rollback does not create any files."""
+        ctx = SessionContext(repo_root=tmp_path, config={})
+        target = tmp_path / "should_not_exist.txt"
+        ctx.buffer_write(target, "content")
+        
+        ctx.rollback()
+        
+        assert not target.exists()
+
+
+class TestLocking:
+    """Tests for commit() locking behavior."""
+
+    def test_commit_raises_on_lock_timeout(self, tmp_path):
+        """Commit raises RuntimeError when lock cannot be acquired."""
+        ctx = SessionContext(repo_root=tmp_path, config={})
+        ctx.buffer_write(tmp_path / "test.txt", "content")
+        
+        # Pre-create lock file with our own PID (simulates active lock)
+        lock_dir = tmp_path / ".ontos"
+        lock_dir.mkdir(parents=True, exist_ok=True)
+        lock_file = lock_dir / "write.lock"
+        lock_file.write_text(str(os.getpid()))  # Our own PID = not stale
+        
+        # Mock time.time to simulate timeout
+        start_time = time.time()
+        call_count = [0]
+        def mock_time():
+            call_count[0] += 1
+            # First call returns start time, subsequent calls exceed timeout
+            if call_count[0] == 1:
+                return start_time
+            return start_time + 10  # Exceeds 5.0 second timeout
+        
+        with patch('time.time', side_effect=mock_time):
+            with pytest.raises(RuntimeError, match="Could not acquire write lock"):
+                ctx.commit()
+
+    def test_commit_acquires_and_releases_lock(self, tmp_path):
+        """Commit properly acquires and releases lock."""
+        ctx = SessionContext(repo_root=tmp_path, config={})
+        ctx.buffer_write(tmp_path / "test.txt", "content")
+        
+        lock_file = tmp_path / ".ontos" / "write.lock"
+        
+        ctx.commit()
+        
+        # Lock should be released after commit
+        assert not lock_file.exists()
+
+
+class TestFromRepo:
+    """Tests for from_repo() factory method."""
+
+    def test_from_repo_creates_context_with_config(self, tmp_path):
+        """from_repo creates context with loaded config dict."""
+        # Mock ontos_config module
+        mock_config = MagicMock()
+        mock_config.DOCS_DIR = 'custom_docs'
+        mock_config.ONTOS_MODE = 'prompted'
+        
+        with patch.dict('sys.modules', {'ontos_config': mock_config}):
+            ctx = SessionContext.from_repo(tmp_path)
+        
+        assert ctx.repo_root == tmp_path
+        assert ctx.config.get('DOCS_DIR') == 'custom_docs'
+        assert ctx.config.get('ONTOS_MODE') == 'prompted'
+
+
+class TestDiagnostics:
+    """Tests for warn() and error() diagnostic methods."""
+
+    def test_warn_collects_messages(self, tmp_path):
+        """warn() adds messages to warnings list."""
+        ctx = SessionContext(repo_root=tmp_path, config={})
+        ctx.warn("warning 1")
+        ctx.warn("warning 2")
+        
+        assert ctx.warnings == ["warning 1", "warning 2"]
+
+    def test_error_collects_messages(self, tmp_path):
+        """error() adds messages to errors list."""
+        ctx = SessionContext(repo_root=tmp_path, config={})
+        ctx.error("error 1")
+        ctx.error("error 2")
+        
+        assert ctx.errors == ["error 1", "error 2"]

--- a/Ontos_CHANGELOG.md
+++ b/Ontos_CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to **Project Ontos itself** (the protocol and tooling) will 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.9.5] - 2025-01-08
+## [2.9.5] - 2026-01-08
 
 ### Theme: "Quality & Testing"
 

--- a/Ontos_CHANGELOG.md
+++ b/Ontos_CHANGELOG.md
@@ -21,6 +21,34 @@ All notable changes to **Project Ontos itself** (the protocol and tooling) will 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.9.5] - 2025-01-08
+
+### Theme: "Quality & Testing"
+
+Fixes architectural violations and adds test coverage for core transaction system.
+
+### Fixed
+- **Pure/Impure Violation** — `paths._warn_deprecated()` now uses `warnings.warn()`
+  - Standard Python deprecation pattern
+  - No caller changes required
+  - Enables v3.0 MCP Server exposure
+
+- **DRY Violation** — Removed duplicate `normalize_type()` in frontmatter.py
+
+### Added
+- **20 new tests** for SessionContext in `test_context.py`
+  - Buffer operations (4 tests)
+  - Commit behavior (7 tests)
+  - Rollback (2 tests)
+  - Locking behavior (2 tests)
+  - Factory and diagnostics (3 tests)
+  - Commit failure handling (2 tests)
+
+### Tests
+- Total: 132 tests (112 existing + 20 new)
+
+---
+
 ## [2.9.4] - 2025-12-23
 
 ### Theme: "Documentation & Polish"

--- a/Ontos_Context_Map.md
+++ b/Ontos_Context_Map.md
@@ -1,6 +1,6 @@
 <!--
 Ontos Context Map
-Generated: 2025-12-24 07:26:09 UTC
+Generated: 2026-01-08 00:51:30 UTC
 Mode: Contributor
 Scanned: .ontos-internal
 -->
@@ -9,7 +9,7 @@ Scanned: .ontos-internal
 > in your project, this file will be overwritten with your project's context.
 
 # Ontos Context Map
-Generated on: 2025-12-24 16:26:09
+Generated on: 2026-01-08 09:51:30
 Scanned Directory: `/Users/jonathanoh/Dev/Project-Ontos/.ontos-internal, docs`
 
 ## 1. Hierarchy Tree
@@ -85,12 +85,18 @@ Scanned Directory: `/Users/jonathanoh/Dev/Project-Ontos/.ontos-internal, docs`
 - **v2_9_4_implementation_plan** [L2] [draft] (v2.9.4_implementation_plan.md) ~4,500 tokens
   - Status: draft
   - Depends On: v2_9_implementation_plan, master_plan_v4
+- **v2_9_5_implementation_plan** [L2] [draft] (v2.9.5_implementation_plan.md) ~6,700 tokens
+  - Status: draft
+  - Depends On: master_plan_v4, v2_8_implementation_plan
 - **v2_9_implementation_plan** [L2] (v2.9_implementation_plan.md) ~29,600 tokens
   - Status: active
   - Depends On: master_plan_v4, v2_8_implementation_plan
 - **v2_strategy** [L2] (v2_strategy.md) ~2,600 tokens
   - Status: active
   - Depends On: mission
+- **v3_0_security_requirements** [L2] [draft] (v3.0_security_requirements.md) ~5,100 tokens
+  - Status: draft
+  - Depends On: master_plan_v4, v2_9_implementation_plan
 - **v3_master_plan_context_kernel_review_codex** [L2] [draft] (v3_master_plan_context_kernel_review_codex.md) ~968 tokens
   - Status: draft
   - Depends On: master_plan_v4
@@ -514,12 +520,14 @@ No issues found.
 | v2_9_4_implementation_plan | [v2.9.4_implementation_plan.md](/Users/jonathanoh/Dev/Project-Ontos/.ontos-internal/strategy/v2.9/v2.9.4_implementation_plan.md) | strategy |
 | v2_9_4_implementation_plan_review_codex_gpt5_v1 | [v2.9.4_implementation_plan_review_codex_gpt5_v1.md](/Users/jonathanoh/Dev/Project-Ontos/.ontos-internal/strategy/proposals/v2.9/v2.9.4_implementation_plan_review_codex_gpt5_v1.md) | atom |
 | v2_9_4_implementation_plan_review_gemini | [v2.9.4_implementation_plan_review_gemini.md](/Users/jonathanoh/Dev/Project-Ontos/.ontos-internal/strategy/proposals/v2.9/v2.9.4_implementation_plan_review_gemini.md) | atom |
+| v2_9_5_implementation_plan | [v2.9.5_implementation_plan.md](/Users/jonathanoh/Dev/Project-Ontos/.ontos-internal/strategy/proposals/v2.9.5/v2.9.5_implementation_plan.md) | strategy |
 | v2_9_implementation_plan | [v2.9_implementation_plan.md](/Users/jonathanoh/Dev/Project-Ontos/.ontos-internal/strategy/v2.9/v2.9_implementation_plan.md) | strategy |
 | v2_9_implementation_plan_review_codex | [v2.9_implementation_plan_review_codex.md](/Users/jonathanoh/Dev/Project-Ontos/.ontos-internal/strategy/proposals/v2.9/v2.9_implementation_plan_review_codex.md) | atom |
 | v2_9_implementation_plan_review_codex_v2 | [v2.9_implementation_plan_review_codex_v2.md](/Users/jonathanoh/Dev/Project-Ontos/.ontos-internal/strategy/proposals/v2.9/v2.9_implementation_plan_review_codex_v2.md) | atom |
 | v2_9_implementation_plan_review_codex_v3 | [v2.9_implementation_plan_review_codex_v3.md](/Users/jonathanoh/Dev/Project-Ontos/.ontos-internal/strategy/proposals/v2.9/v2.9_implementation_plan_review_codex_v3.md) | atom |
 | v2_9_implementation_plan_review_gemini | [v2.9_implementation_plan_review_gemini.md](/Users/jonathanoh/Dev/Project-Ontos/.ontos-internal/strategy/proposals/v2.9/v2.9_implementation_plan_review_gemini.md) | atom |
 | v2_strategy | [v2_strategy.md](/Users/jonathanoh/Dev/Project-Ontos/.ontos-internal/strategy/v2_strategy.md) | strategy |
+| v3_0_security_requirements | [v3.0_security_requirements.md](/Users/jonathanoh/Dev/Project-Ontos/.ontos-internal/strategy/proposals/v3.0/security/v3.0_security_requirements.md) | strategy |
 | v3_master_plan_context_kernel_review_codex | [v3_master_plan_context_kernel_review_codex.md](/Users/jonathanoh/Dev/Project-Ontos/.ontos-internal/strategy/proposals/v3.0/V3.0 Components/v3_master_plan_context_kernel_review_codex.md) | strategy |
 | v3_master_plan_context_kernel_review_codex_v2 | [v3_master_plan_context_kernel_review_codex_v2.md](/Users/jonathanoh/Dev/Project-Ontos/.ontos-internal/strategy/proposals/v3.0/V3.0 Components/v3_master_plan_context_kernel_review_codex_v2.md) | strategy |
 | v3_master_plan_context_kernel_review_codex_v3 | [v3_master_plan_context_kernel_review_codex_v3.md](/Users/jonathanoh/Dev/Project-Ontos/.ontos-internal/strategy/proposals/v3.0/V3.0 Components/v3_master_plan_context_kernel_review_codex_v3.md) | strategy |


### PR DESCRIPTION
## Summary

Implements v2.9.5 as specified in the implementation plan.

**Spec Reference:** [`.ontos-internal/strategy/proposals/v2.9.5/v2.9.5_implementation_plan.md`](https://github.com/ohjona/Project-Ontos/blob/v2.9.5/.ontos-internal/strategy/proposals/v2.9.5/v2.9.5_implementation_plan.md)

## Changes

### Fixed
- **Pure/Impure Violation** — `paths._warn_deprecated()` now uses `warnings.warn()` instead of `print()`
  - Standard Python deprecation pattern
  - No caller changes required
  - Enables v3.0 MCP Server exposure (blocks API/MCP usage when core modules call print())

- **DRY Violation** — Removed duplicate `normalize_type()` in `frontmatter.py` (lines 125-147 deleted)

### Added
- **20 behavioral tests** for `SessionContext` in `test_context.py`
  - `TestBufferOperations` (4 tests): buffer_write/delete/move methods
  - `TestCommit` (7 tests): file creation, nested dirs, buffer clearing
  - `TestCommitFailure` (2 tests): cleanup on failure, error recording
  - `TestRollback` (2 tests): buffer discard, no file creation
  - `TestLocking` (2 tests): lock timeout, acquire/release
  - `TestFromRepo` (1 test): factory method with mocked config
  - `TestDiagnostics` (2 tests): warn/error collection

### Version
- Bumped to 2.9.5 in `ontos_config_defaults.py`

## Verification

```bash
# All 132 tests pass
cd .ontos/scripts && python3 -m pytest tests/ -v
# 132 passed in 0.34s
```

## Files Changed

| File | Action | Description |
|------|--------|-------------|
| `paths.py` | Modified | Replace print() with warnings.warn() |
| `frontmatter.py` | Modified | Remove duplicate normalize_type() |
| `test_context.py` | Created | 20 SessionContext behavioral tests |
| `ontos_config_defaults.py` | Modified | Version bump to 2.9.5 |
| `Ontos_CHANGELOG.md` | Modified | Add v2.9.5 entry |

---

*Implemented by Antigravity, powered by Gemini 2.5 Pro*