### PR TITLE
docs: add dedicated MCP Setup section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ The server runs over stdio — your IDE manages the process lifecycle.
 > ```bash
 > which ontos   # Find the path, e.g. /Users/you/.local/bin/ontos
 > ```
-> Then set `"command": "/Users/you/.local/bin/ontos"` in the config above. Alternatively, use `"command": "python3"` with `"args": ["-m", "ontos", "serve"]`.
+> Then set `"command": "/Users/you/.local/bin/ontos"` in the config above. Alternatively, use `"command": "python"` with `"args": ["-m", "ontos", "serve"]`.
 
 **Cursor** (`.cursor/mcp.json` in your project):
 ```json
@@ -283,6 +283,9 @@ The server runs over stdio — your IDE manages the process lifecycle.
 }
 ```
 
+> [!NOTE]
+> Cursor launches the MCP server from your project root by default. If your project is elsewhere, add `"--workspace", "/path/to/your/project"` to the `args` array.
+
 ### 4. Available Tools
 
 The MCP server exposes 8 tools (6 read-only, 2 write-capable):
@@ -293,9 +296,9 @@ The MCP server exposes 8 tools (6 read-only, 2 write-capable):
 | `context_map` | Full context map (supports compact modes) | ✅ |
 | `get_document` | Read one document by ID or path | ✅ |
 | `list_documents` | Paginated listing with type/status filters | ✅ |
+| `export_graph` | Structured graph export (optional file output) | ⚠️ |
 | `query` | Dependency details for a single document | ✅ |
 | `health` | Server uptime, document count, version | ✅ |
-| `export_graph` | Structured graph export (optional file output) | ⚠️ |
 | `refresh` | Force cache rebuild after bulk changes | ⚠️ |
 
 `export_graph` can write a file within the workspace root. `refresh` rebuilds the internal cache. Both are safe but not strictly read-only.
@@ -304,8 +307,11 @@ The MCP server exposes 8 tools (6 read-only, 2 write-capable):
 
 ```bash
 ontos --version   # Should show 4.0.0
-ontos serve       # Should start without errors (Ctrl+C to stop)
+ontos serve       # Starts the stdio server (Ctrl+C to stop)
 ```
+
+> [!NOTE]
+> The server communicates over stdio (JSON-RPC), so it won't print a "ready" message — silence is normal. To verify it's working, connect through your IDE and call a tool like `health`.
 
 For the full migration guide, including optional usage logging and known limitations, see [Migration Guide v3→v4](docs/reference/Migration_v3_to_v4.md).
 

--- a/README.md
+++ b/README.md
@@ -236,9 +236,13 @@ pip install 'ontos[mcp]'
 > [!NOTE]
 > MCP requires **Python 3.10+**. The base `pip install ontos` (without the extra) remains Python 3.9+ and does not include MCP dependencies.
 >
-> Already have Ontos installed? Upgrading:
-> - **pip:** `pip install --upgrade 'ontos[mcp]'`
-> - **pipx:** `pipx install --force 'ontos[mcp]'` (pipx upgrade does not add new extras)
+> **Already using Ontos?** Your existing documents, context map, and logs work immediately — the MCP server reads the same files as the CLI. No data migration or format conversion required:
+> ```bash
+> pip install --upgrade 'ontos[mcp]'
+> cd your-project
+> ontos serve
+> ```
+> Using pipx? Run `pipx install --force 'ontos[mcp]'` (pipx upgrade does not add new extras).
 
 ### 2. Start the Server
 

--- a/README.md
+++ b/README.md
@@ -264,6 +264,13 @@ The server runs over stdio — your IDE manages the process lifecycle.
 }
 ```
 
+> [!TIP]
+> **`ontos` not found?** Desktop apps may not inherit your shell PATH. Use the absolute path instead:
+> ```bash
+> which ontos   # Find the path, e.g. /Users/you/.local/bin/ontos
+> ```
+> Then set `"command": "/Users/you/.local/bin/ontos"` in the config above. Alternatively, use `"command": "python3"` with `"args": ["-m", "ontos", "serve"]`.
+
 **Cursor** (`.cursor/mcp.json` in your project):
 ```json
 {
@@ -278,18 +285,20 @@ The server runs over stdio — your IDE manages the process lifecycle.
 
 ### 4. Available Tools
 
-The MCP server exposes 8 read-only tools:
+The MCP server exposes 8 tools (6 read-only, 2 write-capable):
 
-| Tool | Purpose |
-|------|---------|
-| `workspace_overview` | Project orientation — key documents, graph stats, warnings |
-| `context_map` | Full context map (supports compact modes) |
-| `get_document` | Read one document by ID or path |
-| `list_documents` | Paginated listing with type/status filters |
-| `query` | Dependency details for a single document |
-| `export_graph` | Structured graph export (summary or full) |
-| `health` | Server uptime, document count, version |
-| `refresh` | Force cache rebuild after bulk changes |
+| Tool | Purpose | Read-only |
+|------|---------|:---------:|
+| `workspace_overview` | Project orientation — key documents, graph stats, warnings | ✅ |
+| `context_map` | Full context map (supports compact modes) | ✅ |
+| `get_document` | Read one document by ID or path | ✅ |
+| `list_documents` | Paginated listing with type/status filters | ✅ |
+| `query` | Dependency details for a single document | ✅ |
+| `health` | Server uptime, document count, version | ✅ |
+| `export_graph` | Structured graph export (optional file output) | ⚠️ |
+| `refresh` | Force cache rebuild after bulk changes | ⚠️ |
+
+`export_graph` can write a file within the workspace root. `refresh` rebuilds the internal cache. Both are safe but not strictly read-only.
 
 ### 5. Verify
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 - [Who Ontos Is For](#who-ontos-is-for)
 - [Use Cases](#use-cases)
 - [Quick Start](#quick-start)
+- [MCP Setup](#mcp-setup)
 - [Workflow](#workflow)
 - [Best Practices](#best-practices)
 - [What Ontos Is NOT](#what-ontos-is-not)
@@ -181,8 +182,7 @@ pip install ontos
 ```
 
 > [!TIP]
-> **For MCP server mode** (native AI IDE integration): `pipx install 'ontos[mcp]'` or `pip install 'ontos[mcp]'`.
-> Requires Python 3.10+. See the [Migration Guide v3→v4](docs/reference/Migration_v3_to_v4.md).
+> **Want native AI IDE integration?** See [MCP Setup](#mcp-setup) below to enable `ontos serve` for Claude Desktop, Cursor, and other MCP-compatible tools.
 
 > [!NOTE]
 > **"command not found: ontos"?** Your Python scripts directory may not be on PATH.
@@ -216,6 +216,89 @@ ontos init --no-scaffold # Skip scaffold prompt entirely
 > **"Ontos"** (or "Activate Ontos")
 
 If configured, the agent reads `AGENTS.md`, regenerates the context map, loads relevant files, and confirms what context it has.
+
+---
+
+## MCP Setup
+
+**New in v4.0.** Ontos can run as an MCP (Model Context Protocol) server, exposing your knowledge graph directly to AI agents. Instead of agents shelling out to CLI commands and parsing text, they connect to a persistent `ontos serve` process and call structured tools — with live cache invalidation when your docs change.
+
+### 1. Install with MCP
+
+```bash
+# pipx (recommended)
+pipx install 'ontos[mcp]'
+
+# or pip
+pip install 'ontos[mcp]'
+```
+
+> [!NOTE]
+> MCP requires **Python 3.10+**. The base `pip install ontos` (without the extra) remains Python 3.9+ and does not include MCP dependencies.
+>
+> Already have Ontos installed? Upgrading:
+> - **pip:** `pip install --upgrade 'ontos[mcp]'`
+> - **pipx:** `pipx install --force 'ontos[mcp]'` (pipx upgrade does not add new extras)
+
+### 2. Start the Server
+
+```bash
+ontos serve                    # Serve current directory
+ontos serve --workspace /path  # Serve a specific project
+```
+
+The server runs over stdio — your IDE manages the process lifecycle.
+
+### 3. Configure Your IDE
+
+**Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+```json
+{
+  "mcpServers": {
+    "ontos": {
+      "command": "ontos",
+      "args": ["serve"],
+      "cwd": "/path/to/your/project"
+    }
+  }
+}
+```
+
+**Cursor** (`.cursor/mcp.json` in your project):
+```json
+{
+  "mcpServers": {
+    "ontos": {
+      "command": "ontos",
+      "args": ["serve"]
+    }
+  }
+}
+```
+
+### 4. Available Tools
+
+The MCP server exposes 8 read-only tools:
+
+| Tool | Purpose |
+|------|---------|
+| `workspace_overview` | Project orientation — key documents, graph stats, warnings |
+| `context_map` | Full context map (supports compact modes) |
+| `get_document` | Read one document by ID or path |
+| `list_documents` | Paginated listing with type/status filters |
+| `query` | Dependency details for a single document |
+| `export_graph` | Structured graph export (summary or full) |
+| `health` | Server uptime, document count, version |
+| `refresh` | Force cache rebuild after bulk changes |
+
+### 5. Verify
+
+```bash
+ontos --version   # Should show 4.0.0
+ontos serve       # Should start without errors (Ctrl+C to stop)
+```
+
+For the full migration guide, including optional usage logging and known limitations, see [Migration Guide v3→v4](docs/reference/Migration_v3_to_v4.md).
 
 ---
 


### PR DESCRIPTION
## Summary

MCP is the flagship v4.0 feature but was buried in a `[!TIP]` callout beneath the install instructions. Users scanning Quick Start would see `pipx install ontos` and move on without knowing MCP exists.

## Changes

- **Added `MCP Setup` to the table of contents**
- **Replaced the buried tip callout** with a short pointer to the new section
- **Added a full `## MCP Setup` section** (between Quick Start and Workflow) with 5 steps:
  1. Install with `[mcp]` extra (pipx + pip, with upgrade notes)
  2. Start the server (`ontos serve`)
  3. Configure IDE (Claude Desktop + Cursor JSON configs)
  4. Available tools table (all 8 MCP tools)
  5. Verify

The Migration Guide v3→v4 link is preserved for advanced options (usage logging, known limitations).

## Rationale

MCP deserves a top-level section, not a callout. Users should be able to go from zero to a working MCP connection without leaving the README.

---
*Created by Antigravity (Claude Opus 4.6). Will not merge without explicit approval.*