### PR TITLE
v3.3 A3: add CLI surface/output/taxonomy implementation spec

### DIFF
--- a/.ontos-internal/strategy/proposals/v3.3a/v3.3_Track_A3_Implementation_Spec.md
+++ b/.ontos-internal/strategy/proposals/v3.3a/v3.3_Track_A3_Implementation_Spec.md
@@ -1,0 +1,457 @@
+---
+id: v3_3_track_a3_implementation_spec
+type: strategy
+status: draft
+depends_on:
+  - v3_3_release_plan
+  - v3_3_merged_audit_findings
+  - v3_3_track_b_implementation_spec_v2
+  - v3_3_track_a2_implementation_spec
+concepts:
+  - v3.3a
+  - track-a3
+  - cli-surface
+  - output-contracts
+  - command-taxonomy
+---
+
+# v3.3 Track A3 Implementation Spec
+
+## 1. Overview
+
+Track A3 hardens the command surface after A1 + B + A2 by making CLI behavior consistent across:
+
+- JSON output contracts
+- exit-code semantics
+- help text and flag semantics
+- command taxonomy/discoverability
+- status vocabulary and output formatting
+
+Release-plan A3 started with 22 items. After codebase verification on post-A2 `main`:
+
+- 2 items are already resolved and removed from implementation scope (`#20`, `#52`)
+- 20 items remain in scope (including 4 partials with residual work)
+
+Risk level: medium. Highest risk is JSON schema unification and return-contract normalization because these affect scripts and tests across many commands.
+
+Estimated change volume: ~1.1k-1.6k LOC including tests and golden updates.
+
+## 2. Scope
+
+### 2.1 In Scope (Remaining A3 Items)
+
+- [ ] `#2 (G-1)` short-flag overload (`-f`) normalization
+- [ ] `#3 (G-2/C-2/C-3)` JSON output contract unification (residual)
+- [ ] `#6 (C-1)` missing-command exit code
+- [ ] `#7 (C-4/G-3)` `scaffold --apply --dry-run` mutual exclusion / semantics
+- [ ] `#16 (G-3)` dry-run/apply UX consistency across mutating commands
+- [ ] `#17 (G-4)` `map --obsidian` help-text correction
+- [ ] `#18 (G-6)` confirmation/skip-flag consistency
+- [ ] `#19 (G-7)` status terminology alignment (`doctor` vs `maintain`) (residual)
+- [ ] `#21 (G-9/X-M12)` instruction-command surface consolidation (residual)
+- [ ] `#24 (G-14)` user vs internal error handling in CLI
+- [ ] `#34 (CC-02/X-M7)` cross-command import chain removal
+- [ ] `#35 (CC-04)` command return-type contract unification
+- [ ] `#39 (CC-08)` `SessionContext.commit()` exception handling (residual)
+- [ ] `#43 (CC-18)` unused `dry_run` fields cleanup (`map`, `log`)
+- [ ] `#46 (X-M1)` `stub` input validation hardening
+- [ ] `#47 (X-M2)` `scaffold` silent-failure hardening
+- [ ] `#49 (X-M4)` `query --health` cycle detection
+- [ ] `#50 (X-M5)` `maintain --skip unknown` exit semantics
+- [ ] `#58 (CC-17)` `OutputHandler` bypass cleanup (`doctor`, `init`, `log`)
+- [ ] `#62 (X-M11)` `ontos export --all` instruction-export surface
+
+### 2.2 Already Resolved (Pruned from A3 Implementation)
+
+| Item | Resolution Status | Evidence | Resolved By |
+|---|---|---|---|
+| `#20 (G-8)` `query --health` ignores `--quiet` | Resolved | `query_command()` uses `OutputHandler(quiet=options.quiet)` and renders health via `output.plain(...)` | Track B-era query command refactor (merged baseline) |
+| `#52 (G-10)` hidden `agent-export` alias should warn or remove | Resolved | Hidden alias still exists but emits explicit deprecation warning on invocation | Track B CLI consolidation pass (merged baseline) |
+
+### 2.3 Partially Resolved (Residual Scope Included Above)
+
+| Item | Partial Resolution in Merged Tracks | Residual Work in A3 |
+|---|---|---|
+| `#3` | `link-check` / `rename` added JSON outputs; some commands emit structured JSON | unify all command JSON under one envelope and eliminate mixed text/JSON behavior |
+| `#19` | `maintain` statuses constrained to literal values in A2 | align `doctor` status taxonomy and cross-command vocabulary |
+| `#21` | deprecation warnings added for legacy aliases | finish command-surface consolidation and add `export --all` |
+| `#39` | `consolidate` now handles commit failures in A2 | add explicit commit error handling in `scaffold` / `promote` / `verify` / `stub` |
+
+### 2.4 Out of Scope
+
+- All Track A4 items (`#4`, `#5`, `#22`, `#23`, `#30`, `#31`, `#32`, `#53`, `#54`, `#55`, `#56`, `#57`, `#59`)
+- Feature work unrelated to A3 command surface (no new diagnostics/features beyond `#62`)
+- Any behavior changes in Track B core algorithms (`scan_scope`, `body_refs`, `link_diagnostics`, `rename` rewrite engine)
+
+## 3. Dependencies
+
+Prerequisites are complete and merged:
+
+- Track A1 (core contracts and loader/graph normalization)
+- Track B (new commands `link-check`, `rename`, shared scan scope)
+- Track A2 (runtime root resolution, maintain task typing, command safety fixes)
+
+New A3 constraints from merged work:
+
+1. A3 must include Track B commands in all command-surface rules (`link-check`, `rename`).
+2. A3 must preserve A2 path-resolution behavior and not reintroduce `Path.cwd()` anchoring.
+3. A3 must keep `TaskStatus` contract from A2 while aligning vocabulary at UI boundary.
+
+## 4. Technical Design
+
+## Group 1: CLI Contract Core (`#3`, `#6`, `#24`, `#35`, `#58`)
+
+### Purpose
+
+Create one command-surface contract for return types, JSON schema, and error routing.
+
+### Files
+
+- Create: `ontos/core/errors.py`
+- Modify: `ontos/ui/json_output.py`
+- Modify: `ontos/cli.py`
+- Modify (output contract): `ontos/commands/doctor.py`, `ontos/commands/init.py`, `ontos/commands/log.py`, `ontos/commands/query.py`, `ontos/commands/env.py`, `ontos/commands/promote.py`, `ontos/commands/consolidate.py`, `ontos/commands/verify.py`, `ontos/commands/scaffold.py`, `ontos/commands/stub.py`, `ontos/commands/migrate.py`, `ontos/commands/export_data.py`, `ontos/commands/migration_report.py`, `ontos/commands/agents.py`, `ontos/commands/export_claude.py`, `ontos/commands/link_check.py`, `ontos/commands/rename.py`
+
+### Design
+
+1. **Unified command return contract (`#35`)**
+- Public command entrypoints (`*_command(options)`) must return `int` exit code only.
+- Remove tuple-return public signatures from commands currently returning `(exit_code, message)` or `(exit_code, payload)`.
+- If a command needs structured intermediate data for tests, keep an internal helper (`_run_*`) returning structured data, but CLI-facing function returns `int`.
+
+2. **Unified JSON envelope (`#3`)**
+- Add shared helpers in `ontos/ui/json_output.py`:
+  - `emit_command_success(command, exit_code, message, data=None, warnings=None)`
+  - `emit_command_error(command, exit_code, code, message, details=None, data=None)`
+- Required schema for every `--json` command response:
+```json
+{
+  "schema_version": "3.3",
+  "command": "query",
+  "status": "success",
+  "exit_code": 0,
+  "message": "Query complete",
+  "data": {},
+  "warnings": [],
+  "error": null
+}
+```
+- Error payload:
+```json
+{
+  "schema_version": "3.3",
+  "command": "query",
+  "status": "error",
+  "exit_code": 2,
+  "message": "Unknown task(s): foo",
+  "data": {},
+  "warnings": [],
+  "error": {
+    "code": "E_USER_INPUT",
+    "details": "Valid tasks: ..."
+  }
+}
+```
+- Existing command-specific JSON content must be nested under `data` and not printed as raw top-level JSON blobs.
+
+3. **No-command exit (`#6`)**
+- In `cli.main()`, when no command is provided:
+  - print help in human mode
+  - emit `E_NO_COMMAND` envelope in JSON mode
+  - return exit code `2` (usage error), not `0`.
+
+4. **Error taxonomy (`#24`)**
+- Define `OntosUserError` and `OntosInternalError` in `ontos/core/errors.py`.
+- `cli.main()` exception routing:
+  - `OntosUserError` -> clean user message, exit `2`, JSON `E_USER_INPUT`
+  - unexpected exception -> generic internal message, exit `5`, JSON `E_INTERNAL`
+- Do not dump raw tracebacks by default.
+
+5. **OutputHandler bypass removal (`#58`)**
+- `doctor`, `init`, and `log` must use `OutputHandler` for human output.
+- Direct `print()` is allowed only for interactive prompts (`input(...)` prompt text) or final JSON string emission helpers.
+
+Developer test: **Yes**. No unresolved design choices remain for this group.
+
+## Group 2: Flag Semantics and Help Consistency (`#2`, `#7`, `#16`, `#17`, `#18`)
+
+### Purpose
+
+Make command flags predictable and self-consistent without breaking successful workflows.
+
+### Files
+
+- Modify: `ontos/cli.py`
+- Modify: `ontos/commands/scaffold.py`
+- Modify: `ontos/commands/log.py`
+- Modify: `ontos/commands/consolidate.py`
+- Modify: `ontos/commands/promote.py`
+
+### Design
+
+1. **Short-flag consistency (`#2`)**
+- Reserve `-f` for `--force` only.
+- `map --filter`: move short flag from `-f` to `-F`.
+- `env --format`: remove `-f` short flag (long-only).
+- Compatibility window:
+  - keep legacy parsing for old short flags for v3.3 only
+  - emit deprecation warning when old short flags are used
+  - remove legacy aliases in v3.4.
+
+2. **Scaffold dry-run/apply conflict (`#7`)**
+- In CLI parser, make `--apply` and `--dry-run` mutually exclusive for `scaffold`.
+- Default remains dry-run when neither flag is provided.
+- Handler mapping:
+  - `--apply` -> `apply=True`, `dry_run=False`
+  - `--dry-run` or default -> `apply=False`, `dry_run=True`
+
+3. **Dry-run UX consistency (`#16`)**
+- Standardize help text for mutating commands:
+  - default dry-run commands: explicit “Dry-run by default. Use --apply to write.”
+  - default live commands: explicit “Runs live by default. Use --dry-run for preview.”
+- Do not silently ignore conflicting flags.
+- No default-mode flips in A3 except `scaffold` conflict bug fix above.
+
+4. **Map help correction (`#17`)**
+- Update `map --obsidian` help text: remove “tags” claim; keep wikilink behavior only.
+
+5. **Confirmation skip consistency (`#18`)**
+- Introduce canonical `--yes` alias where command confirms interactively:
+  - `log`: `--yes` alias for current `--auto`
+  - `consolidate`: `--yes` alias for current “process without prompting” mode
+  - `promote`: add `--yes` to auto-confirm interactive prompts; keep `--all-ready` unchanged
+- Keep existing flags for backward compatibility in v3.3.
+
+Developer test: **Yes**. Command-by-command behavior is explicit and complete.
+
+## Group 3: Command Taxonomy and Instruction Export Surface (`#21`, `#34`, `#62`)
+
+### Purpose
+
+Unify instruction-file generation surface and remove command-to-command import coupling.
+
+### Files
+
+- Create: `ontos/core/instruction_artifacts.py`
+- Modify: `ontos/commands/agents.py`
+- Modify: `ontos/commands/export_claude.py`
+- Modify: `ontos/commands/claude_template.py`
+- Modify: `ontos/commands/export.py` (legacy wrapper behavior only)
+- Modify: `ontos/commands/instruction_protocol.py` (shared marker utilities remain here)
+- Modify: `ontos/cli.py`
+
+### Design
+
+1. **Remove cross-command import chain (`#34`)**
+- Move shared instruction generation logic to `ontos/core/instruction_artifacts.py`.
+- Commands must import shared core module, not each other.
+- End state:
+  - `agents.py` and `export_claude.py` depend on core instruction service.
+  - No command imports another command for generation logic.
+
+2. **Consolidate command surface (`#21`)**
+- Keep both user-facing entry points for v3.3:
+  - `ontos agents`
+  - `ontos export claude`
+- Make both delegate to same shared generation service with consistent output/error semantics.
+- Keep hidden alias `agent-export` (already warning) as compatibility-only alias.
+
+3. **Add `ontos export --all` (`#62`)**
+- Add top-level `--all` flag under `export` root command (not a new top-level command):
+  - Generates `AGENTS.md`, `.cursorrules`, and `CLAUDE.md` in one operation.
+- Semantics:
+  - respects `--force`
+  - returns non-zero if any output fails
+  - reports per-artifact results in human and JSON modes
+- If `export --all` is used, subcommand argument is optional and ignored.
+
+Developer test: **Yes**. Consolidation behavior and ownership boundaries are unambiguous.
+
+## Group 4: Safety and Validation Hardening (`#39`, `#43`, `#46`, `#47`, `#50`)
+
+### Purpose
+
+Close remaining silent-failure and validation gaps in mutating commands.
+
+### Files
+
+- Modify: `ontos/commands/promote.py`
+- Modify: `ontos/commands/scaffold.py`
+- Modify: `ontos/commands/verify.py`
+- Modify: `ontos/commands/stub.py`
+- Modify: `ontos/commands/maintain.py`
+- Modify: `ontos/commands/map.py`
+- Modify: `ontos/commands/log.py`
+
+### Design
+
+1. **Commit exception handling (`#39`)**
+- Wrap every `ctx.commit()` call in `promote`, `scaffold`, `verify`, and `stub`.
+- On commit failure:
+  - emit command-specific error message with file/action context
+  - return non-zero (`1` for operation failure)
+  - do not fall through to generic CLI catch-all.
+
+2. **Remove unused dry-run fields (`#43`)**
+- Remove `GenerateMapOptions.dry_run`.
+- Remove `EndSessionOptions.dry_run`.
+- Remove dead assignments/call paths relying on those fields.
+
+3. **Stub input validation (`#46`)**
+- Validate non-interactive `stub` input before `create_stub(...)`:
+  - `id` must match same ID regex used by `rename`
+  - `doc_type` must be valid Ontos document type
+  - `depends_on` tokens must be non-empty normalized strings
+- Invalid input returns usage error (`exit 2`) with actionable message.
+
+4. **Scaffold silent-failure hardening (`#47`)**
+- Replace broad bare `except Exception: continue/False` with explicit error collection.
+- `find_untagged_files` and `scaffold_file` must surface per-path failures (permission, decode, invalid path).
+- In non-JSON mode: summarize failed files at end.
+- In JSON mode: include failed path list under `data.failures`.
+
+5. **Maintain unknown skip is error (`#50`)**
+- If `--skip` contains unknown task names:
+  - do not run tasks
+  - return usage error exit code `2`
+  - include known task names in message (and JSON `error.details`).
+
+Developer test: **Yes**. Each failure path has deterministic exit and message behavior.
+
+## Group 5: Health Correctness and Status Taxonomy (`#19`, `#49`)
+
+### Purpose
+
+Align user-visible status words and ensure health metrics include cycle detection.
+
+### Files
+
+- Modify: `ontos/commands/query.py`
+- Modify: `ontos/core/graph.py` (if needed for export shape only; no algorithm change)
+- Modify: `ontos/commands/doctor.py`
+- Modify: `ontos/commands/maintain.py` (UI mapping only; keep A2 `TaskStatus`)
+
+### Design
+
+1. **Cycle detection in `query --health` (`#49`)**
+- Extend `query_health()` to call `detect_cycles(graph)`.
+- Add fields to health payload:
+  - `cycles` (count)
+  - `cycle_samples` (list of cycle paths, capped to first 10)
+- Human formatter includes cycle count and samples when non-zero.
+- JSON output includes these fields under `data`.
+
+2. **Status vocabulary alignment (`#19`)**
+- Canonical status vocabulary for CLI outputs:
+  - `success`, `failed`, `warning`, `skipped`
+- `doctor` per-check statuses change:
+  - `pass -> success`
+  - `fail -> failed`
+  - `warn -> warning`
+- `maintain` remains `success|failed|skipped` (already A2-compliant).
+- JSON output across commands must only use canonical vocabulary.
+
+Developer test: **Yes**. Status mapping and query-health payload are fully specified.
+
+## 5. Test Strategy
+
+## 5.1 Group 1 Tests (Contract + JSON + Error Routing)
+
+- `tests/ui/test_json_output.py`
+  - new envelope helper tests (success/error shape, required keys)
+- `tests/test_cli.py`
+  - no-command returns `2`
+  - `OntosUserError` path returns `2`, `E_USER_INPUT`
+  - generic exception path returns `5`, `E_INTERNAL`
+- New: `tests/commands/test_json_contract_a3.py`
+  - parameterized commands in `--json` mode all include envelope keys
+  - no mixed plain text with JSON
+- Update: `tests/commands/test_doctor_phase4.py`, `tests/test_end_session.py`, `tests/test_env_cli.py`, `tests/commands/test_query_parity.py`
+
+## 5.2 Group 2 Tests (Flags/Help)
+
+- `tests/test_cli.py`
+  - `map -F` works
+  - deprecated short-flag warnings for legacy `-f` cases
+  - scaffold `--apply` + `--dry-run` rejected
+- `tests/commands/test_scaffold_parity.py`
+  - default dry-run remains true
+- `tests/commands/golden/*help.txt`
+  - update expected help text for `map`, `scaffold`, `log`, `consolidate`, `promote`
+
+## 5.3 Group 3 Tests (Taxonomy + Export All)
+
+- `tests/commands/test_agents.py`
+  - shared backend output parity for agents/cursor generation
+- `tests/commands/test_export_phase4.py`
+  - `export claude` still works via shared backend
+- New: `tests/commands/test_export_all.py`
+  - `export --all` generates AGENTS.md, .cursorrules, CLAUDE.md
+  - partial failure returns non-zero with per-file diagnostics
+- `tests/test_cli.py`
+  - `agent-export` still hidden and warns
+
+## 5.4 Group 4 Tests (Safety/Validation)
+
+- `tests/commands/test_promote_parity.py`, `tests/commands/test_verify_parity.py`, `tests/commands/test_scaffold_parity.py`, `tests/commands/test_stub_parity.py`
+  - `ctx.commit()` exception paths return deterministic non-zero and error output
+- `tests/commands/test_stub_parity.py`
+  - invalid `--id` / `--type` rejected (`exit 2`)
+- `tests/commands/test_scaffold_parity.py`
+  - permission/path errors surfaced in summary/JSON
+- `tests/commands/test_maintain.py`
+  - unknown skip returns `2` and no tasks execute
+- `tests/commands/test_map.py`, `tests/test_end_session.py`
+  - removal of dead dry_run fields does not regress behavior
+
+## 5.5 Group 5 Tests (Health/Taxonomy)
+
+- `tests/commands/test_query_parity.py` and `tests/commands/golden/query_health.txt`
+  - cycle count and sample display
+- `tests/test_cycle_detection.py`
+  - query health JSON includes cycle fields
+- `tests/commands/test_doctor_phase4.py`
+  - status vocabulary changed to `success|failed|warning`
+
+## 5.6 Full Regression
+
+- Run full suite: `pytest -q tests/`
+- Golden refresh only where expected by intentional surface changes.
+
+## 6. Migration / Compatibility
+
+User-visible changes:
+
+1. `ontos` with no command now exits `2` (usage error).
+2. JSON outputs gain required envelope fields (`schema_version`, `command`, `status`, `exit_code`, `message`, `data`, `warnings`, `error`).
+3. `doctor` status words change (`pass/fail/warn` -> `success/failed/warning`).
+4. `maintain --skip unknown` now fails fast (`exit 2`) instead of warning-and-continue.
+5. `map` short flag for filter changes (`-f` -> `-F`), and `env -f` format shorthand is deprecated/removed.
+6. `scaffold --apply --dry-run` now explicit conflict (parser error).
+7. New `export --all` behavior for instruction artifact generation.
+
+Compatibility policy for v3.3:
+
+- Legacy short flags and deprecated aliases remain accepted when feasible but emit warnings.
+- JSON schema changes are additive at top-level but still considered a contract change for strict parsers.
+- Command function Python API return signatures normalize to `int`; internal helper APIs can be retained for tests.
+
+## 7. Risk Assessment
+
+| Item Group | Risk | Why | Mitigation |
+|---|---|---|---|
+| Group 1 (`#3/#6/#24/#35/#58`) | High | touches nearly all command surface and JSON scripting contracts | land in small commits; add command-by-command JSON contract tests first |
+| Group 2 (`#2/#7/#16/#17/#18`) | Medium | flag behavior/help changes can surprise users | keep compatibility aliases + explicit deprecation warnings |
+| Group 3 (`#21/#34/#62`) | Medium | taxonomy changes and new export orchestration path | shared backend + integration tests for all command entry points |
+| Group 4 (`#39/#43/#46/#47/#50`) | Medium | failure-path semantics and validation changes may affect automation | deterministic exit-code tests for every negative path |
+| Group 5 (`#19/#49`) | Low-Medium | output wording and query-health payload changes | golden updates + explicit cycle fixtures |
+
+## 8. Implementation Order
+
+1. Group 1 contract foundation (`cli.py`, `json_output.py`, error classes).
+2. Group 4 safety fixes (commit handling + validation hardening).
+3. Group 2 flag/help consistency.
+4. Group 5 health/taxonomy alignment.
+5. Group 3 instruction command consolidation + `export --all`.
+6. Final pass: full regression + golden refresh + compatibility warnings audit.
+


### PR DESCRIPTION
## Summary
- Add `v3.3_Track_A3_Implementation_Spec.md` for Track A3
- Verify A3 items against current post-A1/B/A2 codebase
- Prune resolved items and define implementation scope, design groups, tests, compatibility, and risk

## Notes
- Includes only the A3 spec file in this PR
- Leaves local `Ontos_Context_Map.md` workspace change out of scope
