### PR TITLE
fix: align ontos log with archive hook

### DIFF
--- a/.ontos/scripts/ontos_config_defaults.py
+++ b/.ontos/scripts/ontos_config_defaults.py
@@ -109,6 +109,10 @@ EVENT_TYPES = {
         'definition': 'Architectural or design decisions',
         'examples': ['Chose OAuth over SAML', 'Selected PostgreSQL for persistence'],
     },
+    'release': {
+        'definition': 'Packaging or release activities',
+        'examples': ['Published v3.0.0', 'Cut release candidate'],
+    },
 }
 
 # Valid event type values (for validation)

--- a/.ontos/scripts/ontos_end_session.py
+++ b/.ontos/scripts/ontos_end_session.py
@@ -1649,8 +1649,8 @@ Slug format:
     
     # NEW v2.0 arguments
     parser.add_argument('--event-type', '-e', type=str, metavar='TYPE',
-                        choices=['feature', 'fix', 'refactor', 'exploration', 'chore', 'decision'],
-                        help='Type of work performed (feature/fix/refactor/exploration/chore/decision)')
+                        choices=['feature', 'fix', 'refactor', 'exploration', 'chore', 'decision', 'release'],
+                        help='Type of work performed (feature/fix/refactor/exploration/chore/decision/release)')
     parser.add_argument('--concepts', type=str, metavar='TAGS',
                         help='Comma-separated concept tags (e.g., "auth,oauth,security")')
     parser.add_argument('--impacts', type=str, metavar='IDS',

--- a/ontos/__main__.py
+++ b/ontos/__main__.py
@@ -3,7 +3,7 @@ Entry point for `python -m ontos` invocation.
 
 This module enables running Ontos as a Python module:
     python -m ontos map
-    python -m ontos log -e feature -s "Session summary"
+    python -m ontos log -e feature -t "Session summary"
 """
 
 import sys

--- a/ontos/_scripts/ontos_config_defaults.py
+++ b/ontos/_scripts/ontos_config_defaults.py
@@ -119,6 +119,10 @@ EVENT_TYPES = {
         'definition': 'Architectural or design decisions',
         'examples': ['Chose OAuth over SAML', 'Selected PostgreSQL for persistence'],
     },
+    'release': {
+        'definition': 'Packaging or release activities',
+        'examples': ['Published v3.0.0', 'Cut release candidate'],
+    },
 }
 
 # Valid event type values (for validation)

--- a/ontos/_scripts/ontos_end_session.py
+++ b/ontos/_scripts/ontos_end_session.py
@@ -56,7 +56,7 @@ def main() -> int:
     parser.add_argument(
         "--event-type", "-e",
         default="chore",
-        choices=["feat", "fix", "chore", "docs", "refactor", "test", "perf"],
+        choices=["feat", "fix", "chore", "docs", "refactor", "test", "perf", "release"],
         help="Event type (default: chore)"
     )
     parser.add_argument(

--- a/ontos/cli.py
+++ b/ontos/cli.py
@@ -110,10 +110,16 @@ def _register_map(subparsers, parent):
 def _register_log(subparsers, parent):
     """Register log command."""
     p = subparsers.add_parser("log", help="End session logging", parents=[parent])
-    p.add_argument("--epoch", "-e",
-                   help="Epoch identifier")
+    p.add_argument("topic", nargs="?",
+                   help="Log entry title/topic")
+    p.add_argument("--event-type", "-e",
+                   help="Session event type (feature, fix, refactor, exploration, chore, decision, release)")
+    p.add_argument("--source", "-s",
+                   help="Session source (e.g., tool/agent name)")
+    p.add_argument("--epoch",
+                   help="(Deprecated) Alias for --source")
     p.add_argument("--title", "-t",
-                   help="Log entry title")
+                   help="Log entry title (overrides positional topic)")
     p.add_argument("--auto", action="store_true",
                    help="Skip confirmation prompt")
     p.set_defaults(func=_cmd_log)
@@ -273,8 +279,11 @@ def _cmd_log(args) -> int:
     from ontos.commands.log import log_command, LogOptions
 
     options = LogOptions(
+        event_type=args.event_type or "",
+        source=args.source or "",
         epoch=args.epoch or "",
         title=args.title or "",
+        topic=args.topic or "",
         auto=args.auto,
         json_output=args.json,
         quiet=args.quiet,


### PR DESCRIPTION
# Fix: Align `ontos log` with archive hook + accept `release` event type

## Why this PR exists (problem statement)
Recent attempts to archive sessions before pushing failed in three ways:
1) `ontos log -e release` crashed with `__init__() got an unexpected keyword argument 'epoch'` because the CLI `-e` flag was wired to `epoch` (deprecated) rather than event type.
2) `python3 .ontos/scripts/ontos_end_session.py -e release` rejected `release` because the legacy script’s `--event-type` choices did not include it.
3) Even when a log file was created by `ontos log`, the pre‑push hook still blocked because no archive marker file was created; the hook requires `.ontos/session_archived` to exist.

This created a mismatch between how logs are generated vs. how the hook validates archiving, especially for documentation/release flows.

---

## Root cause analysis (detailed)
- **CLI/log mismatch**
  - `ontos/cli.py` exposed `--epoch/-e` and `--title/-t` for `ontos log`, but `ontos/commands/log.py` expected `event_type` and `source`. The CLI was passing `epoch` into `LogOptions`, then `log_command()` used `epoch` as `source`, hard‑coding event type to `chore`. This caused `-e` to be treated as source instead of event type and raised the `epoch` error at call time.
- **Legacy script mismatch**
  - `.ontos/scripts/ontos_end_session.py` and `ontos/_scripts/ontos_end_session.py` both limited `--event-type` choices to non‑release values.
- **Archive hook mismatch**
  - `.ontos/scripts/ontos_pre_push_check.py` relies on `.ontos/session_archived` to exist. `ontos/commands/log.py` created logs but never wrote the marker file; only the legacy end_session script did, so the hook still blocked after a successful `ontos log`.

---

## What I changed (exactly)

### 1) Make `ontos log` accept event type and positional topic
**File:** `ontos/cli.py`
- Added positional `topic` argument for quick descriptions (e.g., `ontos log -e chore "README update"`).
- Added `--event-type/-e` for event type selection.
- Added `--source/-s` for source attribution.
- Kept `--epoch` as a deprecated alias for `--source` to avoid breaking old usage.
- `--title` still supported as an explicit override; if both topic and title are set, title wins.

### 2) Properly map CLI options in `LogOptions`
**File:** `ontos/commands/log.py`
- `LogOptions` now carries `event_type`, `source`, `topic`, and deprecated `epoch`.
- `log_command()` now:
  - Treats `epoch` as a fallback alias to `source`.
  - Passes `event_type` through (default `chore` if unspecified).
  - Uses `title` or `topic` for the log title/slug.

### 3) Create the archive marker after log creation
**File:** `ontos/commands/log.py`
- Added `_create_archive_marker(project_root, log_path)`.
- Called it after writing the log file. This creates `.ontos/session_archived` so the pre‑push hook unblocks.
- Marker creation is best‑effort; failures do not fail log creation.

### 4) Allow `release` event type everywhere
**Files:**
- `.ontos/scripts/ontos_config_defaults.py`
- `ontos/_scripts/ontos_config_defaults.py`
- `.ontos/scripts/ontos_end_session.py`
- `ontos/_scripts/ontos_end_session.py`

Changes:
- Added `release` to `EVENT_TYPES` for consistent validation.
- Added `release` to legacy script `--event-type` choices so `python3 .ontos/scripts/ontos_end_session.py -e release` no longer errors.

### 5) Normalize release template handling
**File:** `ontos/commands/log.py`
- Added event type alias: `release -> chore` to reuse the existing `chore` template body.

### 6) Minor docs fix for example usage
**File:** `ontos/__main__.py`
- Corrected example `python -m ontos log -e feature -t "Session summary"` (since `-s` is now source, not title).

---

## Behavior after changes (verified locally)
- `python -m ontos log -e release "README and license update for v3.0.0 release"`
  - Creates a log in `.ontos-internal/logs/…`
  - Writes `.ontos/session_archived`
  - Pre‑push hook recognizes the archive marker
- `python3 .ontos/scripts/ontos_end_session.py -e release --dry-run`
  - No longer fails on invalid choice
- `ontos log -e chore -t "title"` still works

---

## Files touched (full list)
- `ontos/cli.py`
- `ontos/commands/log.py`
- `ontos/__main__.py`
- `.ontos/scripts/ontos_config_defaults.py`
- `ontos/_scripts/ontos_config_defaults.py`
- `.ontos/scripts/ontos_end_session.py`
- `ontos/_scripts/ontos_end_session.py`

---

## Tests
- Manual verification:
  - `python -m ontos log -e release "README and license update for v3.0.0 release"`
  - `python -m ontos log -e release -t "README and license update for v3.0.0 release"`
  - `python3 .ontos/scripts/ontos_end_session.py -e release --dry-run`
- No automated tests added (existing test suite does not cover log CLI wiring). If desired, I can add CLI-level tests under `tests/test_cli_phase4.py`.

---

## Risk assessment
- Low risk. Changes are localized to log CLI wiring + event type validation and are backward compatible due to keeping `--epoch` alias and defaulting to `chore`.
- Marker creation is best‑effort and cannot break log creation.

---

## Follow‑ups (optional)
- Add explicit CLI tests for `ontos log` parsing.
- Update any user docs to reflect the `--event-type/-e` and positional topic behavior.
