### PR TITLE
Config-driven Critical Paths (v3.2.1b)

### DIFF
--- a/ontos/commands/map.py
+++ b/ontos/commands/map.py
@@ -325,11 +325,15 @@ def _format_critical_path(path_str: Optional[str], root_path: Optional[Path]) ->
         return "`(unset)`"
 
     raw = str(path_str).strip()
-    path = Path(raw)
+    try:
+        path = Path(raw)
+    except ValueError:
+        return "`(invalid path)`"
 
     if path.is_absolute():
         return "`(invalid path)`"
 
+    # Tri-state: None = unknown (no root), False = missing, True = present.
     exists = None
     if root_path:
         try:

--- a/ontos/commands/map.py
+++ b/ontos/commands/map.py
@@ -234,13 +234,6 @@ def _generate_tier1_summary(
         sections.append("\n".join(kd_lines))
 
     # Critical Paths (config-driven)
-    def _format_critical_path(path_str: str) -> str:
-        display_path = f"{path_str.rstrip('/')}/"
-        if root_path:
-            if not (root_path / Path(path_str)).exists():
-                return f"`{display_path}` (missing)"
-        return f"`{display_path}`"
-
     cp_lines = ["### Critical Paths"]
     docs_dir = config.get("docs_dir") or "docs"
     logs_dir = config.get("logs_dir") or f"{docs_dir}/logs"


### PR DESCRIPTION
## Summary
- make Critical Paths config-driven (docs/logs) with contributor-only .ontos-internal paths
- add .ontos-internal/reference/ in contributor mode
- sanitize and validate Critical Paths paths (no absolute/path traversal, escape backticks)
- annotate missing paths and harden project_root handling
- add tests for user vs contributor mode, custom docs/logs, missing annotation, backtick sanitization, invalid paths, and unset/root_path cases

## Testing
- pytest tests/commands/test_map.py tests/commands/test_map_tier1_key_documents.py