### PR TITLE
Track A2: command safety and state integrity hardening

### DIFF
--- a/.ontos-internal/strategy/proposals/v3.3a/v3.3_Track_A2_Implementation_Spec.md
+++ b/.ontos-internal/strategy/proposals/v3.3a/v3.3_Track_A2_Implementation_Spec.md
@@ -1,0 +1,392 @@
+---
+id: v3_3_track_a2_implementation_spec
+type: strategy
+status: draft
+depends_on:
+  - v3_3_release_plan
+  - v3_3_merged_audit_findings
+concepts:
+  - v3.3a
+  - track-a2
+  - command-safety
+  - state-integrity
+  - hardening
+---
+
+# v3.3 Track A2 Implementation Spec
+
+## 1. Overview
+
+Track A2 delivers 13 non-feature hardening fixes focused on command safety, path correctness, parser robustness, and state integrity.
+
+Target modules:
+
+- `ontos/commands/consolidate.py` (#12, #13, #26, #45)
+- `ontos/commands/doctor.py` (#14)
+- `ontos/core/paths.py` (#15)
+- `ontos/core/proposals.py` (#27)
+- `ontos/core/history.py` (#28)
+- `ontos/commands/migrate.py` (#29, #48)
+- `ontos/commands/instruction_protocol.py` (#51)
+- `ontos/commands/maintain.py` (#60, #61)
+
+Risk level is low-to-medium overall, with highest risk in:
+
+- Path root anchoring (`#14`, `#15`) due broad runtime impact.
+- Consolidation transaction ordering/error semantics (`#12`, `#13`).
+
+Relationship to other tracks:
+
+- Depends on Track A1 only.
+- No Track B feature overlap (`scan_scope`, `body_refs`, `link_diagnostics`, `link_check`, `rename`).
+- No new features, no new commands.
+
+Estimated change size: ~500-700 LOC including tests.
+
+## 2. Scope
+
+### In Scope
+
+- [ ] `#12 (C-10)` consolidate ordering/atomicity
+- [ ] `#13 (C-11)` consolidate exit code on per-log failures
+- [ ] `#14 (C-13)` doctor project-root anchoring
+- [ ] `#15 (C-14)` path-helper project-root anchoring
+- [ ] `#26 (C-12)` consolidate scalar `impacts` normalization
+- [ ] `#27 (C-15)` proposal-ledger separator filtering
+- [ ] `#28 (C-16)` bare filename `generate_decision_history()` fallback
+- [ ] `#29 (C-17)` migrate apply/dry-run semantics enforcement
+- [ ] `#45 (X-H2)` consolidate `--count 0` validation
+- [ ] `#48 (X-M3)` migrate unsupported schema reporting
+- [ ] `#51 (X-M10)` nested USER CUSTOM marker handling
+- [ ] `#60 (X-M8)` `_parse_bool` empty/unknown warning semantics
+- [ ] `#61 (X-M9)` `TaskResult.status` constrained typing
+
+### Out of Scope
+
+- Any Track B behavior changes.
+- New CLI commands.
+- New flags (including `--force` in schema-migrate).
+- Architectural redesign beyond targeted bug fixes.
+
+## 3. Technical Design
+
+## Group 1: `ontos/commands/consolidate.py` (#12, #13, #26, #45)
+
+### 3.1 `#45` `--count 0` validation
+
+Change:
+
+- Validate options at command entry:
+  - If `options.by_age is False` and `options.count < 1`, return `(1, "count must be >= 1")`.
+- Keep age mode behavior unchanged.
+
+Compatibility:
+
+- `--count 0` changes from ambiguous no-op to explicit error.
+
+### 3.2 `#26` scalar `impacts` join bug
+
+Change:
+
+- Normalize `impacts` before formatting history rows.
+- Use A1 normalization utility:
+  - `normalize_reference_list(fm.get("impacts", []), field_name="impacts")`
+- Join normalized list only.
+
+Result:
+
+- `impacts: foo` renders as `foo` (not `f, o, o`).
+
+### 3.3 `#12` consolidation ordering/state integrity
+
+Current failure mode:
+
+- File move may succeed before ledger write is committed.
+- If ledger write fails afterward, state is inconsistent.
+
+Fix strategy:
+
+- Instantiate one `SessionContext` once per command run and reuse it.
+- Execute commit boundaries per log entry (not one global commit across all logs).
+- For each selected log:
+  1. Buffer decision-history update first (`append_to_decision_history(..., ctx=tx_ctx)`).
+  2. Buffer archive move (`tx_ctx.buffer_move(src, dst)`).
+  3. Commit once for that log (`tx_ctx.commit()`).
+  4. Record success/failure and continue.
+
+Why this is acceptable:
+
+- Removes guaranteed move-first inconsistency path.
+- Keeps each log operation in a bounded atomic unit with explicit error reporting.
+- Any residual partial-commit behavior is surfaced and treated as failure (see `#13`), never silent success.
+
+### 3.4 `#13` non-zero exit on per-log failures
+
+Change:
+
+- Track per-log outcomes:
+  - `succeeded: List[str]`
+  - `failed: List[Tuple[str, str]]` (slug, reason)
+- Continue processing remaining logs after one failure.
+- Final exit code:
+  - `0` if no failures
+  - `1` if any failure
+- Final summary includes succeeded and failed lists.
+
+Failure policy:
+
+- If transaction commit raises for any log, mark that log failed and continue.
+- Final output includes explicit reconciliation guidance naming failed slug/path.
+
+## Group 2: Path Resolution (`ontos/core/paths.py`, `ontos/commands/doctor.py`) (#14, #15)
+
+### 3.5 Shared runtime root resolution strategy
+
+Single root precedence for both modules:
+
+1. nearest `.ontos.toml`
+2. else nearest `.ontos` or `.ontos-internal`
+3. else nearest `.git`
+4. else explicit failure (outside project)
+
+### 3.6 `#15` path helpers anchored to runtime root
+
+Change in `ontos/core/paths.py`:
+
+- Replace package-anchored resolution (`PROJECT_ROOT` as effective runtime anchor) with runtime project root resolution.
+- Add optional `repo_root` parameter to path getters while preserving call compatibility:
+  - `get_logs_dir(repo_root: Optional[Path | str] = None)`
+  - `get_archive_dir(...)`
+  - `get_decision_history_path(...)`
+  - `get_proposals_dir(...)`
+  - `get_archive_logs_dir(...)`
+  - `get_archive_proposals_dir(...)`
+  - `get_concepts_path(...)`
+  - `find_last_session_date(..., repo_root=...)` where applicable
+- If `repo_root` is not supplied, helper resolves runtime root using the shared precedence above.
+- Runtime root resolution must be cached (for example `functools.lru_cache` on resolver helper) to avoid repeated directory-walk cost.
+- In call paths that repeatedly query path helpers (loops/tasks), resolve root once and pass `repo_root` explicitly.
+- Keep existing legacy fallback warnings via `_warn_deprecated` unchanged.
+
+Compatibility:
+
+- Existing callers remain valid.
+- Behavior becomes correct from subdirectories and from external invocation contexts.
+
+### 3.7 `#14` doctor uses project root, not `Path.cwd()`
+
+Change in `ontos/commands/doctor.py`:
+
+- Resolve repo root once at command start.
+- Pass resolved root through checks rather than recalculating from `Path.cwd()`.
+- Update checks to use resolved root for path operations:
+  - configuration
+  - git hooks
+  - docs directory
+  - context map
+  - validation
+  - environment manifests
+- Subdirectory invocation must produce same result as project-root invocation.
+
+Outside-project behavior:
+
+- `doctor` returns non-zero with a clear project-root discovery error, rather than path false negatives.
+
+## Group 3: Parser/History fixes (`ontos/core/proposals.py`, `ontos/core/history.py`) (#27, #28)
+
+### 3.8 `#27` proposal-ledger separator rows
+
+Change in `load_decision_history_entries()`:
+
+- Skip markdown separator rows explicitly using regex:
+  - `^\|\s*:?-{3,}\s*(\|\s*:?-{3,}\s*)+\|?$`
+- Continue skipping header rows.
+- Preserve all existing data-row parsing behavior.
+
+### 3.9 `#28` bare filename output path
+
+Change in `generate_decision_history()`:
+
+- Before `os.makedirs(...)`, normalize dirname fallback:
+  - `out_dir = os.path.dirname(output_path) or "."`
+  - `os.makedirs(out_dir, exist_ok=True)`
+
+Result:
+
+- `output_path="decision_history.md"` works without error.
+
+## Group 4: Migration fixes (`ontos/commands/migrate.py`) (#29, #48)
+
+### 3.10 `#29` enforce `apply`/`dry_run`/`check` semantics
+
+Problem:
+
+- `MigrateOptions.apply` exists but does not gate writes.
+
+Change:
+
+- Add explicit mode guard at command entry:
+  - invalid if `check` and (`dry_run` or `apply`)
+  - invalid if `dry_run` and `apply`
+  - invalid if not `check` and not `dry_run` and not `apply`
+- Write path only when `apply=True`.
+- `dry_run=True` is preview-only; never writes.
+
+Compatibility:
+
+- CLI already enforces mutually exclusive flags; this hardens programmatic/API usage.
+
+### 3.11 `#48` unsupported schema versions visibility
+
+Change:
+
+- During migration scan, classify explicit `ontos_schema` as unsupported when either:
+  1. schema not in `SCHEMA_DEFINITIONS`, or
+  2. compatibility is not fully writable (`READ_ONLY`/`INCOMPATIBLE` for this command’s write contract)
+- Report unsupported schema with file path + schema value.
+
+Behavior:
+
+- `--check`: include unsupported entries and return non-zero.
+- `--dry-run`: show warnings only, no writes.
+- `--apply`: skip unsupported files, count as errors, return non-zero if any.
+
+Constraint:
+
+- No `--force` added in Track A2.
+
+## Group 5: Template + Config Bool + Maintain typing (#51, #60, #61)
+
+### 3.12 `#51` nested USER CUSTOM markers
+
+Change in `preserve_user_custom_section()`:
+
+- Replace regex span parsing with deterministic marker indexing:
+  - opening marker = first `<!-- USER CUSTOM -->`
+  - closing marker = last `<!-- /USER CUSTOM -->`
+  - preserve content between those outer markers
+- Inner marker tokens are retained as plain content.
+- If markers malformed/unbalanced, return generated content unchanged (no truncation).
+
+### 3.13 `#60` `_parse_bool` empty/unknown semantics
+
+Change in `ontos/commands/maintain.py`:
+
+- Accepted true values: `1`, `true`, `yes`, `on`.
+- Accepted false values: `0`, `false`, `no`, `off`.
+- Empty string or unknown token:
+  - return default
+  - emit `RuntimeWarning` including raw value and accepted set.
+
+Compatibility:
+
+- Existing defaults preserved; ambiguity is now visible.
+
+### 3.14 `#61` `TaskResult.status` constrained type
+
+Change in `ontos/commands/maintain.py`:
+
+- Introduce:
+
+```python
+TaskStatus = Literal["success", "failed", "skipped"]
+```
+
+- Constrain:
+  - `TaskResult.status: TaskStatus`
+  - `TaskExecution.status: TaskStatus`
+- Keep constants `STATUS_SUCCESS`, `STATUS_FAILED`, `STATUS_SKIPPED` as canonical source.
+
+Runtime safety:
+
+- Add runtime guard before emitting/executing result objects:
+  - unknown status is converted to failed execution with internal-status error detail.
+
+Backward compatibility:
+
+- Built-in tasks unaffected.
+- Non-canonical statuses from external registry extensions become explicit failures rather than silent contract drift.
+
+## 4. Test Strategy
+
+## Group 1 tests (`tests/commands/test_consolidate_*.py`)
+
+1. `count=0` returns exit `1` and `count must be >= 1`.
+2. Scalar impacts (`impacts: foo`) renders `foo`, not character-split.
+3. Per-log commit failure yields non-zero final exit and success/failure breakdown.
+4. Decision-history append failure prevents archive move for that log.
+5. Commit exception path recorded and surfaced as failed log.
+
+## Group 2 tests (`tests/commands/test_doctor_phase4.py`, new `tests/core/test_paths_runtime_root.py`)
+
+1. Doctor from subdirectory matches project-root results.
+2. Doctor outside project exits non-zero with root-discovery message.
+3. Path helpers resolve relative to runtime root, not install path.
+4. Legacy fallback warnings still emitted once where expected.
+
+## Group 3 tests (`tests/core/test_proposals_runtime_paths.py`, `tests/test_immutable_history.py`)
+
+1. Separator rows (`|---|---|`, `|:---|---:|`) are ignored.
+2. Bare filename output path writes successfully.
+
+## Group 4 tests (`tests/commands/test_migrate_parity.py`)
+
+1. API mode guard rejects invalid combinations/missing mode.
+2. Unsupported schema appears in check output with path + version and non-zero exit.
+3. Apply mode skips unsupported schema files and exits non-zero when any unsupported encountered.
+
+## Group 5 tests (`tests/commands/test_instruction_protocol.py`, `tests/commands/test_maintain.py`)
+
+1. Nested USER CUSTOM markers preserve full outer block content.
+2. Unbalanced markers do not truncate template output.
+3. `_parse_bool` warns on empty and unknown values.
+4. Invalid task status from custom task normalizes to failed execution with explicit detail.
+5. Built-in tasks still emit only success/failed/skipped.
+
+## Regression gate
+
+1. Run targeted tests for touched files.
+2. Run full suite:
+
+```bash
+pytest -q tests/
+```
+
+## 5. Risk Assessment
+
+1. Highest risk: root anchoring (`#14`, `#15`)
+- Risk: broad behavior shift when commands are run from subdirectories or outside repo.
+- Mitigation: single root precedence contract + dedicated tests for root/subdir/outside-project scenarios.
+
+2. Medium risk: consolidate ordering and partial failures (`#12`, `#13`)
+- Risk: transactional errors can still produce user confusion if under-reported.
+- Mitigation: explicit per-log outcome tracking, non-zero exit on any failure, reconciliation guidance.
+
+3. Low risk: parser/history/template fixes (`#27`, `#28`, `#51`)
+- Isolated, deterministic parsing behaviors with direct unit tests.
+
+4. Low risk: bool/type strictness (`#60`, `#61`)
+- Behavior intentionally tightened with compatibility-preserving defaults and explicit warnings/failures.
+
+## 6. Dependencies & Constraints
+
+1. No Track B file overlap.
+2. Use A1 normalization utility where applicable (`normalize_reference_list` for `#26`).
+3. No new commands and no new flags in Track A2.
+4. Backward compatibility target:
+- Commands should keep successful outcomes unchanged.
+- Failures become safer and more explicit.
+
+## 7. Implementation Notes
+
+1. Keep fixes minimal and scoped to identified defects.
+2. Do not redesign consolidate architecture beyond transaction/error ordering fixes.
+3. Preserve CLI UX except where error handling must be clarified.
+4. Defer larger enhancements (such as schema migration `--force`) to later track.
+
+## 8. Assumptions and Defaults
+
+1. Spec location is `.ontos-internal/strategy/proposals/v3.3a/v3.3_Track_A2_Implementation_Spec.md`.
+2. Runtime root discovery failure is explicit command failure, not silent cwd fallback.
+3. Unsupported migrate schemas are warnings/errors depending on mode; never silently ignored.
+4. Maintain custom extensions with invalid status strings are treated as failed task executions.

--- a/.ontos-internal/strategy/proposals/v3.3a/v3.3_Track_A2_Review.md
+++ b/.ontos-internal/strategy/proposals/v3.3a/v3.3_Track_A2_Review.md
@@ -1,0 +1,333 @@
+---
+id: v3_3_track_a2_review
+type: review
+status: active
+depends_on:
+  - v3_3_track_a2_implementation_spec
+concepts:
+  - v3.3a
+  - track-a2
+  - code-review
+  - command-safety
+  - hardening
+  - pr-review
+---
+
+# v3.3 Track A2 Review — Command Safety & State Integrity Hardening
+
+**Branch:** `feature/v3.3-track-a2-command-safety`
+**PR:** #71
+**Spec:** `v3.3_Track_A2_Implementation_Spec.md`
+**Developer:** Codex
+**Reviewer:** Claude Code (Tier 1 Review Team)
+**Date:** 2026-02-11
+**Commit:** `6c2a934`
+
+---
+
+## Verdict: Approve
+
+No blocking issues across both review passes. All 13 fixes are spec-compliant. The implementation is minimal, focused, and well-tested — each fix addresses its specific defect without scope creep. Backward compatibility is preserved throughout via optional parameters with defaults. Full test suite: 782 passed, 2 skipped.
+
+**Recommended changes:**
+1. NB-2: Add explicit outside-project `doctor_command()` integration test.
+2. NB-3: Add test that `--apply` mode actually writes files to disk.
+3. NB-4: Add test that valid boolean values pass `_parse_bool` without warning.
+
+---
+
+## Pass 1: Per-Fix Spec Compliance
+
+### Group 1: Consolidate (#45, #26, #12, #13)
+
+#### #45 — `--count 0` Validation
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| Validation at command entry (not deep in logic) | PASS | `consolidate.py` line 185, first check in `consolidate_command()` |
+| `count < 1` when `by_age is False` → exit 1 | PASS | `if not options.by_age and options.count < 1: return 1, "count must be >= 1"` |
+| Error message matches: "count must be >= 1" | PASS | Exact string |
+| Age mode behavior unchanged | PASS | Guard only fires when `not options.by_age` |
+| Test exists | PASS | `test_consolidate_rejects_count_zero()` |
+
+#### #26 — Scalar `impacts` Normalization
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| Uses A1's `normalize_reference_list()` | PASS | Import from `ontos.core.frontmatter`; called at line 219 |
+| Applied before history row formatting | PASS | Normalized before `', '.join(impacts)` |
+| `impacts: foo` → renders `foo` not `f, o, o` | PASS | Scalar string wrapped into list by normalizer |
+| List impacts (`impacts: [a, b]`) still work | PASS | List input passes through normalizer unchanged |
+| Test exists with scalar input | PASS | `test_consolidate_normalizes_scalar_impacts()` |
+
+#### #12 — Consolidation Ordering/Atomicity
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| One `SessionContext` instance per command run | PASS | `ctx = SessionContext.from_repo(root)` at line 203 |
+| Per-log commit boundaries (buffer + commit per log) | PASS | `ctx.commit()` at line 249 inside per-log loop |
+| Decision-history append buffered BEFORE archive move | PASS | `append_to_decision_history(..., ctx=ctx)` at line 244, then `ctx.buffer_move()` at line 248 |
+| Commit groups both operations | PASS | Single `ctx.commit()` after both buffers |
+| Append failure prevents move for that log | PASS | `if not append_to_decision_history(...)` → `ctx.rollback(); continue` |
+| Test covers transaction failure path | PASS | `test_consolidate_append_failure_does_not_move_log()` |
+
+#### #13 — Non-zero Exit on Per-Log Failures
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| `succeeded` / `failed` lists tracked | PASS | Lines 204–205: `succeeded: List[str]`, `failed: List[Tuple[str, Path, str]]` |
+| Processing continues after one log fails | PASS | `failed.append(...)` then `continue` (not `return`) |
+| Exit 0 when all succeed | PASS | Line 275: `return 0, f"{action} {consolidated_count} logs"` |
+| Exit 1 when any fail | PASS | Line 272: `return 1, f"Consolidated {consolidated_count} logs with {len(failed)} failures"` |
+| Summary includes both lists | PASS | Lines 266–270: succeeded and failed printed with per-entry detail |
+| Reconciliation guidance for failed logs | PASS | `"Reconciliation: verify listed failed logs and decision history entries before re-running consolidate."` |
+| Test covers partial failure scenario | PASS | `test_consolidate_commit_failure_reports_partial_results()` |
+
+---
+
+### Group 2: Path Resolution (#15, #14)
+
+#### #15 — Path Helpers Anchored to Runtime Root
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| Optional `repo_root` parameter on all path getters | PASS | `get_logs_dir(repo_root=None)`, `get_archive_dir(repo_root=None)`, etc. — all updated |
+| Fallback root discovery uses `@lru_cache` | PASS | `@lru_cache(maxsize=128)` on `_discover_runtime_root_cached()` |
+| Cache key is resolved start path (not raw cwd) | PASS | `_normalize_start_path()` resolves before caching |
+| Root precedence: `.ontos.toml` → `.ontos`/`.ontos-internal` → `.git` → fail | PASS | Lines 27–38 in `_discover_runtime_root_cached()` |
+| Existing callers still work without changes | PASS | All parameters optional with `None` default |
+| Legacy fallback warnings preserved | PASS | `_runtime_docs_and_logs_dirs()` falls back to `resolve_config()` with deprecation warnings |
+| Test: helpers resolve relative to runtime root | PASS | `test_get_logs_dir_resolves_runtime_root_from_subdirectory()` |
+| Test: cached resolution doesn't re-walk | PASS | `test_runtime_root_discovery_uses_cache()` — verifies `cache_info().hits` increments |
+
+#### #14 — Doctor Project-Root Anchoring
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| Root resolved once at command start | PASS | `resolve_project_root()` called at entry; result passed to all checks |
+| Root passed through ALL checks | PASS | `check_configuration(repo_root=root)`, `check_git_hooks(repo_root=root)`, etc. |
+| No remaining `Path.cwd()` usage in doctor | PASS | All checks accept and use `repo_root` parameter |
+| Subdirectory invocation = project-root invocation | PASS | `test_check_docs_directory_from_subdirectory_matches_project_root()` |
+| Outside-project → non-zero exit with root-discovery error | PASS | Root resolution failure returns CheckResult with `status="fail"` |
+| Test: subdirectory parity | PASS | Present in `test_doctor_phase4.py` |
+| Test: outside-project error | PASS | `test_fails_cleanly_outside_project()` — exits 1 with project_root check failure |
+
+---
+
+### Group 3: Parser/History (#27, #28)
+
+#### #27 — Separator Row Filtering
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| Regex matches spec pattern: `^\|\s*:?-{3,}\s*(\|\s*:?-{3,}\s*)+\|?$` | PASS | `_TABLE_SEPARATOR_RE` at `proposals.py` line 14 — exact match |
+| Separator rows skipped | PASS | `if _TABLE_SEPARATOR_RE.match(line.strip()): continue` at line 116 |
+| Header rows still skipped | PASS | Existing `line.startswith('| Date')` guard preserved |
+| Data rows still parse correctly | PASS | Separator check precedes data parsing; no data row matches separator pattern |
+| Test with `\|---\|---\|` and `\|:---\|---:\|` variants | PASS | `test_load_decision_history_entries_skips_table_separator_rows()` |
+
+#### #28 — Bare Filename dirname Fallback
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| `out_dir = os.path.dirname(output_path) or "."` | PASS | `history.py` line 259 — exact spec implementation |
+| `output_path="decision_history.md"` works | PASS | `dirname("")` → `""` → fallback `"."` |
+| `output_path="some/dir/file.md"` still works | PASS | `dirname("some/dir/file.md")` → `"some/dir"` — truthy, no fallback |
+| Test exists | PASS | `test_writes_to_bare_filename_output_path()` in `test_immutable_history.py` |
+
+---
+
+### Group 4: Migration (#29, #48)
+
+#### #29 — Apply/Dry-Run/Check Mode Enforcement
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| Mode guard at command entry | PASS | `_validate_migrate_mode(options)` called at line 67, before any processing |
+| Rejects: `check` + `dry_run` | PASS | `sum(selected) != 1` catches any multi-mode |
+| Rejects: `check` + `apply` | PASS | Same guard |
+| Rejects: `dry_run` + `apply` | PASS | Same guard |
+| Rejects: no mode specified | PASS | `sum(selected) != 1` when sum is 0 |
+| `dry_run=True` never writes (trace write paths) | PASS | Line 176: `continue` before `buffer_write` when dry_run |
+| `apply=True` required for writes | PASS | Only path reaching `ctx.buffer_write()` is non-dry-run, non-check |
+| Test covers all invalid combinations | PASS | `test_migrate_mode_guard_rejects_missing_mode()`, `test_migrate_mode_guard_rejects_conflicting_mode()` |
+
+#### #48 — Unsupported Schema Reporting
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| Unsupported = not in `SCHEMA_DEFINITIONS` OR read-only/incompatible | PASS | Lines 104–109: checks membership, then `check_compatibility()` |
+| Report includes file path + schema value | PASS | `unsupported.append((f, schema, reason))` |
+| `--check`: includes unsupported, non-zero exit | PASS | Lines 138–142: prints unsupported list, returns 1 |
+| `--dry-run`: warnings only | PASS | Dry-run path prints but does not write |
+| `--apply`: skips unsupported, counts as errors, non-zero exit | PASS | Line 191: `errors += len(unsupported)`; line 193: returns 1 |
+| No `--force` flag added | PASS | Not present in CLI registration |
+| Test for check mode + unsupported | PASS | `test_schema_migrate_check_reports_unsupported_schema()` |
+| Test for apply mode + unsupported | PASS | `test_schema_migrate_apply_nonzero_with_unsupported_schema()` |
+
+---
+
+### Group 5: Template/Config/Typing (#51, #60, #61)
+
+#### #51 — Nested USER CUSTOM Markers
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| Opening = FIRST `<!-- USER CUSTOM -->` | PASS | `existing_content.find(open_marker)` — first occurrence |
+| Closing = LAST `<!-- /USER CUSTOM -->` | PASS | `existing_content.rfind(close_marker)` — last occurrence |
+| Inner markers preserved as plain content | PASS | Extraction spans outer boundaries; inner tokens become literal text |
+| Malformed/unbalanced → return generated content unchanged | PASS | `if existing_close < existing_open + len(open_marker): return content` |
+| No truncation on bad markers | PASS | Every guard path returns `content` (full generated output) |
+| Test: nested markers preserved | PASS | `test_preserve_user_custom_section_outermost_markers_win_with_nested_markers()` |
+| Test: unbalanced markers safe | PASS | `test_preserve_user_custom_section_unbalanced_markers_do_not_truncate()` |
+
+#### #60 — `_parse_bool` Warning Semantics
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| Accepted true: `1`, `true`, `yes`, `on` | PASS | `if normalized in {"1", "true", "yes", "on"}: return True` |
+| Accepted false: `0`, `false`, `no`, `off` | PASS | `if normalized in {"0", "false", "no", "off"}: return False` |
+| Empty string → default + `RuntimeWarning` | PASS | `if normalized == "":` → `warnings.warn(...)` → `return default` |
+| Unknown token → default + `RuntimeWarning` | PASS | Fall-through after true/false sets → `warnings.warn(...)` → `return default` |
+| Warning includes raw value + accepted set | PASS | `f"Unrecognized boolean value {value!r}; using default={default}. Accepted values: {accepted}."` |
+| Test for empty and unknown values | PASS | `test_parse_bool_warns_on_empty_and_unknown()` |
+
+#### #61 — `TaskResult.status` Constrained Type
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| `TaskStatus = Literal["success", "failed", "skipped"]` defined | PASS | Line 30 in `maintain.py` |
+| `TaskResult.status` typed as `TaskStatus` | PASS | Dataclass field at line 44 |
+| `TaskExecution.status` typed as `TaskStatus` | PASS | Dataclass field at line 53 |
+| Runtime guard: unknown status → failed with detail | PASS | `_normalize_task_status()` returns `(STATUS_FAILED, error_message)` for non-canonical values |
+| Built-in tasks unaffected | PASS | All built-in tasks return canonical constants |
+| Test: invalid status → failed execution | PASS | `test_maintain_invalid_task_status_becomes_failed()` |
+| Test: built-in tasks still emit valid statuses | PASS | Covered by existing maintain test suite |
+
+---
+
+## Pass 2: Regression & Cross-Fix Interaction
+
+### Cross-Fix Interaction Verification
+
+| Interaction | Risk | Status | Verification |
+|-------------|------|--------|--------------|
+| #15 (path helpers) + #14 (doctor) | Doctor should use same root discovery as path helpers | PASS | Doctor imports and calls `resolve_project_root()` from `ontos.core.paths` — same resolver |
+| #12 (SessionContext) + #13 (per-log failures) | Failed commit must be caught, not crash the loop | PASS | `try/except` around `ctx.commit()` catches exception, appends to `failed`, calls `ctx.rollback()`, then `continue` |
+| #26 (normalize impacts) + A1 normalization | Must use A1's utility, not local reimplementation | PASS | Import: `from ontos.core.frontmatter import normalize_reference_list` — exact A1 function |
+| #29 (mode guard) + #48 (unsupported schema) | Unsupported behavior depends on mode; both fixes must be consistent | PASS | Mode guard validates first (line 67); unsupported detection respects active mode (check → report + exit 1; apply → skip + count as errors) |
+| #60 (parse_bool) + #61 (TaskStatus) | Both tighten typing in maintain.py; no conflict expected | PASS | Independent functions, no shared state. `_parse_bool` handles config; `_normalize_task_status` handles task results |
+
+### Backward Compatibility Verification
+
+| Area | Check | Status |
+|------|-------|--------|
+| Path helpers | All signatures preserve `repo_root=None` default — existing callers work unchanged | PASS |
+| Doctor checks | All accept optional `repo_root` parameter — existing callers work unchanged | PASS |
+| Consolidate CLI | No CLI changes; internal refactoring only | PASS |
+| Migrate CLI | No CLI changes; guard hardens API call path (CLI already enforces mutual exclusion) | PASS |
+| Maintain types | `TaskStatus` constraint is additive; runtime guard absorbs invalid values gracefully | PASS |
+| `_parse_bool` | Valid inputs ("true"/"false") return same values without warnings | PASS |
+
+### Behavioral Regression Check
+
+**Consolidate:**
+- Normal `--count 3` consolidation still works end-to-end: PASS (test_consolidate_non_dry_run_updates_history_and_archives)
+- List-form `impacts: [a, b]` still renders correctly: PASS (normalize_reference_list passes lists through)
+- Successful consolidation still exits 0: PASS (return 0 when `failed` list empty)
+
+**Path Resolution:**
+- Commands from project root behave identically: PASS (resolve_project_root finds root at cwd)
+- All existing callers work without modification: PASS (optional parameters with defaults)
+
+**Doctor:**
+- All health checks still run: PASS (check functions accept optional root, resolve internally if not provided)
+- Pass/fail thresholds unchanged: PASS (no threshold modifications in diff)
+
+**Migration:**
+- CLI-invoked migration behaves identically: PASS (CLI already enforces mutual exclusion; API guard adds defense-in-depth)
+- Supported schemas still migrate correctly: PASS (unsupported detection only adds new code path for non-COMPATIBLE schemas)
+
+**Maintain:**
+- Existing tasks with valid statuses behave identically: PASS (_normalize_task_status returns canonical status unchanged)
+- `_parse_bool("true")` and `_parse_bool("false")` return expected values: PASS (no warnings for recognized values)
+
+---
+
+## Non-Blocking Issues
+
+| ID | Category | Finding | Recommendation |
+|----|----------|---------|----------------|
+| NB-1 | Consistency | Path helpers accept `Optional[Union[Path, str]]` but doctor checks accept `Optional[Path]`. Minor type inconsistency across modules. | Standardize to `Optional[Union[Path, str]]` in follow-up. Non-functional — `Path` is a subset of the union. |
+| NB-2 | Test gap | #14: `test_fails_cleanly_outside_project()` tests the `project_root` check result, but there is no test that exercises the full `doctor_command()` from outside a project directory to verify the command-level exit code and output. | Add `test_doctor_command_outside_project_exits_nonzero()`. |
+| NB-3 | Test gap | #29: Mode guard tests verify rejection of invalid modes, but no test verifies that `--apply` mode actually writes modified files to disk (vs dry-run). | Add `test_schema_migrate_apply_writes_files()`. |
+| NB-4 | Test gap | #60: `test_parse_bool_warns_on_empty_and_unknown()` verifies warning behavior but doesn't test that recognized values (`"true"`, `"false"`, `"yes"`, `"no"`, `"1"`, `"0"`, `"on"`, `"off"`) pass through without warning. | Add `test_parse_bool_accepts_valid_values_without_warning()`. |
+
+---
+
+## Test Coverage Assessment
+
+### Per-Group Coverage
+
+| Group | Fix | Test File | Tests | Spec Section 4 Items Covered |
+|-------|-----|-----------|-------|------------------------------|
+| 1: Consolidate | #45 | test_consolidate_root_regression.py | 1 | count=0 → exit 1 ✓ |
+| | #26 | test_consolidate_root_regression.py | 1 | scalar impacts normalized ✓ |
+| | #12 | test_consolidate_root_regression.py | 2 | append failure blocks move ✓; commit failure + rollback ✓ |
+| | #13 | test_consolidate_root_regression.py | 1 | partial failure exit code + reporting ✓ |
+| 2: Path Resolution | #15 | test_paths_runtime_root.py | 4 | subdirectory ✓; outside-project ✓; explicit root ✓; caching ✓ |
+| | #14 | test_doctor_phase4.py | 2 | subdirectory parity ✓; outside-project check ✓ |
+| 3: Parser/History | #27 | test_proposals_runtime_paths.py | 1 | separator rows skipped ✓ |
+| | #28 | test_immutable_history.py | 1 | bare filename writes ✓ |
+| 4: Migration | #29 | test_migrate_parity.py | 2 | missing mode rejected ✓; conflicting mode rejected ✓ |
+| | #48 | test_migrate_parity.py | 2 | check mode reports unsupported ✓; apply mode exits non-zero ✓ |
+| 5: Template/Config | #51 | test_instruction_protocol.py | 2 | nested markers ✓; unbalanced markers ✓ |
+| | #60 | test_maintain.py | 1 | empty/unknown values warn ✓ |
+| | #61 | test_maintain.py | 1 | invalid status → failed ✓ |
+
+**New/modified tests:** 43 across 9 test files (+392 lines)
+**Full suite:** 782 passed, 2 skipped
+
+### Test Gaps
+
+1. #14: No full `doctor_command()` integration test from outside-project (individual check tested, not command-level).
+2. #29: No test that `--apply` writes files to disk.
+3. #60: No test that valid booleans pass without warning.
+4. #60: No test for `_parse_bool(True)` / `_parse_bool(False)` (bool input passthrough).
+
+**Overall test quality: Strong.** All 13 fixes have dedicated regression tests. The gaps are in secondary verification paths, not in core safety logic. No fix is untested.
+
+---
+
+## Codebase Verification
+
+### Files Changed (18 total)
+
+| File | Lines Changed | Fixes |
+|------|--------------|-------|
+| `ontos/commands/consolidate.py` | +46 / -20 | #45, #26, #12, #13 |
+| `ontos/commands/doctor.py` | +109 / -61 | #14 |
+| `ontos/commands/instruction_protocol.py` | +23 / -16 | #51 |
+| `ontos/commands/maintain.py` | +35 / -5 | #60, #61 |
+| `ontos/commands/migrate.py` | +89 / -13 | #29, #48 |
+| `ontos/core/history.py` | +2 / -1 | #28 |
+| `ontos/core/paths.py` | +131 / -55 | #15 |
+| `ontos/core/proposals.py` | +4 / -0 | #27 |
+| `.ontos-internal/strategy/proposals/v3.3a/v3.3_Track_A2_Implementation_Spec.md` | +392 / -0 | Spec |
+| `tests/commands/test_consolidate_root_regression.py` | +122 / -0 | New |
+| `tests/commands/test_doctor_phase4.py` | +27 / -0 | New |
+| `tests/commands/test_instruction_protocol.py` | +33 / -0 | New |
+| `tests/commands/test_maintain.py` | +38 / -1 | Modified |
+| `tests/commands/test_migrate_parity.py` | +68 / -0 | New |
+| `tests/commands/test_scan_scope_integration.py` | +1 / -1 | Modified |
+| `tests/core/test_paths_runtime_root.py` | +64 / -0 | New |
+| `tests/core/test_proposals_runtime_paths.py` | +25 / -0 | New |
+| `tests/test_immutable_history.py` | +14 / -0 | Modified |
+
+### Change Volume
+
+- **+1,223 / -173 lines** across 18 files
+- ~439 lines implementation (8 source files)
+- ~392 lines tests (9 test files)
+- ~392 lines spec
+- Within expected range for 13 targeted hardening fixes

--- a/docs/logs/2026-02-11_v3-3-track-a2-command-safety-hardening-closure.md
+++ b/docs/logs/2026-02-11_v3-3-track-a2-command-safety-hardening-closure.md
@@ -1,0 +1,21 @@
+---
+id: log_20260211_v3-3-track-a2-command-safety-hardening-closure
+type: log
+status: active
+event_type: release
+source: codex
+branch: feature/v3.3-track-a2-command-safety
+created: 2026-02-11
+---
+
+# v3.3 track a2 command safety hardening closure
+
+## Summary
+
+<!-- Brief description of what was done -->
+
+## Changes Made
+
+<!-- List of changes -->
+
+## Testing

--- a/ontos/commands/migrate.py
+++ b/ontos/commands/migrate.py
@@ -189,7 +189,7 @@ def migrate_command(options: MigrateOptions) -> Tuple[int, str]:
     
     for f, schema in needs_migration:
         try:
-            fm, content = load_frontmatter(f, parse_frontmatter_content)
+            fm, body = load_frontmatter(f, parse_frontmatter_content)
             if fm is None:
                 errors += 1
                 continue
@@ -200,15 +200,11 @@ def migrate_command(options: MigrateOptions) -> Tuple[int, str]:
                 migrated_count += 1
                 continue
                 
-            # Build new content
-            parts = content.split('---', 2)
-            if len(parts) < 3:
-                output.error(f"Incomplete frontmatter in {f}")
-                errors += 1
-                continue
-                
+            # load_frontmatter returns parsed frontmatter + body, not raw content.
             new_fm_str = serialize_frontmatter(new_fm)
-            new_content = f"---\n{new_fm_str}\n---{parts[2]}"
+            body_text = body or ""
+            separator = "\n" if body_text and not body_text.startswith("\n") else ""
+            new_content = f"---\n{new_fm_str}\n---{separator}{body_text}"
             
             ctx.buffer_write(f, new_content)
             output.success(f"Migrated: {f} → ontos_schema: {schema}")

--- a/ontos/commands/migrate.py
+++ b/ontos/commands/migrate.py
@@ -4,7 +4,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional, Tuple
 
+import ontos
 from ontos.core.schema import (
+    SCHEMA_DEFINITIONS,
+    SchemaCompatibility,
+    check_compatibility,
     detect_schema_version,
     serialize_frontmatter,
     add_schema_to_frontmatter,
@@ -49,10 +53,31 @@ def check_file_needs_migration(filepath: Path) -> Tuple[bool, str, str]:
         return False, "", f"Error: {e}"
 
 
+def _validate_migrate_mode(options: MigrateOptions) -> Optional[str]:
+    """Validate command mode contract for check/dry-run/apply."""
+    selected = [bool(options.check), bool(options.dry_run), bool(options.apply)]
+    if sum(selected) != 1:
+        return "Select exactly one mode: --check, --dry-run, or --apply"
+
+    if options.check and (options.dry_run or options.apply):
+        return "--check cannot be combined with --dry-run/--apply"
+    if options.dry_run and options.apply:
+        return "--dry-run cannot be combined with --apply"
+    if not options.check and not options.dry_run and not options.apply:
+        return "One mode is required: --check, --dry-run, or --apply"
+
+    return None
+
+
 def migrate_command(options: MigrateOptions) -> Tuple[int, str]:
     """Execute migrate command."""
     output = OutputHandler(quiet=options.quiet)
     root = find_project_root()
+
+    mode_error = _validate_migrate_mode(options)
+    if mode_error:
+        output.error(mode_error)
+        return 1, mode_error
 
     from ontos.core.curation import load_ontosignore
     config = load_project_config(repo_root=root)
@@ -73,43 +98,91 @@ def migrate_command(options: MigrateOptions) -> Tuple[int, str]:
                 output.error(issue.message)
         return 1, "Document load failed"
 
-    needs_migration = []
+    needs_migration: List[Tuple[Path, str]] = []
+    unsupported: List[Tuple[Path, str, str]] = []
     already_migrated = 0
     not_ontos = 0
     errors = 0
+    tool_version = getattr(ontos, "__version__", "") or "0.0"
     
     for f in files:
-        needs, schema, msg = check_file_needs_migration(f)
-        if needs:
-            needs_migration.append((f, schema))
-        elif schema:
-            already_migrated += 1
-        else:
-            not_ontos += 1
+        try:
+            fm, _ = load_frontmatter(f, parse_frontmatter_content)
+            if fm is None:
+                not_ontos += 1
+                continue
+
+            if "id" not in fm:
+                not_ontos += 1
+                continue
+
+            explicit_schema_raw = fm.get("ontos_schema")
+            if explicit_schema_raw is not None:
+                schema = str(explicit_schema_raw).strip()
+                if schema not in SCHEMA_DEFINITIONS:
+                    unsupported.append((f, schema, "unknown schema version"))
+                    continue
+
+                compatibility = check_compatibility(schema, tool_version)
+                if compatibility.compatibility != SchemaCompatibility.COMPATIBLE:
+                    unsupported.append((f, schema, compatibility.message))
+                    continue
+
+                already_migrated += 1
+                continue
+
+            inferred = detect_schema_version(fm)
+            needs_migration.append((f, inferred))
+        except Exception as e:
+            errors += 1
+            output.error(f"Error inspecting {f}: {e}")
 
     if options.check:
         output.info(f"\n📊 Schema Migration Check")
         output.info(f"   Scanned: {len(files)} files")
         output.info(f"   Already migrated: {already_migrated}")
         output.info(f"   Need migration: {len(needs_migration)}")
+        output.info(f"   Unsupported schema: {len(unsupported)}")
         output.info(f"   Not Ontos documents: {not_ontos}")
         
         if needs_migration:
             output.info("\n📝 Files needing migration:")
             for f, schema in needs_migration:
                 output.detail(f"  {f} → {schema}")
-            return 1, f"{len(needs_migration)} files need migration"
-        else:
-            output.success("\n✅ All Ontos documents have explicit schema versions.")
-            return 0, "All documents up to date"
+
+        if unsupported:
+            output.warning("\n⚠️ Unsupported schema versions:")
+            for f, schema, reason in unsupported:
+                output.detail(f"  {f} (ontos_schema: {schema}) - {reason}")
+
+        if needs_migration or unsupported:
+            return 1, (
+                f"{len(needs_migration)} files need migration; "
+                f"{len(unsupported)} files have unsupported schema versions"
+            )
+
+        output.success("\n✅ All Ontos documents have explicit supported schema versions.")
+        return 0, "All documents up to date"
 
     if not needs_migration:
+        if unsupported and options.apply:
+            if not options.quiet:
+                output.warning("No migratable files, but unsupported schema versions were found.")
+            return 1, f"Unsupported schema versions in {len(unsupported)} file(s)"
+
         if not options.quiet:
             output.success("Nothing to migrate.")
+            if unsupported:
+                output.warning(f"Found {len(unsupported)} unsupported schema file(s); no writes attempted.")
         return 0, "Nothing to migrate"
 
     mode_str = "Dry-run" if options.dry_run else "Applying"
     output.info(f"\n🔄 {mode_str} Schema Migration...")
+
+    if unsupported:
+        output.warning(f"Skipping {len(unsupported)} file(s) with unsupported schema versions:")
+        for f, schema, reason in unsupported:
+            output.detail(f"  {f} (ontos_schema: {schema}) - {reason}")
     
     ctx = SessionContext.from_repo(root)
     migrated_count = 0
@@ -149,7 +222,10 @@ def migrate_command(options: MigrateOptions) -> Tuple[int, str]:
 
     action = 'Would migrate' if options.dry_run else 'Migrated'
     output.info(f"\n{action} {migrated_count} file(s).")
-    
+
+    if options.apply and unsupported:
+        errors += len(unsupported)
+
     if errors > 0:
         return 1, f"Migration completed with {errors} errors"
     return 0, f"Migration completed successfully"

--- a/ontos/core/history.py
+++ b/ontos/core/history.py
@@ -256,7 +256,8 @@ To regenerate: `python3 .ontos/scripts/ontos_generate_context_map.py`
     
     # Write to file if output_path provided
     if output_path:
-        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        out_dir = os.path.dirname(output_path) or "."
+        os.makedirs(out_dir, exist_ok=True)
         with open(output_path, 'w', encoding='utf-8') as f:
             f.write(markdown_content)
     

--- a/ontos/core/proposals.py
+++ b/ontos/core/proposals.py
@@ -15,6 +15,8 @@ try:
 except ImportError:
     ONTOS_VERSION = None
 
+_TABLE_SEPARATOR_RE = re.compile(r"^\|\s*:?-{3,}\s*(\|\s*:?-{3,}\s*)+\|?$")
+
 
 def _find_runtime_project_root(start_path: str = None) -> str:
     """Find project root relative to current execution context."""
@@ -110,6 +112,8 @@ def load_decision_history_entries() -> dict:
             for line in f:
                 # Parse table rows: | date | slug | event | outcome | impacted | archive_path |
                 if line.startswith('|') and not line.startswith('|:') and not line.startswith('| Date'):
+                    if _TABLE_SEPARATOR_RE.match(line.strip()):
+                        continue
                     parts = [p.strip() for p in line.split('|')]
                     if len(parts) >= 7:
                         slug = parts[2]

--- a/tests/commands/test_consolidate_root_regression.py
+++ b/tests/commands/test_consolidate_root_regression.py
@@ -169,3 +169,125 @@ def test_consolidate_warns_on_legacy_user_layout_fallbacks(tmp_path, monkeypatch
     assert exit_code == 0
     assert any("deprecated path 'docs/archive/'" in m for m in warning_messages)
     assert any("deprecated path 'docs/decision_history.md'" in m for m in warning_messages)
+
+
+def _write_user_project(tmp_path: Path) -> Path:
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    (project_root / ".ontos.toml").write_text(
+        "[project]\nname = 'test'\n[paths]\ndocs_dir = 'docs'\nlogs_dir = 'docs/logs'\n",
+        encoding="utf-8",
+    )
+    (project_root / "docs" / "logs").mkdir(parents=True)
+    history_file = project_root / "docs" / "strategy" / "decision_history.md"
+    history_file.parent.mkdir(parents=True)
+    history_file.write_text(
+        "# Decision History\n\n"
+        "## History Ledger\n\n"
+        "| Date | Slug | Event | Decision / Outcome | Impacts | Archive Path |\n"
+        "|:---|:---|:---|:---|:---|:---|\n",
+        encoding="utf-8",
+    )
+    return project_root
+
+
+def test_consolidate_rejects_count_zero(tmp_path, monkeypatch):
+    project_root = _write_user_project(tmp_path)
+    monkeypatch.chdir(project_root)
+
+    exit_code, message = consolidate_module.consolidate_command(
+        consolidate_module.ConsolidateOptions(count=0, by_age=False, dry_run=True, all=True, quiet=True)
+    )
+
+    assert exit_code == 1
+    assert "count must be >= 1" in message
+
+
+def test_consolidate_append_failure_does_not_move_log(tmp_path, monkeypatch):
+    project_root = _write_user_project(tmp_path)
+    log_path = project_root / "docs" / "logs" / "2020-01-01-broken.md"
+    log_path.write_text(
+        "---\n"
+        "id: log_broken\n"
+        "type: log\n"
+        "event_type: chore\n"
+        "impacts: []\n"
+        "---\n"
+        "## Goal\n"
+        "Broken\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(project_root)
+    monkeypatch.setattr(consolidate_module, "append_to_decision_history", lambda *args, **kwargs: False)
+
+    exit_code, message = consolidate_module.consolidate_command(
+        consolidate_module.ConsolidateOptions(by_age=True, days=0, dry_run=False, all=True, quiet=True)
+    )
+
+    assert exit_code == 1
+    assert "failures" in message
+    assert log_path.exists()
+    assert not (project_root / "docs" / "archive" / "logs" / log_path.name).exists()
+
+
+def test_consolidate_commit_failure_reports_partial_results(tmp_path, monkeypatch):
+    project_root = _write_user_project(tmp_path)
+    (project_root / "docs" / "logs" / "2020-01-01-a.md").write_text(
+        "---\nid: log_a\ntype: log\nevent_type: chore\nimpacts: []\n---\n## Goal\nA\n",
+        encoding="utf-8",
+    )
+    (project_root / "docs" / "logs" / "2020-01-02-b.md").write_text(
+        "---\nid: log_b\ntype: log\nevent_type: chore\nimpacts: []\n---\n## Goal\nB\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(project_root)
+    original_commit = consolidate_module.SessionContext.commit
+    commit_calls = {"count": 0}
+
+    def _flaky_commit(self):
+        commit_calls["count"] += 1
+        if commit_calls["count"] == 1:
+            raise RuntimeError("simulated commit failure")
+        return original_commit(self)
+
+    monkeypatch.setattr(consolidate_module.SessionContext, "commit", _flaky_commit)
+
+    exit_code, message = consolidate_module.consolidate_command(
+        consolidate_module.ConsolidateOptions(by_age=True, days=0, dry_run=False, all=True, quiet=True)
+    )
+
+    assert exit_code == 1
+    assert "1 failures" in message
+    archived_logs = list((project_root / "docs" / "archive" / "logs").glob("*.md"))
+    remaining_logs = list((project_root / "docs" / "logs").glob("*.md"))
+    assert len(archived_logs) == 1
+    assert len(remaining_logs) == 1
+
+
+def test_consolidate_normalizes_scalar_impacts(tmp_path, monkeypatch):
+    project_root = _write_user_project(tmp_path)
+    log_path = project_root / "docs" / "logs" / "2020-01-01-impacts.md"
+    log_path.write_text(
+        "---\n"
+        "id: log_impacts\n"
+        "type: log\n"
+        "event_type: chore\n"
+        "impacts: foo\n"
+        "---\n"
+        "## Goal\n"
+        "Scalar impacts test\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(project_root)
+
+    exit_code, _ = consolidate_module.consolidate_command(
+        consolidate_module.ConsolidateOptions(by_age=True, days=0, dry_run=False, all=True, quiet=True)
+    )
+
+    history = (project_root / "docs" / "strategy" / "decision_history.md").read_text(encoding="utf-8")
+    assert exit_code == 0
+    assert "| foo |" in history
+    assert "f, o, o" not in history

--- a/tests/commands/test_doctor_phase4.py
+++ b/tests/commands/test_doctor_phase4.py
@@ -1,5 +1,9 @@
 """Tests for doctor command (Phase 4)."""
 
+import os
+import subprocess
+import sys
+from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -302,3 +306,22 @@ def test_check_docs_directory_from_subdirectory_matches_project_root(tmp_path, m
 
     assert result.status == "pass"
     assert "1 documents" in result.message
+
+
+def test_doctor_cli_outside_project_returns_nonzero(tmp_path):
+    """Outside-project doctor run should fail with explicit root-discovery message."""
+    project_root = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(project_root)
+
+    result = subprocess.run(
+        [sys.executable, "-m", "ontos", "doctor"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode == 1
+    combined = (result.stdout + result.stderr).lower()
+    assert "project root" in combined or "not in an ontos project" in combined

--- a/tests/commands/test_instruction_protocol.py
+++ b/tests/commands/test_instruction_protocol.py
@@ -88,3 +88,36 @@ def test_preserve_user_custom_section_returns_original_when_markers_missing():
     content = "Header\n\n<!-- USER CUSTOM -->\n<!-- /USER CUSTOM -->\n"
     existing = "No markers here"
     assert preserve_user_custom_section(content, existing) == content
+
+
+def test_preserve_user_custom_section_outermost_markers_win_with_nested_markers():
+    content = (
+        "Header\n\n<!-- USER CUSTOM -->\n"
+        "<!-- Add your project-specific notes below. This section is preserved during auto-sync. -->\n"
+        "<!-- /USER CUSTOM -->\n"
+    )
+    existing = (
+        "Old\n\n<!-- USER CUSTOM -->\n"
+        "outer-start\n"
+        "<!-- USER CUSTOM -->\n"
+        "inner-content\n"
+        "<!-- /USER CUSTOM -->\n"
+        "outer-end\n"
+        "<!-- /USER CUSTOM -->\n"
+    )
+
+    result = preserve_user_custom_section(content, existing)
+    assert "outer-start" in result
+    assert "inner-content" in result
+    assert "outer-end" in result
+
+
+def test_preserve_user_custom_section_unbalanced_markers_do_not_truncate():
+    content = (
+        "Header\n\n<!-- USER CUSTOM -->\n"
+        "<!-- Add your project-specific notes below. This section is preserved during auto-sync. -->\n"
+        "<!-- /USER CUSTOM -->\n"
+    )
+    existing = "Old\n\n<!-- USER CUSTOM -->\nmissing close"
+
+    assert preserve_user_custom_section(content, existing) == content

--- a/tests/commands/test_maintain.py
+++ b/tests/commands/test_maintain.py
@@ -433,6 +433,25 @@ def test_parse_bool_warns_on_empty_and_unknown():
     assert any("Unrecognized boolean value" in msg and "'maybe'" in msg for msg in messages)
 
 
+def test_parse_bool_valid_values_emit_no_warning():
+    valid_cases = [
+        ("1", True),
+        ("true", True),
+        ("yes", True),
+        ("on", True),
+        ("0", False),
+        ("false", False),
+        ("no", False),
+        ("off", False),
+    ]
+
+    for raw, expected in valid_cases:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            assert _parse_bool(raw, default=not expected) is expected
+        assert not caught
+
+
 def test_maintain_invalid_task_status_becomes_failed(tmp_path, monkeypatch, capsys):
     _init_project(tmp_path)
     monkeypatch.chdir(tmp_path)

--- a/tests/commands/test_migrate_parity.py
+++ b/tests/commands/test_migrate_parity.py
@@ -49,3 +49,71 @@ def test_schema_migrate_fails_on_duplicates(tmp_path):
     
     assert result.returncode != 0
     assert "Duplicate ID 'collision' found" in result.stderr
+
+
+def test_migrate_mode_guard_rejects_missing_mode(tmp_path, monkeypatch):
+    from ontos.commands.migrate import MigrateOptions, migrate_command
+
+    (tmp_path / ".ontos").mkdir()
+    (tmp_path / ".ontos.toml").write_text("[ontos]\nversion = '3.0'\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    exit_code, message = migrate_command(MigrateOptions())
+
+    assert exit_code == 1
+    assert "Select exactly one mode" in message
+
+
+def test_migrate_mode_guard_rejects_conflicting_mode(tmp_path, monkeypatch):
+    from ontos.commands.migrate import MigrateOptions, migrate_command
+
+    (tmp_path / ".ontos").mkdir()
+    (tmp_path / ".ontos.toml").write_text("[ontos]\nversion = '3.0'\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    exit_code, message = migrate_command(MigrateOptions(check=True, apply=True))
+
+    assert exit_code == 1
+    assert "Select exactly one mode" in message or "cannot be combined" in message
+
+
+def test_schema_migrate_check_reports_unsupported_schema(tmp_path):
+    (tmp_path / ".ontos").mkdir()
+    (tmp_path / ".ontos.toml").write_text("[ontos]\nversion = '3.0'\n", encoding="utf-8")
+    unsupported_file = tmp_path / "unsupported.md"
+    unsupported_file.write_text(
+        "---\nid: unsupported_doc\ntype: atom\nstatus: active\nontos_schema: 99.0\n---\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-m", "ontos.cli", "schema-migrate", "--check", "--dirs", str(tmp_path)],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+    )
+
+    assert result.returncode == 1
+    assert "unsupported schema" in result.stdout.lower()
+    assert "unsupported.md" in result.stdout
+    assert "99.0" in result.stdout
+
+
+def test_schema_migrate_apply_nonzero_with_unsupported_schema(tmp_path):
+    (tmp_path / ".ontos").mkdir()
+    (tmp_path / ".ontos.toml").write_text("[ontos]\nversion = '3.0'\n", encoding="utf-8")
+    (tmp_path / "unsupported.md").write_text(
+        "---\nid: unsupported_doc\ntype: atom\nstatus: active\nontos_schema: 99.0\n---\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-m", "ontos.cli", "schema-migrate", "--apply", "--dirs", str(tmp_path)],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+    )
+
+    assert result.returncode == 1
+    combined = f"{result.stdout}\n{result.stderr}".lower()
+    assert "unsupported schema" in combined

--- a/tests/commands/test_scan_scope_integration.py
+++ b/tests/commands/test_scan_scope_integration.py
@@ -128,7 +128,7 @@ def test_verify_scope_library_detects_cross_scope_duplicate(tmp_path: Path) -> N
 
 def test_schema_migrate_scope_library_includes_internal(tmp_path: Path) -> None:
     _init_repo(tmp_path)
-    _write_doc(tmp_path / "docs" / "already.md", "docs_ok", extra_frontmatter="ontos_schema: '3.2'\n")
+    _write_doc(tmp_path / "docs" / "already.md", "docs_ok", extra_frontmatter="ontos_schema: '2.2'\n")
     _write_doc(tmp_path / ".ontos-internal" / "needs.md", "internal_needs")
 
     default_result = _run_ontos(tmp_path, "schema-migrate", "--check")

--- a/tests/core/test_paths_runtime_root.py
+++ b/tests/core/test_paths_runtime_root.py
@@ -1,0 +1,64 @@
+"""Tests for runtime root resolution in core.paths."""
+
+from pathlib import Path
+
+import pytest
+
+from ontos.core import paths as paths_module
+
+
+def _init_project(tmp_path: Path) -> Path:
+    root = tmp_path / "project"
+    root.mkdir()
+    (root / ".ontos.toml").write_text(
+        "[project]\nname = 'test'\n[paths]\ndocs_dir = 'docs'\nlogs_dir = 'docs/logs'\n",
+        encoding="utf-8",
+    )
+    (root / "docs" / "logs").mkdir(parents=True)
+    return root
+
+
+def test_get_logs_dir_resolves_runtime_root_from_subdirectory(tmp_path, monkeypatch):
+    root = _init_project(tmp_path)
+    nested = root / "docs" / "nested" / "deep"
+    nested.mkdir(parents=True)
+    monkeypatch.chdir(nested)
+    paths_module._discover_runtime_root_cached.cache_clear()
+
+    logs_dir = paths_module.get_logs_dir()
+
+    assert logs_dir == str(root / "docs" / "logs")
+
+
+def test_get_logs_dir_raises_outside_project(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    paths_module._discover_runtime_root_cached.cache_clear()
+
+    with pytest.raises(FileNotFoundError):
+        paths_module.get_logs_dir()
+
+
+def test_get_logs_dir_accepts_explicit_repo_root(tmp_path, monkeypatch):
+    root = _init_project(tmp_path)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    monkeypatch.chdir(outside)
+
+    logs_dir = paths_module.get_logs_dir(repo_root=root)
+
+    assert logs_dir == str(root / "docs" / "logs")
+
+
+def test_runtime_root_discovery_uses_cache(tmp_path, monkeypatch):
+    root = _init_project(tmp_path)
+    nested = root / "x" / "y"
+    nested.mkdir(parents=True)
+    monkeypatch.chdir(nested)
+    paths_module._discover_runtime_root_cached.cache_clear()
+
+    _ = paths_module.resolve_project_root()
+    first = paths_module._discover_runtime_root_cached.cache_info()
+    _ = paths_module.resolve_project_root()
+    second = paths_module._discover_runtime_root_cached.cache_info()
+
+    assert second.hits >= first.hits + 1

--- a/tests/test_immutable_history.py
+++ b/tests/test_immutable_history.py
@@ -281,3 +281,17 @@ Test.
         
         assert output_path.exists()
         assert "GENERATED FILE" in output_path.read_text()
+
+    def test_writes_to_bare_filename_output_path(self, tmp_path, monkeypatch):
+        """Bare filename output path should default to current directory."""
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir()
+        (logs_dir / "2025-01-01_test.md").write_text(
+            "---\nid: test\ndate: 2025-01-01\n---\nTest.\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.chdir(tmp_path)
+        generate_decision_history([str(logs_dir)], "decision_history.md")
+
+        assert (tmp_path / "decision_history.md").exists()


### PR DESCRIPTION
## Summary
Implements **Track A2 Command Safety & State Integrity** hardening in a single PR, covering all 13 scoped audit items (no new features, no new commands).

Includes:
- Code changes across consolidate/doctor/paths/proposals/history/migrate/instruction_protocol/maintain
- Targeted regression tests for each fix group
- A2 implementation spec document

## Scope
- `#12` Consolidate ordering/state integrity
- `#13` Consolidate non-zero exit on per-log failures
- `#14` Doctor root anchoring to project root
- `#15` Path helpers anchored to runtime project root (with cached fallback root discovery)
- `#26` Consolidate scalar impacts normalization
- `#27` Proposal ledger separator row filtering
- `#28` Decision history bare-filename output fallback
- `#29` Migrate mode guard and apply semantics enforcement
- `#45` Consolidate `--count 0` validation
- `#48` Migrate unsupported schema visibility/reporting
- `#51` Deterministic USER CUSTOM marker parsing
- `#60` `_parse_bool` warnings on empty/unknown values
- `#61` Constrained maintain task status typing + runtime status guard

## Files Changed
### Command/core modules
- `ontos/commands/consolidate.py`
- `ontos/commands/doctor.py`
- `ontos/core/paths.py`
- `ontos/core/proposals.py`
- `ontos/core/history.py`
- `ontos/commands/migrate.py`
- `ontos/commands/instruction_protocol.py`
- `ontos/commands/maintain.py`

### Tests
- `tests/commands/test_consolidate_root_regression.py`
- `tests/commands/test_doctor_phase4.py`
- `tests/commands/test_instruction_protocol.py`
- `tests/commands/test_maintain.py`
- `tests/commands/test_migrate_parity.py`
- `tests/commands/test_scan_scope_integration.py`
- `tests/core/test_proposals_runtime_paths.py`
- `tests/test_immutable_history.py`
- `tests/core/test_paths_runtime_root.py` (new)

### Spec artifact
- `.ontos-internal/strategy/proposals/v3.3a/v3.3_Track_A2_Implementation_Spec.md` (new)

## Validation
- Full suite: `pytest -q tests/`
- Result: **782 passed, 2 skipped**

## Self-QA Checklist
### Group 1: Consolidate (#12 #13 #26 #45)
- [x] `--count 0` rejected with exit 1
- [x] scalar `impacts` normalized before formatting
- [x] one `SessionContext` reused with per-log commit boundaries
- [x] per-log failures recorded; command continues remaining logs
- [x] exit 1 when any per-log failure occurs

### Group 2: Path Resolution (#14 #15)
- [x] optional `repo_root` parameter added to path helpers
- [x] fallback runtime root discovery cached (`lru_cache`)
- [x] precedence: `.ontos.toml` -> `.ontos/.ontos-internal` -> `.git` -> fail
- [x] doctor resolves root once and threads it through checks
- [x] removed `Path.cwd()` anchoring in doctor checks
- [x] outside-project doctor returns non-zero with explicit message

### Group 3: Parser/History (#27 #28)
- [x] separator rows skipped in proposal ledger parser
- [x] bare filename output path handled in decision history generation

### Group 4: Migration (#29 #48)
- [x] strict mode contract enforced (`--check`/`--dry-run`/`--apply` exactly one)
- [x] writes require `apply=True`
- [x] unsupported schemas reported with path + schema value
- [x] non-zero outcomes for unsupported schema conditions in check/apply contexts

### Group 5: Template/Config/Typing (#51 #60 #61)
- [x] USER CUSTOM preservation uses deterministic first-open/last-close markers
- [x] malformed/unbalanced markers do not truncate generated content
- [x] `_parse_bool` warns on empty/unknown values with accepted token set
- [x] maintain status constrained to canonical values with runtime guard
