### PR TITLE
v3.3 Track A4b: Tests, dead code & deferred items

### DIFF
--- a/.ontos.toml
+++ b/.ontos.toml
@@ -13,11 +13,8 @@ skip_patterns = ["_template.md", "archive/*"]
 [validation]
 max_dependency_depth = 5
 allowed_orphan_types = ["atom"]
-strict = false
 
 [workflow]
-enforce_archive_before_push = true
-require_source_in_logs = true
 log_retention_count = 20
 
 [hooks]

--- a/ontos/commands/__init__.py
+++ b/ontos/commands/__init__.py
@@ -69,7 +69,6 @@ from ontos.commands.export import (
 from ontos.commands.verify import (
     verify_command,
     VerifyOptions,
-    verify_document,
     find_stale_documents_list,
 )
 

--- a/ontos/commands/hook.py
+++ b/ontos/commands/hook.py
@@ -13,7 +13,11 @@ This is a deliberate safety choice:
 - Prefer allowing potentially invalid state over blocking legitimate work
 - Warnings are printed to stderr for visibility
 
-To enable blocking behavior, set strict mode in .ontos.toml (future feature).
+To enable blocking behavior, set strict mode in .ontos.toml.
+
+JSON OUTPUT: hook is a hidden/internal command (HIDDEN_COMMANDS in cli.py)
+and intentionally does not support --json output. It communicates via
+exit codes and stderr only.
 """
 
 import sys

--- a/ontos/core/config.py
+++ b/ontos/core/config.py
@@ -62,14 +62,11 @@ class ValidationConfig:
     """[validation] section."""
     max_dependency_depth: int = 5
     allowed_orphan_types: List[str] = field(default_factory=lambda: ["atom"])
-    strict: bool = False
 
 
 @dataclass
 class WorkflowConfig:
     """[workflow] section."""
-    enforce_archive_before_push: bool = True
-    require_source_in_logs: bool = True
     log_retention_count: int = 20  # Required by Roadmap
 
 
@@ -115,9 +112,6 @@ def _validate_types(data: dict) -> None:
     """Validate types in config data before dataclass instantiation."""
     type_requirements = {
         ("validation", "max_dependency_depth"): int,
-        ("validation", "strict"): bool,
-        ("workflow", "enforce_archive_before_push"): bool,
-        ("workflow", "require_source_in_logs"): bool,
         ("workflow", "log_retention_count"): int,
         ("hooks", "pre_push"): bool,
         ("hooks", "pre_commit"): bool,

--- a/ontos/core/frontmatter.py
+++ b/ontos/core/frontmatter.py
@@ -272,10 +272,10 @@ def normalize_status(value, on_error: Optional[Callable[[str, Any, List[str]], N
 
 def load_common_concepts(docs_dir: str = None) -> set:
     """Load known concepts from Common_Concepts.md if it exists.
-    
+
     Args:
         docs_dir: Documentation directory to search.
-    
+
     Returns:
         Set of known concept strings.
     """
@@ -285,22 +285,22 @@ def load_common_concepts(docs_dir: str = None) -> set:
             docs_dir = DOCS_DIR
         except ImportError:
             docs_dir = 'docs'
-    
+
     possible_paths = [
         os.path.join(docs_dir, 'reference', 'Common_Concepts.md'),
         os.path.join(docs_dir, 'Common_Concepts.md'),
         'docs/reference/Common_Concepts.md',
     ]
-    
+
     concepts_file = None
     for path in possible_paths:
         if os.path.exists(path):
             concepts_file = path
             break
-            
+
     if not concepts_file:
         return set()
-    
+
     concepts = set()
     try:
         with open(concepts_file, 'r', encoding='utf-8') as f:
@@ -309,7 +309,7 @@ def load_common_concepts(docs_dir: str = None) -> set:
         concepts.update(matches)
     except (IOError, OSError):
         pass
-    
+
     return concepts
 
 

--- a/ontos/core/suggestions.py
+++ b/ontos/core/suggestions.py
@@ -149,26 +149,6 @@ def validate_concepts(
     return valid, unknown
 
 
-def extract_doc_ids_from_text(text: str, valid_ids: Set[str]) -> List[str]:
-    """Extract document IDs mentioned in text.
-
-    Args:
-        text: Text to search (e.g., commit message, log content)
-        valid_ids: Set of valid document IDs to match against
-
-    Returns:
-        List of matches found in text
-    """
-    found = []
-    text_lower = text.lower()
-    
-    for doc_id in valid_ids:
-        if doc_id.lower() in text_lower:
-            found.append(doc_id)
-    
-    return found
-
-
 def suggest_candidates_for_broken_ref(
     broken_ref: str,
     all_docs: Dict[str, DocumentData],

--- a/tests/commands/test_json_contract_a3.py
+++ b/tests/commands/test_json_contract_a3.py
@@ -48,14 +48,25 @@ def test_json_envelope_keys_for_multiple_commands(tmp_path: Path) -> None:
     _init_project(tmp_path)
 
     command_sets = [
+        # Original A3 commands
         ("--json", "query", "--list-ids"),
         ("--json", "doctor"),
         ("--json", "export", "data"),
+        # A4 expansion
+        ("--json", "init", "--yes"),
+        ("--json", "agents"),
+        ("--json", "stub", "--goal", "test stub", "--type", "atom"),
+        ("--json", "scaffold"),
+        ("--json", "maintain", "--dry-run"),
+        ("--json", "rename", "sample", "sample_new"),
     ]
 
     for command in command_sets:
         result = _run_ontos(tmp_path, *command)
         assert result.stdout, f"missing stdout for command: {' '.join(command)}"
         payload = json.loads(result.stdout)
-        assert REQUIRED_KEYS.issubset(payload.keys()), payload
+        assert REQUIRED_KEYS.issubset(payload.keys()), (
+            f"Command {' '.join(command)} missing keys: "
+            f"{REQUIRED_KEYS - set(payload.keys())}"
+        )
 

--- a/tests/commands/test_log.py
+++ b/tests/commands/test_log.py
@@ -1,0 +1,131 @@
+"""Tests for the log command: creation, flags, JSON output, and return types."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from ontos.commands.log import (
+    EndSessionOptions,
+    LogOptions,
+    create_session_log,
+    log_command,
+)
+
+
+def _init_git_project(tmp_path: Path) -> None:
+    """Create a minimal git+ontos project for log tests."""
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".ontos.toml").write_text(
+        "[ontos]\nversion = '3.0'\n", encoding="utf-8"
+    )
+    docs_logs = tmp_path / "docs" / "logs"
+    docs_logs.mkdir(parents=True)
+
+
+def _run_ontos(tmp_path: Path, *args: str) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    project_root = Path(__file__).resolve().parents[2]
+    env["PYTHONPATH"] = str(project_root)
+    return subprocess.run(
+        [sys.executable, "-m", "ontos", *args],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+# ---------------------------------------------------------------------------
+# create_session_log (unit)
+# ---------------------------------------------------------------------------
+
+class TestCreateSessionLog:
+    def test_basic_creation(self, tmp_path):
+        """create_session_log returns content and path."""
+        _init_git_project(tmp_path)
+        options = EndSessionOptions(event_type="chore", topic="test session")
+        git_info = {"branch": "main", "commits": [], "changed_files": []}
+        content, path = create_session_log(tmp_path, options, git_info)
+        assert "id:" in content
+        assert "type: log" in content
+        assert path.suffix == ".md"
+
+    def test_topic_appears_in_filename(self, tmp_path):
+        _init_git_project(tmp_path)
+        options = EndSessionOptions(topic="my-special-topic")
+        git_info = {"branch": "main", "commits": [], "changed_files": []}
+        _, path = create_session_log(tmp_path, options, git_info)
+        assert "my-special-topic" in path.name
+
+    def test_event_type_in_frontmatter(self, tmp_path):
+        _init_git_project(tmp_path)
+        options = EndSessionOptions(event_type="feature", topic="feat")
+        git_info = {"branch": "main", "commits": [], "changed_files": []}
+        content, _ = create_session_log(tmp_path, options, git_info)
+        assert "event_type: feature" in content
+
+
+# ---------------------------------------------------------------------------
+# log_command (integration via subprocess)
+# ---------------------------------------------------------------------------
+
+class TestLogCommandCLI:
+    def test_auto_flag_creates_log(self, tmp_path):
+        """--auto flag skips prompts and creates a log."""
+        _init_git_project(tmp_path)
+        # Initialize a real git repo so git commands work
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "--allow-empty", "-m", "init"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+        result = _run_ontos(tmp_path, "log", "--auto")
+        assert result.returncode == 0
+
+    def test_json_output_has_envelope_keys(self, tmp_path):
+        """--json output conforms to v3.3 envelope schema."""
+        _init_git_project(tmp_path)
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "--allow-empty", "-m", "init"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+        result = _run_ontos(tmp_path, "--json", "log", "--auto")
+        assert result.stdout, "expected JSON output on stdout"
+        payload = json.loads(result.stdout)
+        required = {
+            "schema_version", "command", "status", "exit_code",
+            "message", "data", "warnings", "error",
+        }
+        assert required.issubset(payload.keys()), f"Missing keys: {required - set(payload.keys())}"
+
+    def test_return_type_is_int(self, tmp_path, monkeypatch):
+        """log_command should return an int exit code."""
+        _init_git_project(tmp_path)
+        subprocess.run(["git", "init"], cwd=tmp_path, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "--allow-empty", "-m", "init"],
+            cwd=tmp_path,
+            capture_output=True,
+        )
+        monkeypatch.chdir(tmp_path)
+        options = LogOptions(auto=True, quiet=True)
+        result = log_command(options)
+        assert isinstance(result, int)
+        assert result == 0
+
+    def test_not_in_git_repo_returns_error(self, tmp_path, monkeypatch):
+        """log_command returns 1 when not in a git repository."""
+        monkeypatch.chdir(tmp_path)
+        # No .git dir — should fail
+        options = LogOptions(auto=True, quiet=True)
+        result = log_command(options)
+        assert result == 1

--- a/tests/core/test_config_phase3.py
+++ b/tests/core/test_config_phase3.py
@@ -82,14 +82,12 @@ class TestValidateTypes:
     def test_validate_types_rejects_string_for_bool(self):
         """Type validation rejects string for bool with ConfigError."""
         with pytest.raises(ConfigError, match="must be bool"):
-            _validate_types({"workflow": {"enforce_archive_before_push": "yes"}})
+            _validate_types({"hooks": {"pre_push": "yes"}})
 
     def test_validate_types_accepts_correct_types(self):
         """Type validation passes for correct types."""
         # Should not raise
         _validate_types({"workflow": {"log_retention_count": 50}})
-        _validate_types({"workflow": {"enforce_archive_before_push": True}})
-        _validate_types({"validation": {"strict": False}})
         _validate_types({"hooks": {"pre_push": True, "pre_commit": False}})
 
 
@@ -128,7 +126,6 @@ class TestDictToConfig:
             "workflow": {"log_retention_count": 50}
         })
         assert config.workflow.log_retention_count == 50
-        assert config.workflow.enforce_archive_before_push is True  # Default
 
     def test_dict_to_config_path_validation(self, tmp_path):
         """dict_to_config validates paths when repo_root provided."""

--- a/tests/core/test_graph.py
+++ b/tests/core/test_graph.py
@@ -1,0 +1,225 @@
+"""Tests for core graph primitives: build_graph, cycle detection, orphan detection, depth calculation."""
+
+from pathlib import Path
+
+import pytest
+
+from ontos.core.graph import (
+    DependencyGraph,
+    GraphNode,
+    build_graph,
+    calculate_depths,
+    detect_cycles,
+    detect_orphans,
+)
+from ontos.core.types import DocumentData, DocumentStatus, DocumentType
+
+
+def _make_doc(doc_id: str, doc_type: str = "atom", depends_on: list = None) -> DocumentData:
+    """Create a minimal DocumentData for testing."""
+    return DocumentData(
+        id=doc_id,
+        type=DocumentType(doc_type),
+        status=DocumentStatus.ACTIVE,
+        filepath=Path(f"docs/{doc_id}.md"),
+        frontmatter={"id": doc_id, "type": doc_type},
+        content="",
+        depends_on=depends_on or [],
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_graph
+# ---------------------------------------------------------------------------
+
+class TestBuildGraph:
+    def test_empty_input(self):
+        graph, errors = build_graph({})
+        assert len(graph.nodes) == 0
+        assert errors == []
+
+    def test_single_doc_no_deps(self):
+        docs = {"a": _make_doc("a")}
+        graph, errors = build_graph(docs)
+        assert "a" in graph.nodes
+        assert errors == []
+
+    def test_multiple_docs_with_edges(self):
+        docs = {
+            "a": _make_doc("a", "kernel"),
+            "b": _make_doc("b", "strategy", depends_on=["a"]),
+            "c": _make_doc("c", "atom", depends_on=["b"]),
+        }
+        graph, errors = build_graph(docs)
+        assert len(graph.nodes) == 3
+        assert graph.edges["b"] == ["a"]
+        assert graph.edges["c"] == ["b"]
+        assert "b" in graph.reverse_edges["a"]
+        assert errors == []
+
+    def test_broken_link_produces_error(self):
+        docs = {"a": _make_doc("a", depends_on=["nonexistent"])}
+        graph, errors = build_graph(docs)
+        assert len(errors) == 1
+        assert errors[0].error_type.value == "broken_link"
+        assert "nonexistent" in errors[0].message
+
+    def test_self_reference_is_not_broken_link(self):
+        """Self-references are valid edges (caught by cycle detection, not build_graph)."""
+        docs = {"a": _make_doc("a", depends_on=["a"])}
+        graph, errors = build_graph(docs)
+        assert len(errors) == 0  # ID exists, so no broken link
+        # But cycle detection catches it
+        cycles = detect_cycles(graph)
+        assert len(cycles) >= 1
+
+
+# ---------------------------------------------------------------------------
+# detect_cycles
+# ---------------------------------------------------------------------------
+
+class TestDetectCycles:
+    def test_no_cycles(self):
+        docs = {
+            "a": _make_doc("a"),
+            "b": _make_doc("b", depends_on=["a"]),
+        }
+        graph, _ = build_graph(docs)
+        cycles = detect_cycles(graph)
+        assert cycles == []
+
+    def test_simple_cycle_a_b_a(self):
+        docs = {
+            "a": _make_doc("a", depends_on=["b"]),
+            "b": _make_doc("b", depends_on=["a"]),
+        }
+        graph, _ = build_graph(docs)
+        cycles = detect_cycles(graph)
+        assert len(cycles) >= 1
+        # At least one cycle should contain both a and b
+        flat = [node for cycle in cycles for node in cycle]
+        assert "a" in flat
+        assert "b" in flat
+
+    def test_complex_cycle_a_b_c_a(self):
+        docs = {
+            "a": _make_doc("a", depends_on=["b"]),
+            "b": _make_doc("b", depends_on=["c"]),
+            "c": _make_doc("c", depends_on=["a"]),
+        }
+        graph, _ = build_graph(docs)
+        cycles = detect_cycles(graph)
+        assert len(cycles) >= 1
+
+    def test_acyclic_diamond(self):
+        docs = {
+            "a": _make_doc("a"),
+            "b": _make_doc("b", depends_on=["a"]),
+            "c": _make_doc("c", depends_on=["a"]),
+            "d": _make_doc("d", depends_on=["b", "c"]),
+        }
+        graph, _ = build_graph(docs)
+        cycles = detect_cycles(graph)
+        assert cycles == []
+
+
+# ---------------------------------------------------------------------------
+# detect_orphans
+# ---------------------------------------------------------------------------
+
+class TestDetectOrphans:
+    def test_all_connected(self):
+        docs = {
+            "a": _make_doc("a", "kernel"),
+            "b": _make_doc("b", "strategy", depends_on=["a"]),
+        }
+        graph, _ = build_graph(docs)
+        orphans = detect_orphans(graph, allowed_orphan_types=set())
+        # "a" has incoming edge from "b", "b" has no incoming but both have edges
+        # Actually "b" has no incoming edges (nothing depends on b)
+        assert "b" in orphans
+
+    def test_some_orphans(self):
+        docs = {
+            "a": _make_doc("a", "kernel"),
+            "b": _make_doc("b", "strategy"),
+            "c": _make_doc("c", "atom", depends_on=["a"]),
+        }
+        graph, _ = build_graph(docs)
+        orphans = detect_orphans(graph, allowed_orphan_types=set())
+        # "b" and "c" have no incoming edges
+        assert "b" in orphans
+        assert "c" in orphans
+
+    def test_allowed_orphan_types_filtered(self):
+        docs = {
+            "a": _make_doc("a", "atom"),
+            "b": _make_doc("b", "kernel"),
+        }
+        graph, _ = build_graph(docs)
+        orphans = detect_orphans(graph, allowed_orphan_types={"atom"})
+        # "a" is atom (allowed orphan), "b" is kernel (not allowed)
+        assert "a" not in orphans
+        assert "b" in orphans
+
+    def test_all_orphans(self):
+        docs = {
+            "a": _make_doc("a", "kernel"),
+            "b": _make_doc("b", "strategy"),
+        }
+        graph, _ = build_graph(docs)
+        orphans = detect_orphans(graph, allowed_orphan_types=set())
+        assert set(orphans) == {"a", "b"}
+
+
+# ---------------------------------------------------------------------------
+# calculate_depths
+# ---------------------------------------------------------------------------
+
+class TestCalculateDepths:
+    def test_flat_graph(self):
+        docs = {
+            "a": _make_doc("a"),
+            "b": _make_doc("b"),
+        }
+        graph, _ = build_graph(docs)
+        depths = calculate_depths(graph)
+        assert depths["a"] == 0
+        assert depths["b"] == 0
+
+    def test_linear_chain(self):
+        docs = {
+            "a": _make_doc("a"),
+            "b": _make_doc("b", depends_on=["a"]),
+            "c": _make_doc("c", depends_on=["b"]),
+        }
+        graph, _ = build_graph(docs)
+        depths = calculate_depths(graph)
+        assert depths["a"] == 0
+        assert depths["b"] == 1
+        assert depths["c"] == 2
+
+    def test_diamond_dependency(self):
+        docs = {
+            "a": _make_doc("a"),
+            "b": _make_doc("b", depends_on=["a"]),
+            "c": _make_doc("c", depends_on=["a"]),
+            "d": _make_doc("d", depends_on=["b", "c"]),
+        }
+        graph, _ = build_graph(docs)
+        depths = calculate_depths(graph)
+        assert depths["a"] == 0
+        assert depths["b"] == 1
+        assert depths["c"] == 1
+        assert depths["d"] == 2
+
+    def test_cyclic_nodes_depth_zero(self):
+        docs = {
+            "a": _make_doc("a", depends_on=["b"]),
+            "b": _make_doc("b", depends_on=["a"]),
+        }
+        graph, _ = build_graph(docs)
+        depths = calculate_depths(graph)
+        # Cyclic nodes are treated as depth 0 to prevent infinite recursion
+        assert depths["a"] >= 0
+        assert depths["b"] >= 0

--- a/tests/core/test_schema.py
+++ b/tests/core/test_schema.py
@@ -1,0 +1,160 @@
+"""Tests for schema version detection, validation, compatibility, and serialization."""
+
+import pytest
+
+from ontos.core.schema import (
+    SchemaCheckResult,
+    SchemaCompatibility,
+    check_compatibility,
+    detect_schema_version,
+    parse_version,
+    serialize_frontmatter,
+    validate_frontmatter,
+)
+
+
+# ---------------------------------------------------------------------------
+# parse_version
+# ---------------------------------------------------------------------------
+
+class TestParseVersion:
+    def test_valid_versions(self):
+        assert parse_version("2.1") == (2, 1)
+        assert parse_version("3.0") == (3, 0)
+        assert parse_version("1.0") == (1, 0)
+
+    def test_whitespace_stripped(self):
+        assert parse_version("  2.1 ") == (2, 1)
+
+    def test_invalid_format_raises(self):
+        with pytest.raises(ValueError):
+            parse_version("2")
+        with pytest.raises(ValueError):
+            parse_version("2.1.3")
+        with pytest.raises(ValueError):
+            parse_version("")
+
+    def test_non_integer_raises(self):
+        with pytest.raises(ValueError):
+            parse_version("a.b")
+
+    def test_negative_raises(self):
+        with pytest.raises(ValueError):
+            parse_version("-1.0")
+
+
+# ---------------------------------------------------------------------------
+# detect_schema_version
+# ---------------------------------------------------------------------------
+
+class TestDetectSchemaVersion:
+    def test_explicit_ontos_schema(self):
+        assert detect_schema_version({"id": "x", "ontos_schema": "2.2"}) == "2.2"
+
+    def test_infers_v3_from_implements(self):
+        assert detect_schema_version({"id": "x", "implements": ["y"]}) == "3.0"
+
+    def test_infers_v22_from_curation_level(self):
+        assert detect_schema_version({"id": "x", "curation_level": 1}) == "2.2"
+
+    def test_infers_v21_from_describes(self):
+        assert detect_schema_version({"id": "x", "describes": ["y"]}) == "2.1"
+
+    def test_infers_v20_from_type(self):
+        assert detect_schema_version({"id": "x", "type": "atom"}) == "2.0"
+
+    def test_default_v10(self):
+        assert detect_schema_version({"id": "x"}) == "1.0"
+
+    def test_empty_frontmatter(self):
+        assert detect_schema_version({}) == "1.0"
+        assert detect_schema_version(None) == "1.0"
+
+
+# ---------------------------------------------------------------------------
+# check_compatibility
+# ---------------------------------------------------------------------------
+
+class TestCheckCompatibility:
+    def test_compatible(self):
+        result = check_compatibility("2.1", "2.9.0")
+        assert result.compatibility == SchemaCompatibility.COMPATIBLE
+
+    def test_read_only_future_minor(self):
+        result = check_compatibility("2.9", "2.1")
+        assert result.compatibility == SchemaCompatibility.READ_ONLY
+
+    def test_incompatible_future_major(self):
+        result = check_compatibility("3.0", "2.9.0")
+        assert result.compatibility == SchemaCompatibility.INCOMPATIBLE
+
+    def test_invalid_doc_version(self):
+        result = check_compatibility("bad", "2.9.0")
+        assert result.compatibility == SchemaCompatibility.INCOMPATIBLE
+
+
+# ---------------------------------------------------------------------------
+# validate_frontmatter
+# ---------------------------------------------------------------------------
+
+class TestValidateFrontmatter:
+    def test_valid_v20(self):
+        valid, errors = validate_frontmatter({"id": "test", "type": "atom"}, "2.0")
+        assert valid is True
+        assert errors == []
+
+    def test_missing_required_field(self):
+        valid, errors = validate_frontmatter({"type": "atom"}, "2.0")
+        assert valid is False
+        assert any("id" in e for e in errors)
+
+    def test_empty_required_field(self):
+        valid, errors = validate_frontmatter({"id": "", "type": "atom"}, "2.0")
+        assert valid is False
+
+    def test_unknown_schema_passes(self):
+        valid, errors = validate_frontmatter({"id": "test"}, "99.0")
+        assert valid is True
+
+
+# ---------------------------------------------------------------------------
+# serialize_frontmatter
+# ---------------------------------------------------------------------------
+
+class TestSerializeFrontmatter:
+    def test_basic_roundtrip(self):
+        fm = {"id": "test", "type": "atom", "status": "active"}
+        result = serialize_frontmatter(fm)
+        assert "id: test" in result
+        assert "type: atom" in result
+        assert "status: active" in result
+
+    def test_list_serialization(self):
+        fm = {"id": "test", "depends_on": ["a", "b"]}
+        result = serialize_frontmatter(fm)
+        assert "depends_on: [a, b]" in result
+
+    def test_empty_list(self):
+        fm = {"id": "test", "depends_on": []}
+        result = serialize_frontmatter(fm)
+        assert "depends_on: []" in result
+
+    def test_field_ordering(self):
+        fm = {"depends_on": [], "type": "atom", "id": "test", "status": "active"}
+        result = serialize_frontmatter(fm)
+        lines = result.strip().split("\n")
+        # id should come before type which comes before status
+        id_idx = next(i for i, l in enumerate(lines) if l.startswith("id:"))
+        type_idx = next(i for i, l in enumerate(lines) if l.startswith("type:"))
+        status_idx = next(i for i, l in enumerate(lines) if l.startswith("status:"))
+        assert id_idx < type_idx < status_idx
+
+    def test_unicode_values(self):
+        fm = {"id": "test", "type": "atom"}
+        result = serialize_frontmatter(fm)
+        assert isinstance(result, str)
+
+    def test_null_value(self):
+        fm = {"id": "test", "extra": None}
+        result = serialize_frontmatter(fm)
+        assert "extra: null" in result


### PR DESCRIPTION
## Summary

### Dead Code Removal (Commit 1)
- **#54 (CC-12):** Remove `extract_doc_ids_from_text()` from `suggestions.py`
- **#57 (CC-15):** Remove dead config options: `validation.strict`, `enforce_archive_before_push`, `require_source_in_logs` (from dataclass, type map, `.ontos.toml`, and tests)
- **#59 (CC-20):** Remove dead `verify_document` export from `commands/__init__.py`

**Skipped items (with justification):**
- #53 (CC-10): `load_common_concepts` in `frontmatter.py` has live callers in legacy scripts (`.ontos/scripts/`)
- #55 (CC-13): `parse_frontmatter_yaml()` already removed — does not exist in `io/yaml.py`
- #56 (CC-14): `DocumentCache` is actively used by `map.py` and `files.py`
- #57 partial: `hooks.strict` is active (used in `hook.py`)

### Test Coverage (Commit 2)
- **#30 (C-18):** `tests/core/test_graph.py` — 17 tests for `build_graph`, `detect_cycles`, `detect_orphans`, `calculate_depths`
- **#31 (C-19):** `tests/core/test_schema.py` — 26 tests for `parse_version`, `detect_schema_version`, `check_compatibility`, `validate_frontmatter`, `serialize_frontmatter`
- **#32 (C-20):** `tests/commands/test_log.py` — 7 tests for `create_session_log`, CLI integration, JSON envelope, error paths

### Deferred Items (Commit 3)
- **NB-1:** Convert `rename.py` ad-hoc `json.dumps()` to v3.3 envelope format using `emit_command_success`/`emit_command_error`. Updated existing rename tests.
- **NB-2:** Document `hook` command's intentional JSON exclusion (hidden/internal command)
- **NB-3:** Expand `test_json_contract_a3.py` from 3 → 9 commands (added: `init`, `agents`, `stub`, `scaffold`, `maintain`, `rename`). `link-check` excluded — uses non-envelope JSON format.

## Test Results

```
845 passed, 2 skipped (+50 from 795 baseline)
```

## Test plan

- [ ] Grep verification for all removed dead code
- [ ] All 50 new tests pass independently
- [ ] Rename JSON now conforms to v3.3 envelope (9 commands verified)
- [ ] Full test suite passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)