### PR TITLE
feat(v4.1): Track A — portfolio index, read tools, flock substrate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ __pycache__/
 .DS_Store
 Thumbs.db
 .ontos/session_archived
+.ontos.lock
 ontos.egg-info/
 dist/
 

--- a/docs/logs/2026-04-11_close-out-pr85-track-a-fix-cycle.md
+++ b/docs/logs/2026-04-11_close-out-pr85-track-a-fix-cycle.md
@@ -1,0 +1,61 @@
+---
+id: log_20260411_close-out-pr85-track-a-fix-cycle
+type: log
+status: active
+event_type: fix
+source: cli
+branch: v4.1-track-a-portfolio
+created: 2026-04-11
+---
+
+# close-out-pr85-track-a-fix-cycle
+
+## Summary
+
+Closed out PR #85 after the Track A fix cycle was approved to merge. Cleaned the
+working tree by discarding transient generated context artifacts, recorded the
+session archive, and preserved the final branch state on
+`v4.1-track-a-portfolio` for merge.
+
+## Goal
+
+Finalize the approved Ontos v4.1 Track A fix cycle with a repo-safe cleanup
+step, archive the work in Ontos, and leave the PR branch ready to merge without
+pulling unrelated local artifacts into Git.
+
+## Key Decisions
+
+- Kept the PR branch contents unchanged apart from this close-out log.
+- Restored `AGENTS.md` and `Ontos_Context_Map.md` to `HEAD` instead of
+  committing regenerated copies, because their local diffs reflected unrelated
+  untracked docs and logs.
+- Recorded the amended CB-1 ruling as part of the session outcome:
+  strict config validation remains in place, with only the two approved legacy
+  exceptions: `validation.strict -> hooks.strict` and top-level `[project]`
+  pass-through.
+- Left unrelated untracked local files alone and excluded them from the final
+  push.
+
+## Alternatives Considered
+
+- Regenerating and committing the context artifacts during cleanup:
+  rejected, because the current worktree contains unrelated untracked docs that
+  would have polluted those generated files.
+- Performing another code or test change during close-out:
+  rejected, because PR #85 had already been fully verified and approved to
+  merge.
+
+## Impacts
+
+- PR #85 remains merge-ready on GitHub with the approved fix stack intact.
+- The close-out step is now captured in Ontos session history.
+- No unrelated local planning/review artifacts were staged or pushed.
+
+## Testing
+
+- Final verification prior to approval: `1056 passed, 2 skipped` on
+  `.venv-mcp/bin/pytest`.
+- Verification-focused checks confirmed the amended CB-1 ruling, CB-7 through
+  CB-11, SF-6, and SF-7.
+- Smoke checks completed for `ontos verify`, `ontos verify --portfolio`, and
+  `ontos serve --help`.

--- a/ontos/cli.py
+++ b/ontos/cli.py
@@ -1313,7 +1313,20 @@ def _cmd_verify(args) -> int:
         from ontos.commands.verify import verify_portfolio
         from ontos.mcp.portfolio_config import load_portfolio_config
 
-        config = load_portfolio_config()
+        try:
+            config = load_portfolio_config()
+        except (OSError, ValueError, TypeError) as exc:
+            message = f"Invalid portfolio config: {exc}"
+            if args.json:
+                _emit_handler_result_json(
+                    command="verify",
+                    exit_code=2,
+                    message=message,
+                    data={"error": True},
+                )
+            else:
+                print(message)
+            return 2
         registry_path = Path(config.registry_path).expanduser() if config.registry_path else (
             Path.home() / "Dev" / ".dev-hub" / "registry" / "projects.json"
         )
@@ -1321,6 +1334,7 @@ def _cmd_verify(args) -> int:
             portfolio_db_path=Path.home() / ".config" / "ontos" / "portfolio.db",
             registry_path=registry_path,
             json_output=args.json,
+            workspace_id=getattr(args, "workspace_id", None),
         )
 
     from ontos.commands.verify import VerifyOptions, _run_verify_command

--- a/ontos/cli.py
+++ b/ontos/cli.py
@@ -307,6 +307,16 @@ def _register_serve(subparsers, parent):
         type=Path,
         help="Workspace path to serve (defaults to the current working directory)",
     )
+    p.add_argument(
+        "--portfolio",
+        action="store_true",
+        help="Enable portfolio mode: index all projects under configured scan roots",
+    )
+    p.add_argument(
+        "--read-only",
+        action="store_true",
+        help="Expose only read tools on the MCP surface",
+    )
     p.set_defaults(func=_cmd_serve)
 
 
@@ -429,6 +439,11 @@ def _register_verify(subparsers, parent):
     p.add_argument(
         "--date", "-d",
         help="Verification date (YYYY-MM-DD, default: today)"
+    )
+    p.add_argument(
+        "--portfolio",
+        action="store_true",
+        help="Compare portfolio DB against projects.json and report discrepancies",
     )
     _add_scope_argument(p)
     p.set_defaults(func=_cmd_verify)
@@ -873,6 +888,10 @@ def _cmd_serve(args) -> int:
 
         workspace_root = find_project_root(start_path=resolved_start)
         from ontos.mcp import serve
+        portfolio = bool(getattr(args, "portfolio", False))
+        read_only = bool(getattr(args, "read_only", False))
+        if portfolio or read_only:
+            return serve(workspace_root, portfolio=portfolio, read_only=read_only)
         return serve(workspace_root)
     except FileNotFoundError as exc:
         raise OntosUserError(str(exc), code="E_WORKSPACE_NOT_FOUND") from exc
@@ -1290,6 +1309,20 @@ def _cmd_query(args) -> int:
 
 def _cmd_verify(args) -> int:
     """Handle verify command."""
+    if getattr(args, "portfolio", False):
+        from ontos.commands.verify import verify_portfolio
+        from ontos.mcp.portfolio_config import load_portfolio_config
+
+        config = load_portfolio_config()
+        registry_path = Path(config.registry_path).expanduser() if config.registry_path else (
+            Path.home() / "Dev" / ".dev-hub" / "registry" / "projects.json"
+        )
+        return verify_portfolio(
+            portfolio_db_path=Path.home() / ".config" / "ontos" / "portfolio.db",
+            registry_path=registry_path,
+            json_output=args.json,
+        )
+
     from ontos.commands.verify import VerifyOptions, _run_verify_command
 
     options = VerifyOptions(

--- a/ontos/commands/verify.py
+++ b/ontos/commands/verify.py
@@ -288,7 +288,7 @@ def verify_portfolio(
     portfolio_db_path: Path,
     registry_path: Path,
     json_output: bool = False,
-    workspace_id: str | None = None,
+    workspace_id: Optional[str] = None,
 ) -> int:
     """Compare portfolio DB projects against the dev-hub registry."""
     if not portfolio_db_path.exists():
@@ -431,7 +431,7 @@ def _normalize_path(path_value: Any) -> str:
     return str(Path(str(path_value)).expanduser().resolve(strict=False))
 
 
-def _registry_has_ontos(has_ontos_raw: object | None, normalized_path: str) -> bool:
+def _registry_has_ontos(has_ontos_raw: Optional[object], normalized_path: str) -> bool:
     coerced = _coerce_registry_bool(has_ontos_raw)
     if coerced is not None:
         return coerced
@@ -440,7 +440,7 @@ def _registry_has_ontos(has_ontos_raw: object | None, normalized_path: str) -> b
     return (Path(normalized_path) / ".ontos.toml").exists()
 
 
-def _coerce_registry_bool(value: object | None) -> bool | None:
+def _coerce_registry_bool(value: Optional[object]) -> Optional[bool]:
     if isinstance(value, bool):
         return value
     if isinstance(value, str):

--- a/ontos/commands/verify.py
+++ b/ontos/commands/verify.py
@@ -1,10 +1,12 @@
 """Native verify command implementation."""
 
+import json
 import re
+import sqlite3
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
-from typing import Optional, Tuple, List
+from typing import Any, Optional, Tuple, List
 
 from ontos.core.staleness import (
     normalize_describes,
@@ -279,3 +281,239 @@ def verify_command(options: VerifyOptions) -> int:
     """Run verify command and return exit code only."""
     exit_code, _ = _run_verify_command(options)
     return exit_code
+
+
+def verify_portfolio(
+    *,
+    portfolio_db_path: Path,
+    registry_path: Path,
+    json_output: bool = False,
+) -> int:
+    """Compare portfolio DB projects against the dev-hub registry."""
+    if not portfolio_db_path.exists():
+        message = "Portfolio DB not found. Run `ontos serve --portfolio` first."
+        _emit_verify_portfolio_result(
+            clean=False,
+            missing_in_db=[],
+            missing_in_json=[],
+            field_mismatches=[],
+            summary=message,
+            json_output=json_output,
+            exit_code=2,
+        )
+        return 2
+
+    if not registry_path.exists():
+        message = (
+            f"Registry file not found at {registry_path}. "
+            "Check portfolio.toml registry_path."
+        )
+        _emit_verify_portfolio_result(
+            clean=False,
+            missing_in_db=[],
+            missing_in_json=[],
+            field_mismatches=[],
+            summary=message,
+            json_output=json_output,
+            exit_code=2,
+        )
+        return 2
+
+    try:
+        db_projects = _load_portfolio_db_projects(portfolio_db_path)
+        registry_projects = _load_registry_projects(registry_path)
+    except (sqlite3.DatabaseError, OSError, ValueError, TypeError, json.JSONDecodeError) as exc:
+        _emit_verify_portfolio_result(
+            clean=False,
+            missing_in_db=[],
+            missing_in_json=[],
+            field_mismatches=[],
+            summary=f"Portfolio verification failed: {exc}",
+            json_output=json_output,
+            exit_code=2,
+        )
+        return 2
+
+    db_slugs = set(db_projects.keys())
+    registry_slugs = set(registry_projects.keys())
+    missing_in_db = sorted(registry_slugs - db_slugs)
+    missing_in_json = sorted(db_slugs - registry_slugs)
+
+    field_mismatches: list[dict[str, Any]] = []
+    for slug in sorted(db_slugs & registry_slugs):
+        db_row = db_projects[slug]
+        registry_row = registry_projects[slug]
+        for field in ("path", "status", "has_ontos"):
+            db_value = db_row.get(field)
+            registry_value = registry_row.get(field)
+            if db_value != registry_value:
+                field_mismatches.append(
+                    {
+                        "slug": slug,
+                        "field": field,
+                        "db_value": db_value,
+                        "json_value": registry_value,
+                    }
+                )
+
+    discrepancies = len(missing_in_db) + len(missing_in_json) + len(field_mismatches)
+    clean = discrepancies == 0
+    summary = "No discrepancies found." if clean else f"{discrepancies} discrepancies found."
+    exit_code = 0 if clean else 1
+    _emit_verify_portfolio_result(
+        clean=clean,
+        missing_in_db=missing_in_db,
+        missing_in_json=missing_in_json,
+        field_mismatches=field_mismatches,
+        summary=summary,
+        json_output=json_output,
+        exit_code=exit_code,
+    )
+    return exit_code
+
+
+def _load_portfolio_db_projects(portfolio_db_path: Path) -> dict[str, dict[str, Any]]:
+    connection = sqlite3.connect(str(portfolio_db_path))
+    connection.row_factory = sqlite3.Row
+    try:
+        rows = connection.execute(
+            "SELECT slug, path, status, has_ontos FROM projects"
+        ).fetchall()
+    finally:
+        connection.close()
+
+    projects: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        slug = str(row["slug"])
+        projects[slug] = {
+            "path": _normalize_path(row["path"]),
+            "status": str(row["status"]),
+            "has_ontos": bool(row["has_ontos"]),
+        }
+    return projects
+
+
+def _load_registry_projects(registry_path: Path) -> dict[str, dict[str, Any]]:
+    raw = json.loads(registry_path.read_text(encoding="utf-8"))
+    registry_root = _registry_root(raw, registry_path.parent)
+    if isinstance(raw, dict):
+        records = raw.get("projects", [])
+    else:
+        records = raw
+    if not isinstance(records, list):
+        raise ValueError("Registry JSON must contain a list of project objects.")
+
+    projects: dict[str, dict[str, Any]] = {}
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        path_value = record.get("path")
+        if not isinstance(path_value, str) or not path_value.strip():
+            continue
+        normalized_path = _normalize_registry_path(path_value, registry_root)
+        slug = _slugify_path_name(normalized_path)
+        status = str(record.get("status", "unknown"))
+        has_ontos = _registry_has_ontos(record, normalized_path)
+        projects[slug] = {
+            "path": normalized_path,
+            "status": status,
+            "has_ontos": has_ontos,
+        }
+    return projects
+
+
+def _normalize_path(path_value: Any) -> str:
+    return str(Path(str(path_value)).expanduser().resolve(strict=False))
+
+
+def _normalize_registry_path(path_value: Any, registry_root: Path) -> str:
+    path = Path(str(path_value)).expanduser()
+    if not path.is_absolute():
+        path = registry_root / path
+    return str(path.resolve(strict=False))
+
+
+def _registry_root(raw: object, default_root: Path) -> Path:
+    if isinstance(raw, dict):
+        dev_root = raw.get("dev_root")
+        if isinstance(dev_root, str) and dev_root.strip():
+            return Path(dev_root).expanduser().resolve(strict=False)
+    return default_root.resolve(strict=False)
+
+
+def _registry_has_ontos(record: dict[str, Any], normalized_path: str) -> bool:
+    if "has_ontos" in record:
+        return bool(record.get("has_ontos"))
+    return (Path(normalized_path) / ".ontos.toml").exists()
+
+
+def _slugify_path_name(path_value: str) -> str:
+    path_name = Path(path_value).name
+    try:
+        from ontos.mcp.scanner import slugify
+    except Exception:
+        slugify = None
+    if slugify is not None:
+        return slugify(path_name)
+    lowered = path_name.strip().lower()
+    result: list[str] = []
+    previous_dash = False
+    for char in lowered:
+        if char.isalnum():
+            result.append(char)
+            previous_dash = False
+            continue
+        if not previous_dash:
+            result.append("-")
+        previous_dash = True
+    slug = "".join(result).strip("-")
+    return slug or "workspace"
+
+
+def _emit_verify_portfolio_result(
+    *,
+    clean: bool,
+    missing_in_db: list[str],
+    missing_in_json: list[str],
+    field_mismatches: list[dict[str, Any]],
+    summary: str,
+    json_output: bool,
+    exit_code: int,
+) -> None:
+    if json_output:
+        payload: dict[str, Any] = {
+            "clean": clean,
+            "missing_in_db": missing_in_db,
+            "missing_in_json": missing_in_json,
+            "field_mismatches": field_mismatches,
+            "summary": summary,
+        }
+        if exit_code == 2:
+            payload["error"] = True
+        print(json.dumps(payload, ensure_ascii=True))
+        return
+
+    if clean:
+        print(summary)
+        return
+    if exit_code == 2:
+        print(summary)
+        return
+
+    print(summary)
+    if missing_in_db:
+        print("Missing in portfolio DB:")
+        for slug in missing_in_db:
+            print(f"  - {slug}")
+    if missing_in_json:
+        print("Missing in projects.json:")
+        for slug in missing_in_json:
+            print(f"  - {slug}")
+    if field_mismatches:
+        print("Field mismatches:")
+        for mismatch in field_mismatches:
+            print(
+                "  - "
+                f"{mismatch['slug']} {mismatch['field']}: "
+                f"db={mismatch['db_value']!r} json={mismatch['json_value']!r}"
+            )

--- a/ontos/commands/verify.py
+++ b/ontos/commands/verify.py
@@ -288,6 +288,7 @@ def verify_portfolio(
     portfolio_db_path: Path,
     registry_path: Path,
     json_output: bool = False,
+    workspace_id: str | None = None,
 ) -> int:
     """Compare portfolio DB projects against the dev-hub registry."""
     if not portfolio_db_path.exists():
@@ -333,6 +334,10 @@ def verify_portfolio(
             exit_code=2,
         )
         return 2
+
+    if workspace_id is not None:
+        db_projects = _scope_projects(db_projects, workspace_id)
+        registry_projects = _scope_projects(registry_projects, workspace_id)
 
     db_slugs = set(db_projects.keys())
     registry_slugs = set(registry_projects.keys())
@@ -394,26 +399,17 @@ def _load_portfolio_db_projects(portfolio_db_path: Path) -> dict[str, dict[str, 
 
 
 def _load_registry_projects(registry_path: Path) -> dict[str, dict[str, Any]]:
-    raw = json.loads(registry_path.read_text(encoding="utf-8"))
-    registry_root = _registry_root(raw, registry_path.parent)
-    if isinstance(raw, dict):
-        records = raw.get("projects", [])
-    else:
-        records = raw
-    if not isinstance(records, list):
-        raise ValueError("Registry JSON must contain a list of project objects.")
+    from ontos.mcp.scanner import allocate_slug, load_registry_records, slugify
 
+    records = load_registry_records(registry_path, tolerate_errors=False)
     projects: dict[str, dict[str, Any]] = {}
-    for record in records:
-        if not isinstance(record, dict):
-            continue
-        path_value = record.get("path")
-        if not isinstance(path_value, str) or not path_value.strip():
-            continue
-        normalized_path = _normalize_registry_path(path_value, registry_root)
-        slug = _slugify_path_name(normalized_path)
-        status = str(record.get("status", "unknown"))
-        has_ontos = _registry_has_ontos(record, normalized_path)
+    used_slugs: dict[str, int] = {}
+    for record in sorted(records, key=lambda item: str(item.path)):
+        normalized_path = _normalize_path(record.path)
+        base_slug = slugify(Path(normalized_path).name)
+        slug = allocate_slug(base_slug, used_slugs)
+        status = record.status if record.status else "unknown"
+        has_ontos = _registry_has_ontos(record.has_ontos_raw, normalized_path)
         projects[slug] = {
             "path": normalized_path,
             "status": status,
@@ -422,52 +418,38 @@ def _load_registry_projects(registry_path: Path) -> dict[str, dict[str, Any]]:
     return projects
 
 
+def _scope_projects(
+    projects: dict[str, dict[str, Any]],
+    workspace_id: str,
+) -> dict[str, dict[str, Any]]:
+    if workspace_id in projects:
+        return {workspace_id: projects[workspace_id]}
+    return {}
+
+
 def _normalize_path(path_value: Any) -> str:
     return str(Path(str(path_value)).expanduser().resolve(strict=False))
 
 
-def _normalize_registry_path(path_value: Any, registry_root: Path) -> str:
-    path = Path(str(path_value)).expanduser()
-    if not path.is_absolute():
-        path = registry_root / path
-    return str(path.resolve(strict=False))
-
-
-def _registry_root(raw: object, default_root: Path) -> Path:
-    if isinstance(raw, dict):
-        dev_root = raw.get("dev_root")
-        if isinstance(dev_root, str) and dev_root.strip():
-            return Path(dev_root).expanduser().resolve(strict=False)
-    return default_root.resolve(strict=False)
-
-
-def _registry_has_ontos(record: dict[str, Any], normalized_path: str) -> bool:
-    if "has_ontos" in record:
-        return bool(record.get("has_ontos"))
+def _registry_has_ontos(has_ontos_raw: object | None, normalized_path: str) -> bool:
+    coerced = _coerce_registry_bool(has_ontos_raw)
+    if coerced is not None:
+        return coerced
+    # Deleted workspace entries can remain in the registry even after the path disappears.
+    # For malformed has_ontos values, fallback to filesystem state to preserve this behavior.
     return (Path(normalized_path) / ".ontos.toml").exists()
 
 
-def _slugify_path_name(path_value: str) -> str:
-    path_name = Path(path_value).name
-    try:
-        from ontos.mcp.scanner import slugify
-    except Exception:
-        slugify = None
-    if slugify is not None:
-        return slugify(path_name)
-    lowered = path_name.strip().lower()
-    result: list[str] = []
-    previous_dash = False
-    for char in lowered:
-        if char.isalnum():
-            result.append(char)
-            previous_dash = False
-            continue
-        if not previous_dash:
-            result.append("-")
-        previous_dash = True
-    slug = "".join(result).strip("-")
-    return slug or "workspace"
+def _coerce_registry_bool(value: object | None) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes"}:
+            return True
+        if normalized in {"false", "0", "no", ""}:
+            return False
+    return None
 
 
 def _emit_verify_portfolio_result(

--- a/ontos/core/config.py
+++ b/ontos/core/config.py
@@ -12,7 +12,7 @@ The caller (commands layer) provides the IO callback.
 """
 
 import os
-from dataclasses import dataclass, field, asdict
+from dataclasses import asdict, dataclass, field, fields
 from datetime import datetime
 from pathlib import Path
 from typing import List, Optional, Callable
@@ -123,6 +123,7 @@ def _validate_types(data: dict) -> None:
         ("workflow", "log_retention_count"): int,
         ("hooks", "pre_push"): bool,
         ("hooks", "pre_commit"): bool,
+        ("hooks", "strict"): bool,
         ("mcp", "usage_logging"): bool,
         ("mcp", "usage_log_path"): str,
     }
@@ -141,6 +142,8 @@ def _validate_types(data: dict) -> None:
 
 def dict_to_config(data: dict, repo_root: Optional[Path] = None) -> OntosConfig:
     """Convert dict from TOML to config dataclass."""
+    data = _normalize_legacy_config(data)
+
     # Type validation
     _validate_types(data)
 
@@ -155,13 +158,13 @@ def dict_to_config(data: dict, repo_root: Optional[Path] = None) -> OntosConfig:
                     )
 
     # Build config with defaults for missing fields
-    ontos = OntosSection(**data.get("ontos", {}))
-    paths = PathsConfig(**data.get("paths", {}))
-    scanning = ScanningConfig(**data.get("scanning", {}))
-    validation = ValidationConfig(**data.get("validation", {}))
-    workflow = WorkflowConfig(**data.get("workflow", {}))
-    hooks = HooksConfig(**data.get("hooks", {}))
-    mcp = McpConfig(**data.get("mcp", {}))
+    ontos = OntosSection(**_section_kwargs(OntosSection, data.get("ontos")))
+    paths = PathsConfig(**_section_kwargs(PathsConfig, data.get("paths")))
+    scanning = ScanningConfig(**_section_kwargs(ScanningConfig, data.get("scanning")))
+    validation = ValidationConfig(**_section_kwargs(ValidationConfig, data.get("validation")))
+    workflow = WorkflowConfig(**_section_kwargs(WorkflowConfig, data.get("workflow")))
+    hooks = HooksConfig(**_section_kwargs(HooksConfig, data.get("hooks")))
+    mcp = McpConfig(**_section_kwargs(McpConfig, data.get("mcp")))
 
     return OntosConfig(
         ontos=ontos,
@@ -172,6 +175,40 @@ def dict_to_config(data: dict, repo_root: Optional[Path] = None) -> OntosConfig:
         hooks=hooks,
         mcp=mcp,
     )
+
+
+def _normalize_legacy_config(data: dict) -> dict:
+    """Map known legacy config fields onto the current schema."""
+    normalized = {
+        key: (dict(value) if isinstance(value, dict) else value)
+        for key, value in data.items()
+    }
+    validation = normalized.get("validation")
+    if not isinstance(validation, dict):
+        return normalized
+
+    legacy_strict = validation.pop("strict", None)
+    if legacy_strict is None:
+        return normalized
+
+    hooks = normalized.get("hooks")
+    if not isinstance(hooks, dict):
+        hooks = {}
+        normalized["hooks"] = hooks
+    hooks.setdefault("strict", legacy_strict)
+    return normalized
+
+
+def _section_kwargs(section_type: type, raw_values: object) -> dict:
+    """Return only constructor-supported keys for one config section."""
+    if not isinstance(raw_values, dict):
+        return {}
+    allowed = {field_info.name for field_info in fields(section_type)}
+    return {
+        key: value
+        for key, value in raw_values.items()
+        if key in allowed
+    }
 
 
 # =============================================================================

--- a/ontos/core/config.py
+++ b/ontos/core/config.py
@@ -186,6 +186,12 @@ def _normalize_legacy_config(data: dict) -> dict:
         key: (dict(value) if isinstance(value, dict) else value)
         for key, value in data.items()
     }
+    # Legacy user projects may still carry a top-level [project] section.
+    # Current runtime code does not consume those fields, so treat it as a
+    # compatibility no-op while keeping strict validation for every other
+    # unknown section.
+    normalized.pop("project", None)
+
     validation = normalized.get("validation")
     if not isinstance(validation, dict):
         return normalized

--- a/ontos/core/config.py
+++ b/ontos/core/config.py
@@ -143,6 +143,7 @@ def _validate_types(data: dict) -> None:
 def dict_to_config(data: dict, repo_root: Optional[Path] = None) -> OntosConfig:
     """Convert dict from TOML to config dataclass."""
     data = _normalize_legacy_config(data)
+    _validate_section_names(data)
 
     # Type validation
     _validate_types(data)
@@ -158,13 +159,15 @@ def dict_to_config(data: dict, repo_root: Optional[Path] = None) -> OntosConfig:
                     )
 
     # Build config with defaults for missing fields
-    ontos = OntosSection(**_section_kwargs(OntosSection, data.get("ontos")))
-    paths = PathsConfig(**_section_kwargs(PathsConfig, data.get("paths")))
-    scanning = ScanningConfig(**_section_kwargs(ScanningConfig, data.get("scanning")))
-    validation = ValidationConfig(**_section_kwargs(ValidationConfig, data.get("validation")))
-    workflow = WorkflowConfig(**_section_kwargs(WorkflowConfig, data.get("workflow")))
-    hooks = HooksConfig(**_section_kwargs(HooksConfig, data.get("hooks")))
-    mcp = McpConfig(**_section_kwargs(McpConfig, data.get("mcp")))
+    ontos = OntosSection(**_section_kwargs(OntosSection, "ontos", data.get("ontos")))
+    paths = PathsConfig(**_section_kwargs(PathsConfig, "paths", data.get("paths")))
+    scanning = ScanningConfig(**_section_kwargs(ScanningConfig, "scanning", data.get("scanning")))
+    validation = ValidationConfig(
+        **_section_kwargs(ValidationConfig, "validation", data.get("validation"))
+    )
+    workflow = WorkflowConfig(**_section_kwargs(WorkflowConfig, "workflow", data.get("workflow")))
+    hooks = HooksConfig(**_section_kwargs(HooksConfig, "hooks", data.get("hooks")))
+    mcp = McpConfig(**_section_kwargs(McpConfig, "mcp", data.get("mcp")))
 
     return OntosConfig(
         ontos=ontos,
@@ -199,16 +202,23 @@ def _normalize_legacy_config(data: dict) -> dict:
     return normalized
 
 
-def _section_kwargs(section_type: type, raw_values: object) -> dict:
-    """Return only constructor-supported keys for one config section."""
+def _validate_section_names(data: dict) -> None:
+    """Reject unknown top-level config sections."""
+    allowed = {field_info.name for field_info in fields(OntosConfig)}
+    for section_name in data:
+        if section_name not in allowed:
+            raise ConfigError(f"Unknown config section '{section_name}'")
+
+
+def _section_kwargs(section_type: type, section_name: str, raw_values: object) -> dict:
+    """Return constructor kwargs for one config section and reject unknown keys."""
     if not isinstance(raw_values, dict):
         return {}
     allowed = {field_info.name for field_info in fields(section_type)}
-    return {
-        key: value
-        for key, value in raw_values.items()
-        if key in allowed
-    }
+    for key in raw_values:
+        if key not in allowed:
+            raise ConfigError(f"Unknown config key '{section_name}.{key}'")
+    return dict(raw_values)
 
 
 # =============================================================================

--- a/ontos/core/context.py
+++ b/ontos/core/context.py
@@ -7,10 +7,11 @@ Per v2.8 implementation plan, SessionContext:
 - Is the single source of truth for repository configuration
 - Buffers file operations for later commit
 - Provides atomic writes via two-phase commit
-- Uses file locking with stale detection
+- Uses file locking with flock
 """
 
 from dataclasses import dataclass, field
+import fcntl
 from pathlib import Path
 from typing import Dict, List, Optional
 from enum import Enum
@@ -60,6 +61,7 @@ class SessionContext:
     pending_writes: List[PendingWrite] = field(default_factory=list)
     warnings: List[str] = field(default_factory=list)
     errors: List[str] = field(default_factory=list)
+    _lock_handle: Optional[object] = field(default=None, init=False, repr=False)
 
     @classmethod
     def from_repo(cls, repo_root: Path) -> 'SessionContext':
@@ -145,7 +147,7 @@ class SessionContext:
         if not self.pending_writes:
             return []
 
-        lock_path = self.repo_root / '.ontos' / 'write.lock'
+        lock_path = self.repo_root / ".ontos.lock"
         if not self._acquire_lock(lock_path):
             raise RuntimeError(
                 "Could not acquire write lock. "
@@ -222,41 +224,19 @@ class SessionContext:
         self.errors.append(message)
 
     def _acquire_lock(self, lock_path: Path, timeout: float = 5.0) -> bool:
-        """Acquire a simple file lock with stale detection.
-
-        Uses atomic file creation (O_CREAT | O_EXCL). If a stale lock
-        is detected (holding process is dead), it is automatically removed.
-
-        Args:
-            lock_path: Path to lock file
-            timeout: Maximum seconds to wait
-
-        Returns:
-            True if lock acquired, False if timeout
-        """
+        """Acquire an exclusive flock lock for this workspace."""
         lock_path.parent.mkdir(parents=True, exist_ok=True)
-        start = time.time()
+        start = time.monotonic()
+        handle = lock_path.open("a+", encoding="utf-8")
 
-        while time.time() - start < timeout:
+        while time.monotonic() - start < timeout:
             try:
-                fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
-                os.write(fd, str(os.getpid()).encode())
-                os.close(fd)
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                self._lock_handle = handle
                 return True
-            except FileExistsError:
-                # Check if holding process is still alive
-                try:
-                    pid = int(lock_path.read_text().strip())
-                    os.kill(pid, 0)  # Raises if process doesn't exist
-                except (ProcessLookupError, ValueError, OSError):
-                    # Stale lock - process is dead, remove it
-                    try:
-                        lock_path.unlink()
-                    except FileNotFoundError:
-                        pass
-                    continue
+            except BlockingIOError:
                 time.sleep(0.1)
-
+        handle.close()
         return False
 
     def _release_lock(self, lock_path: Path) -> None:
@@ -265,7 +245,13 @@ class SessionContext:
         Args:
             lock_path: Path to lock file.
         """
+        _ = lock_path
+        if self._lock_handle is None:
+            return
         try:
-            lock_path.unlink()
-        except FileNotFoundError:
-            pass  # Already released
+            fcntl.flock(self._lock_handle.fileno(), fcntl.LOCK_UN)
+        except OSError:
+            pass
+        finally:
+            self._lock_handle.close()
+            self._lock_handle = None

--- a/ontos/core/context.py
+++ b/ontos/core/context.py
@@ -6,7 +6,7 @@ state for an Ontos session and provides transaction support for file operations.
 Per v2.8 implementation plan, SessionContext:
 - Is the single source of truth for repository configuration
 - Buffers file operations for later commit
-- Provides atomic writes via two-phase commit
+- Applies buffered writes sequentially during commit
 - Uses file locking with flock
 """
 
@@ -132,10 +132,11 @@ class SessionContext:
         ))
 
     def commit(self) -> List[Path]:
-        """Execute all buffered operations with two-phase commit.
+        """Execute all buffered operations from the current session.
 
-        ATOMICITY: Uses temp-then-rename pattern. If any operation fails,
-        previous temp files are cleaned up. Rename is atomic on POSIX.
+        Writes and moves stage temporary files before applying updates. The
+        commit is best-effort across buffered operations, not a global
+        transactional two-phase commit.
 
         Returns:
             List of paths successfully modified.

--- a/ontos/core/context.py
+++ b/ontos/core/context.py
@@ -7,7 +7,7 @@ Per v2.8 implementation plan, SessionContext:
 - Is the single source of truth for repository configuration
 - Buffers file operations for later commit
 - Applies buffered writes sequentially during commit
-- Uses file locking with flock
+- Uses flock-based locking to serialize commit attempts
 """
 
 from dataclasses import dataclass, field

--- a/ontos/mcp/__init__.py
+++ b/ontos/mcp/__init__.py
@@ -5,8 +5,13 @@ from __future__ import annotations
 from pathlib import Path
 
 
-def serve(workspace_root: Path) -> int:
+def serve(
+    workspace_root: Path,
+    *,
+    portfolio: bool = False,
+    read_only: bool = False,
+) -> int:
     """Start the Ontos MCP server for one workspace."""
     from ontos.mcp.server import serve as _serve
 
-    return _serve(workspace_root)
+    return _serve(workspace_root, portfolio=portfolio, read_only=read_only)

--- a/ontos/mcp/bundler.py
+++ b/ontos/mcp/bundler.py
@@ -1,0 +1,315 @@
+"""Context bundle assembly for the MCP `get_context_bundle` tool."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import date, datetime, timedelta
+from pathlib import Path
+import re
+from typing import Any
+
+from ontos.core.snapshot import DocumentSnapshot
+from ontos.core.staleness import check_staleness, parse_describes_verified
+from ontos.core.tokens import estimate_tokens
+from ontos.core.types import DocumentData
+from ontos.mcp.tools import TYPE_RANKS
+
+
+TOP_INDEGREE_COUNT = 10
+
+
+@dataclass(frozen=True)
+class BundleDocument:
+    id: str
+    type: str
+    status: str
+    content: str
+    score: float
+    token_estimate: int
+
+
+def build_context_bundle(
+    snapshot: DocumentSnapshot,
+    workspace_root: Path,
+    workspace_slug: str,
+    *,
+    token_budget: int = 8192,
+    max_logs: int = 5,
+    log_window_days: int = 14,
+) -> dict[str, Any]:
+    """Build a token-budgeted context bundle from a workspace snapshot."""
+    docs_by_id = snapshot.documents
+    in_degree = {
+        doc_id: len(snapshot.graph.reverse_edges.get(doc_id, []))
+        for doc_id in docs_by_id
+    }
+    non_kernel_degrees = [
+        value
+        for doc_id, value in in_degree.items()
+        if docs_by_id[doc_id].type.value != "kernel"
+    ]
+    max_non_kernel_indegree = max(non_kernel_degrees) if non_kernel_degrees else 0
+
+    scored_docs = [
+        _to_bundle_doc(doc, in_degree[doc.id], max_non_kernel_indegree)
+        for doc in docs_by_id.values()
+    ]
+    priority_docs = _build_priority_order(
+        scored_docs,
+        docs_by_id,
+        in_degree,
+        workspace_root,
+        max_logs=max_logs,
+        log_window_days=log_window_days,
+    )
+    included, excluded_count, total_tokens = _greedy_pack(priority_docs, token_budget)
+    reordered = _lost_in_middle_order(included)
+    stale_documents = _detect_stale_documents(reordered, docs_by_id)
+
+    warnings: list[str] = []
+    if excluded_count:
+        warnings.append(f"Excluded {excluded_count} documents due to token budget.")
+
+    return {
+        "workspace_id": workspace_slug,
+        "workspace_slug": workspace_slug,
+        "token_estimate": total_tokens,
+        "document_count": len(reordered),
+        "bundle_text": _render_bundle_text(reordered, total_tokens, excluded_count),
+        "included_documents": [
+            {
+                "id": doc.id,
+                "type": doc.type,
+                "score": round(doc.score, 4),
+                "token_estimate": doc.token_estimate,
+            }
+            for doc in reordered
+        ],
+        "excluded_count": excluded_count,
+        "stale_documents": stale_documents,
+        "warnings": warnings,
+    }
+
+
+def _to_bundle_doc(
+    doc: DocumentData,
+    in_degree: int,
+    max_non_kernel_indegree: int,
+) -> BundleDocument:
+    if doc.type.value == "kernel":
+        score = 1.0
+    elif max_non_kernel_indegree > 0:
+        score = 0.5 + (0.5 * (in_degree / max_non_kernel_indegree))
+    else:
+        score = 0.5
+
+    return BundleDocument(
+        id=doc.id,
+        type=doc.type.value,
+        status=doc.status.value,
+        content=doc.content or "",
+        score=score,
+        token_estimate=estimate_tokens(doc.content),
+    )
+
+
+def _build_priority_order(
+    docs: list[BundleDocument],
+    docs_by_id: dict[str, DocumentData],
+    in_degree: dict[str, int],
+    workspace_root: Path,
+    *,
+    max_logs: int,
+    log_window_days: int,
+) -> list[BundleDocument]:
+    kernels = [doc for doc in docs if doc.type == "kernel"]
+    kernels.sort(key=lambda doc: (-in_degree.get(doc.id, 0), doc.id))
+
+    recent_logs = _recent_logs(
+        docs,
+        docs_by_id,
+        workspace_root,
+        max_logs=max_logs,
+        log_window_days=log_window_days,
+    )
+    recent_log_ids = {doc.id for doc in recent_logs}
+
+    non_kernel = [doc for doc in docs if doc.type != "kernel" and doc.id not in recent_log_ids]
+    high_indegree = sorted(
+        non_kernel,
+        key=lambda doc: (-in_degree.get(doc.id, 0), doc.id),
+    )[:TOP_INDEGREE_COUNT]
+    high_indegree_ids = {doc.id for doc in high_indegree}
+
+    remaining = [doc for doc in non_kernel if doc.id not in high_indegree_ids]
+    remaining.sort(
+        key=lambda doc: (
+            TYPE_RANKS.get(doc.type, 99),
+            -in_degree.get(doc.id, 0),
+            doc.id,
+        )
+    )
+
+    return kernels + high_indegree + recent_logs + remaining
+
+
+def _recent_logs(
+    docs: list[BundleDocument],
+    docs_by_id: dict[str, DocumentData],
+    workspace_root: Path,
+    *,
+    max_logs: int,
+    log_window_days: int,
+) -> list[BundleDocument]:
+    if max_logs <= 0:
+        return []
+
+    cutoff = date.today() - timedelta(days=log_window_days)
+    dated_logs: list[tuple[date, BundleDocument]] = []
+
+    for bundle_doc in docs:
+        if bundle_doc.type != "log":
+            continue
+        source = docs_by_id[bundle_doc.id]
+        log_date = _extract_log_date(source, workspace_root)
+        if log_date is None or log_date < cutoff:
+            continue
+        dated_logs.append((log_date, replace(bundle_doc, score=0.3)))
+
+    dated_logs.sort(key=lambda item: (item[0], item[1].id), reverse=True)
+    return [doc for _, doc in dated_logs[:max_logs]]
+
+
+def _extract_log_date(doc: DocumentData, workspace_root: Path) -> date | None:
+    raw_date = doc.frontmatter.get("date")
+    if isinstance(raw_date, datetime):
+        return raw_date.date()
+    if isinstance(raw_date, date):
+        return raw_date
+    if isinstance(raw_date, str):
+        parsed = _parse_iso_date(raw_date)
+        if parsed is not None:
+            return parsed
+
+    for text in (doc.id, doc.filepath.name):
+        parsed = _parse_iso_date(text)
+        if parsed is not None:
+            return parsed
+
+    try:
+        resolved = doc.filepath.resolve(strict=False)
+        if not resolved.is_relative_to(workspace_root.resolve()):
+            return None
+        if not resolved.exists():
+            return None
+        return datetime.fromtimestamp(resolved.stat().st_mtime).date()
+    except OSError:
+        return None
+
+
+def _parse_iso_date(value: str) -> date | None:
+    match = re.search(r"\b(\d{4}-\d{2}-\d{2})\b", value)
+    if not match:
+        return None
+    try:
+        return date.fromisoformat(match.group(1))
+    except ValueError:
+        return None
+
+
+def _greedy_pack(
+    docs: list[BundleDocument],
+    token_budget: int,
+) -> tuple[list[BundleDocument], int, int]:
+    included: list[BundleDocument] = []
+    excluded_count = 0
+    total_tokens = 0
+
+    for doc in docs:
+        if doc.type == "kernel":
+            included.append(doc)
+            total_tokens += doc.token_estimate
+            continue
+
+        if total_tokens + doc.token_estimate <= token_budget:
+            included.append(doc)
+            total_tokens += doc.token_estimate
+        else:
+            excluded_count += 1
+
+    return included, excluded_count, total_tokens
+
+
+def _lost_in_middle_order(docs: list[BundleDocument]) -> list[BundleDocument]:
+    ranked = sorted(docs, key=lambda doc: (-doc.score, doc.id))
+    front: list[BundleDocument] = []
+    back: list[BundleDocument] = []
+
+    for index, doc in enumerate(ranked):
+        if index % 2 == 0:
+            front.append(doc)
+        else:
+            back.append(doc)
+
+    return front + list(reversed(back))
+
+
+def _render_bundle_text(
+    docs: list[BundleDocument],
+    token_estimate: int,
+    excluded_count: int,
+) -> str:
+    sections: list[str] = []
+    for doc in docs:
+        sections.append(
+            f"## {_humanize_id(doc.id)} ({doc.type}, {doc.status})\n\n"
+            f"{doc.content}\n\n---"
+        )
+
+    body = "\n\n".join(sections)
+    footer = (
+        f"<!-- Bundle: {len(docs)} documents, ~{token_estimate} tokens, "
+        f"{excluded_count} excluded -->"
+    )
+    if not body:
+        return footer
+    return f"{body}\n\n{footer}"
+
+
+def _detect_stale_documents(
+    docs: list[BundleDocument],
+    docs_by_id: dict[str, DocumentData],
+) -> list[dict[str, str]]:
+    id_to_path = {
+        doc_id: str(doc.filepath)
+        for doc_id, doc in docs_by_id.items()
+    }
+    stale_items: list[dict[str, str]] = []
+
+    for bundle_doc in docs:
+        source_doc = docs_by_id.get(bundle_doc.id)
+        if source_doc is None:
+            continue
+
+        describes = list(source_doc.describes)
+        verified = parse_describes_verified(source_doc.frontmatter.get("describes_verified"))
+        staleness = check_staleness(
+            doc_id=source_doc.id,
+            doc_path=str(source_doc.filepath),
+            describes=describes,
+            describes_verified=verified,
+            id_to_path=id_to_path,
+        )
+        if staleness is None or not staleness.is_stale():
+            continue
+
+        stale_atoms = ", ".join(atom for atom, _ in staleness.stale_atoms)
+        reason = f"describes targets changed after describes_verified: {stale_atoms}"
+        stale_items.append({"id": source_doc.id, "reason": reason})
+
+    return stale_items
+
+
+def _humanize_id(doc_id: str) -> str:
+    return doc_id.replace("_", " ").title()
+

--- a/ontos/mcp/locking.py
+++ b/ontos/mcp/locking.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 import fcntl
+import os
 from pathlib import Path
 import time
 from typing import Iterator
@@ -18,6 +19,7 @@ def workspace_lock(workspace_root: Path, timeout: float = 5.0) -> Iterator[None]
     lock_path.parent.mkdir(parents=True, exist_ok=True)
 
     handle = lock_path.open("a+", encoding="utf-8")
+    os.set_inheritable(handle.fileno(), False)
     start = time.monotonic()
     try:
         while True:

--- a/ontos/mcp/locking.py
+++ b/ontos/mcp/locking.py
@@ -1,0 +1,40 @@
+"""Workspace-level advisory locking for MCP and CLI write paths."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+import fcntl
+from pathlib import Path
+import time
+from typing import Iterator
+
+from ontos.core.errors import OntosUserError
+
+
+@contextmanager
+def workspace_lock(workspace_root: Path, timeout: float = 5.0) -> Iterator[None]:
+    """Acquire an exclusive flock on ``<workspace>/.ontos.lock``."""
+    lock_path = workspace_root / ".ontos.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+
+    handle = lock_path.open("a+", encoding="utf-8")
+    start = time.monotonic()
+    try:
+        while True:
+            try:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except BlockingIOError:
+                if time.monotonic() - start >= timeout:
+                    raise OntosUserError(
+                        "Workspace is locked by another process.",
+                        code="E_WORKSPACE_BUSY",
+                    )
+                time.sleep(0.1)
+        yield
+    finally:
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        except OSError:
+            pass
+        handle.close()

--- a/ontos/mcp/portfolio.py
+++ b/ontos/mcp/portfolio.py
@@ -54,13 +54,18 @@ class PortfolioIndex:
         """No-op API for compatibility with context-managed callers."""
         self._opened = False
 
-    def rebuild_all(self, scan_roots: list[Path], exclude: list[str]) -> None:
+    def rebuild_all(
+        self,
+        scan_roots: list[Path],
+        exclude: list[str],
+        registry_path: Path | None = None,
+    ) -> None:
         """Rebuild all discovered workspaces from scratch."""
         self.open()
         projects = discover_projects(
             scan_roots=scan_roots,
             exclude=exclude,
-            registry_path=None,
+            registry_path=registry_path,
         )
 
         with self._write_lock:
@@ -217,18 +222,16 @@ class PortfolioIndex:
                 raise
 
         return {
-            "total_count": int(total_count),
-            "offset": offset,
+            "total_hits": int(total_count),
             "results": [
                 {
-                    "workspace": row["workspace"],
-                    "id": row["id"],
+                    "doc_id": row["id"],
+                    "workspace_slug": row["workspace"],
                     "type": row["type"],
                     "status": row["status"],
                     "path": row["path"],
-                    "title": row["title"],
-                    "rank": float(row["rank"]) if row["rank"] is not None else 0.0,
                     "snippet": row["snippet"] or "",
+                    "score": float(row["rank"]) if row["rank"] is not None else 0.0,
                 }
                 for row in rows
             ],

--- a/ontos/mcp/portfolio.py
+++ b/ontos/mcp/portfolio.py
@@ -21,6 +21,7 @@ class PortfolioIndex:
     """SQLite-backed portfolio index for cross-project queries."""
 
     SCHEMA_VERSION = 1
+    CONNECT_TIMEOUT_SECONDS = 5.0
     PRAGMA_BLOCK = """
         PRAGMA journal_mode = WAL;
         PRAGMA synchronous = NORMAL;
@@ -216,6 +217,11 @@ class PortfolioIndex:
                 conn.rollback()
                 if self._is_invalid_fts_query(exc):
                     raise OntosUserError("Malformed full-text query.", code="E_INVALID_QUERY") from exc
+                if self._is_busy_error(exc):
+                    raise OntosUserError(
+                        "Portfolio index is busy. Please retry.",
+                        code="E_PORTFOLIO_BUSY",
+                    ) from exc
                 raise
             except Exception:
                 conn.rollback()
@@ -418,7 +424,10 @@ class PortfolioIndex:
                 conn.execute("PRAGMA wal_checkpoint(PASSIVE);")
 
     def _connect(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(str(self.db_path))
+        conn = sqlite3.connect(
+            str(self.db_path),
+            timeout=self.CONNECT_TIMEOUT_SECONDS,
+        )
         conn.row_factory = sqlite3.Row
         self._apply_pragmas(conn)
         conn.execute("PRAGMA wal_autocheckpoint = 0;")
@@ -507,10 +516,16 @@ class PortfolioIndex:
         )
 
     def _reset_db_file(self) -> None:
-        try:
-            self.db_path.unlink()
-        except FileNotFoundError:
-            return
+        candidates = (
+            self.db_path,
+            self.db_path.with_name(f"{self.db_path.name}-wal"),
+            self.db_path.with_name(f"{self.db_path.name}-shm"),
+        )
+        for path in candidates:
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                continue
 
     def _apply_pragmas(self, conn: sqlite3.Connection) -> None:
         for statement in self.PRAGMA_BLOCK.splitlines():
@@ -581,6 +596,11 @@ class PortfolioIndex:
             or "unterminated string" in message
             or "unknown special query" in message
         )
+
+    @staticmethod
+    def _is_busy_error(exc: sqlite3.OperationalError) -> bool:
+        message = str(exc).lower()
+        return "database is locked" in message or "database table is locked" in message
 
     @staticmethod
     def _stat_fingerprint(path: Path) -> tuple[int, int] | None:

--- a/ontos/mcp/portfolio.py
+++ b/ontos/mcp/portfolio.py
@@ -1,0 +1,612 @@
+"""SQLite-backed portfolio index for cross-workspace MCP reads."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import sqlite3
+import threading
+from typing import Any, Optional
+
+from ontos.commands.export_data import _compute_content_hash
+from ontos.core.errors import OntosUserError
+from ontos.io.config import load_project_config
+from ontos.io.scan_scope import collect_scoped_documents, resolve_scan_scope
+from ontos.io.snapshot import create_snapshot
+from ontos.mcp.scanner import ProjectEntry, discover_projects
+
+
+class PortfolioIndex:
+    """SQLite-backed portfolio index for cross-project queries."""
+
+    SCHEMA_VERSION = 1
+    PRAGMA_BLOCK = """
+        PRAGMA journal_mode = WAL;
+        PRAGMA synchronous = NORMAL;
+        PRAGMA cache_size = -16000;
+        PRAGMA mmap_size = 67108864;
+        PRAGMA temp_store = MEMORY;
+        PRAGMA busy_timeout = 5000;
+    """
+
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = db_path.expanduser().resolve(strict=False)
+        self._write_lock = threading.Lock()
+        self._opened = False
+
+    def open(self) -> None:
+        """Prepare the backing DB and ensure schema compatibility."""
+        with self._write_lock:
+            self.db_path.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                with self._connect() as conn:
+                    self._initialize_db(conn)
+                    conn.execute("PRAGMA optimize = 0x10002;")
+            except sqlite3.DatabaseError:
+                self._reset_db_file()
+                with self._connect() as conn:
+                    self._initialize_db(conn)
+                    conn.execute("PRAGMA optimize = 0x10002;")
+            self._opened = True
+
+    def close(self) -> None:
+        """No-op API for compatibility with context-managed callers."""
+        self._opened = False
+
+    def rebuild_all(self, scan_roots: list[Path], exclude: list[str]) -> None:
+        """Rebuild all discovered workspaces from scratch."""
+        self.open()
+        projects = discover_projects(
+            scan_roots=scan_roots,
+            exclude=exclude,
+            registry_path=None,
+        )
+
+        with self._write_lock:
+            with self._connect() as conn:
+                conn.execute("BEGIN IMMEDIATE;")
+                conn.execute("DELETE FROM edges;")
+                conn.execute("DELETE FROM documents;")
+                conn.execute("DELETE FROM projects;")
+                conn.execute("DELETE FROM scan_state;")
+                conn.execute("DELETE FROM fts_content;")
+                conn.commit()
+
+        for project in projects:
+            self._rebuild_workspace(project.slug, project.path, project=project)
+
+        with self._connect() as conn:
+            conn.execute("INSERT INTO fts_content(fts_content) VALUES('optimize');")
+            try:
+                conn.execute("PRAGMA wal_checkpoint(PASSIVE);")
+            except sqlite3.OperationalError:
+                pass
+
+    def rebuild_workspace(self, slug: str, workspace_root: Path) -> None:
+        """Rebuild one workspace in a serialized write transaction."""
+        self.open()
+        self._rebuild_workspace(slug, workspace_root, project=None)
+
+    def is_workspace_stale(self, slug: str) -> bool:
+        """Return True when tracked file fingerprints drift from scan_state."""
+        self.open()
+        with self._connect() as conn:
+            row = conn.execute(
+                """
+                SELECT p.path AS path, s.fingerprint AS fingerprint
+                FROM projects p
+                LEFT JOIN scan_state s ON s.workspace = p.slug
+                WHERE p.slug = ?
+                """,
+                (slug,),
+            ).fetchone()
+
+        if row is None:
+            return True
+
+        workspace_path = Path(row["path"])
+        if not workspace_path.exists():
+            return True
+
+        stored_raw = row["fingerprint"]
+        if not isinstance(stored_raw, str):
+            return True
+
+        try:
+            stored = json.loads(stored_raw)
+        except ValueError:
+            return True
+
+        current = self._workspace_fingerprint(workspace_path)
+        return stored != current
+
+    def get_projects(self) -> list[dict[str, Any]]:
+        """Return portfolio project metadata rows."""
+        self.open()
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT slug, path, status, doc_count, has_ontos, has_readme,
+                       last_scanned, last_modified, tags, metadata
+                FROM projects
+                ORDER BY slug
+                """
+            ).fetchall()
+
+        payload: list[dict[str, Any]] = []
+        for row in rows:
+            payload.append(
+                {
+                    "slug": row["slug"],
+                    "path": row["path"],
+                    "status": row["status"],
+                    "doc_count": int(row["doc_count"] or 0),
+                    "has_ontos": bool(row["has_ontos"]),
+                    "has_readme": bool(row["has_readme"]),
+                    "last_scanned": row["last_scanned"],
+                    "last_modified": row["last_modified"],
+                    "tags": self._safe_json_array(row["tags"]),
+                    "metadata": self._safe_json_object(row["metadata"]),
+                }
+            )
+        return payload
+
+    def search_fts(
+        self,
+        query: str,
+        workspace: str | None,
+        offset: int,
+        limit: int,
+    ) -> dict[str, Any]:
+        """Execute BM25-ranked full-text search over indexed documents."""
+        self.open()
+        if offset < 0:
+            raise OntosUserError("offset must be >= 0.", code="E_INVALID_OFFSET")
+        if limit <= 0:
+            raise OntosUserError("limit must be > 0.", code="E_INVALID_LIMIT")
+        if not query or not query.strip():
+            raise OntosUserError("query must be non-empty.", code="E_INVALID_QUERY")
+
+        with self._connect() as conn:
+            try:
+                conn.execute("BEGIN;")
+                where = "fts_content MATCH ?"
+                params: list[Any] = [query]
+                if workspace:
+                    where += " AND documents.workspace = ?"
+                    params.append(workspace)
+
+                total_count = conn.execute(
+                    f"""
+                    SELECT COUNT(*)
+                    FROM fts_content
+                    JOIN documents ON documents.rowid = fts_content.rowid
+                    WHERE {where}
+                    """,
+                    tuple(params),
+                ).fetchone()[0]
+
+                rows = conn.execute(
+                    f"""
+                    SELECT
+                        documents.workspace AS workspace,
+                        documents.id AS id,
+                        documents.type AS type,
+                        documents.status AS status,
+                        documents.path AS path,
+                        documents.title AS title,
+                        bm25(fts_content, 10.0, 3.0, 1.0) AS rank,
+                        snippet(fts_content, 2, '<mark>', '</mark>', '...', 32) AS snippet
+                    FROM fts_content
+                    JOIN documents ON documents.rowid = fts_content.rowid
+                    WHERE {where}
+                    ORDER BY rank
+                    LIMIT ? OFFSET ?
+                    """,
+                    tuple(params + [limit, offset]),
+                ).fetchall()
+                conn.commit()
+            except sqlite3.OperationalError as exc:
+                conn.rollback()
+                if self._is_invalid_fts_query(exc):
+                    raise OntosUserError("Malformed full-text query.", code="E_INVALID_QUERY") from exc
+                raise
+            except Exception:
+                conn.rollback()
+                raise
+
+        return {
+            "total_count": int(total_count),
+            "offset": offset,
+            "results": [
+                {
+                    "workspace": row["workspace"],
+                    "id": row["id"],
+                    "type": row["type"],
+                    "status": row["status"],
+                    "path": row["path"],
+                    "title": row["title"],
+                    "rank": float(row["rank"]) if row["rank"] is not None else 0.0,
+                    "snippet": row["snippet"] or "",
+                }
+                for row in rows
+            ],
+        }
+
+    def get_workspace_documents(self, slug: str) -> list[dict[str, Any]]:
+        """Return indexed document rows for one workspace."""
+        self.open()
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT
+                    id, workspace, type, status, path, title, curation,
+                    content_hash, word_count, concepts, last_modified
+                FROM documents
+                WHERE workspace = ?
+                ORDER BY id
+                """,
+                (slug,),
+            ).fetchall()
+        return [dict(row) for row in rows]
+
+    def _rebuild_workspace(
+        self,
+        slug: str,
+        workspace_root: Path,
+        *,
+        project: ProjectEntry | None,
+    ) -> None:
+        root = workspace_root.expanduser().resolve(strict=False)
+        has_ontos = (root / ".ontos.toml").exists()
+        has_readme = (root / "README.md").exists() or (root / "readme.md").exists()
+        snapshot = create_snapshot(
+            root=root,
+            include_content=True,
+            filters=None,
+            git_commit_provider=None,
+            scope=None,
+        )
+
+        with self._write_lock:
+            with self._connect() as conn:
+                conn.execute("BEGIN IMMEDIATE;")
+                rowids = [
+                    row[0]
+                    for row in conn.execute(
+                        "SELECT rowid FROM documents WHERE workspace = ?",
+                        (slug,),
+                    ).fetchall()
+                ]
+                if rowids:
+                    conn.executemany(
+                        "DELETE FROM fts_content WHERE rowid = ?",
+                        [(rowid,) for rowid in rowids],
+                    )
+                conn.execute(
+                    "DELETE FROM edges WHERE from_workspace = ? OR to_workspace = ?",
+                    (slug, slug),
+                )
+                conn.execute("DELETE FROM documents WHERE workspace = ?", (slug,))
+
+                doc_count = len(snapshot.documents)
+                status = project.status if project else self._classify_workspace(has_ontos, has_readme, doc_count)
+                tags = project.tags if project else []
+                metadata = project.metadata if project else {}
+
+                conn.execute(
+                    """
+                    INSERT INTO projects(
+                        slug, path, status, doc_count, has_ontos, has_readme,
+                        last_scanned, last_modified, tags, metadata
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(slug) DO UPDATE SET
+                        path = excluded.path,
+                        status = excluded.status,
+                        doc_count = excluded.doc_count,
+                        has_ontos = excluded.has_ontos,
+                        has_readme = excluded.has_readme,
+                        last_scanned = excluded.last_scanned,
+                        last_modified = excluded.last_modified,
+                        tags = excluded.tags,
+                        metadata = excluded.metadata
+                    """,
+                    (
+                        slug,
+                        str(root),
+                        status,
+                        doc_count,
+                        int(has_ontos),
+                        int(has_readme),
+                        self._iso_now(),
+                        self._path_mtime_iso(root),
+                        json.dumps(tags),
+                        json.dumps(metadata),
+                    ),
+                )
+
+                for doc in sorted(snapshot.documents.values(), key=lambda item: item.id):
+                    doc_path = doc.filepath.resolve(strict=False)
+                    try:
+                        rel_path = doc_path.relative_to(root).as_posix()
+                    except ValueError:
+                        rel_path = doc_path.name
+                    concepts = " ".join(term for term in doc.tags if term)
+                    cursor = conn.execute(
+                        """
+                        INSERT INTO documents(
+                            id, workspace, type, status, path, title, curation,
+                            content_hash, word_count, concepts, body, last_modified
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                        (
+                            doc.id,
+                            slug,
+                            doc.type.value,
+                            doc.status.value,
+                            rel_path,
+                            self._extract_title(doc.frontmatter),
+                            self._extract_curation(doc.frontmatter),
+                            _compute_content_hash(doc.content) if doc.content else None,
+                            len(doc.content.split()) if doc.content else 0,
+                            concepts,
+                            doc.content,
+                            self._path_mtime_iso(doc_path),
+                        ),
+                    )
+                    conn.execute(
+                        """
+                        INSERT INTO fts_content(rowid, title, concepts, body)
+                        VALUES (?, ?, ?, ?)
+                        """,
+                        (
+                            cursor.lastrowid,
+                            self._extract_title(doc.frontmatter) or "",
+                            concepts,
+                            doc.content or "",
+                        ),
+                    )
+
+                    for depends_id in sorted(set(doc.depends_on)):
+                        conn.execute(
+                            """
+                            INSERT OR IGNORE INTO edges(
+                                from_workspace, from_id, to_workspace, to_id, type
+                            ) VALUES (?, ?, ?, ?, 'depends_on')
+                            """,
+                            (slug, doc.id, slug, depends_id),
+                        )
+
+                conn.execute(
+                    """
+                    INSERT INTO scan_state(workspace, fingerprint, scanned_at)
+                    VALUES (?, ?, ?)
+                    ON CONFLICT(workspace) DO UPDATE SET
+                        fingerprint = excluded.fingerprint,
+                        scanned_at = excluded.scanned_at
+                    """,
+                    (
+                        slug,
+                        json.dumps(self._workspace_fingerprint(root), sort_keys=True),
+                        self._iso_now(),
+                    ),
+                )
+                conn.commit()
+
+                docs_count = conn.execute(
+                    "SELECT COUNT(*) FROM documents WHERE workspace = ?",
+                    (slug,),
+                ).fetchone()[0]
+                fts_count = conn.execute(
+                    """
+                    SELECT COUNT(*)
+                    FROM fts_content
+                    JOIN documents ON documents.rowid = fts_content.rowid
+                    WHERE documents.workspace = ?
+                    """,
+                    (slug,),
+                ).fetchone()[0]
+                if docs_count != fts_count:
+                    raise RuntimeError(
+                        f"FTS parity mismatch for {slug}: documents={docs_count}, fts={fts_count}"
+                    )
+
+                conn.execute("PRAGMA wal_checkpoint(PASSIVE);")
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(self.db_path))
+        conn.row_factory = sqlite3.Row
+        self._apply_pragmas(conn)
+        conn.execute("PRAGMA wal_autocheckpoint = 0;")
+        return conn
+
+    def _initialize_db(self, conn: sqlite3.Connection) -> None:
+        version = int(conn.execute("PRAGMA user_version;").fetchone()[0])
+        table_count = int(
+            conn.execute(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%';"
+            ).fetchone()[0]
+        )
+        if version == self.SCHEMA_VERSION:
+            return
+        if version == 0 and table_count == 0:
+            self._create_schema(conn)
+            return
+        raise sqlite3.DatabaseError(
+            f"Schema version mismatch: expected {self.SCHEMA_VERSION}, got {version}"
+        )
+
+    def _create_schema(self, conn: sqlite3.Connection) -> None:
+        conn.executescript(
+            """
+            CREATE TABLE projects (
+                slug         TEXT PRIMARY KEY,
+                path         TEXT NOT NULL UNIQUE,
+                status       TEXT NOT NULL,
+                doc_count    INTEGER DEFAULT 0,
+                has_ontos    BOOLEAN DEFAULT FALSE,
+                has_readme   BOOLEAN DEFAULT FALSE,
+                last_scanned TEXT,
+                last_modified TEXT,
+                tags         TEXT,
+                metadata     TEXT
+            );
+
+            CREATE TABLE documents (
+                id            TEXT NOT NULL,
+                workspace     TEXT NOT NULL REFERENCES projects(slug),
+                type          TEXT NOT NULL,
+                status        TEXT NOT NULL,
+                path          TEXT NOT NULL,
+                title         TEXT,
+                curation      TEXT,
+                content_hash  TEXT,
+                word_count    INTEGER,
+                concepts      TEXT,
+                body          TEXT,
+                last_modified TEXT,
+                PRIMARY KEY (workspace, id)
+            );
+
+            CREATE TABLE edges (
+                from_workspace TEXT NOT NULL,
+                from_id        TEXT NOT NULL,
+                to_workspace   TEXT NOT NULL,
+                to_id          TEXT NOT NULL,
+                type           TEXT NOT NULL DEFAULT 'depends_on',
+                PRIMARY KEY (from_workspace, from_id, to_workspace, to_id, type)
+            );
+
+            CREATE TABLE scan_state (
+                workspace   TEXT PRIMARY KEY REFERENCES projects(slug),
+                fingerprint TEXT NOT NULL,
+                scanned_at  TEXT NOT NULL
+            );
+
+            CREATE VIRTUAL TABLE fts_content USING fts5(
+                title,
+                concepts,
+                body,
+                tokenize='porter unicode61',
+                prefix='2,3'
+            );
+
+            INSERT INTO fts_content(fts_content, rank) VALUES('rank', 'bm25(10.0, 3.0, 1.0)');
+
+            CREATE INDEX idx_documents_workspace ON documents(workspace);
+            CREATE INDEX idx_documents_type ON documents(type);
+            CREATE INDEX idx_documents_status ON documents(status);
+            CREATE INDEX idx_edges_to ON edges(to_workspace, to_id);
+
+            PRAGMA user_version = 1;
+            """
+        )
+
+    def _reset_db_file(self) -> None:
+        try:
+            self.db_path.unlink()
+        except FileNotFoundError:
+            return
+
+    def _apply_pragmas(self, conn: sqlite3.Connection) -> None:
+        for statement in self.PRAGMA_BLOCK.splitlines():
+            line = statement.strip()
+            if not line:
+                continue
+            conn.execute(line)
+
+    @staticmethod
+    def _path_mtime_iso(path: Path) -> str | None:
+        try:
+            stat = path.stat()
+        except OSError:
+            return None
+        return datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat()
+
+    @staticmethod
+    def _iso_now() -> str:
+        return datetime.now(timezone.utc).isoformat()
+
+    @staticmethod
+    def _extract_title(frontmatter: dict[str, Any]) -> Optional[str]:
+        title = frontmatter.get("title")
+        return str(title) if isinstance(title, str) and title.strip() else None
+
+    @staticmethod
+    def _extract_curation(frontmatter: dict[str, Any]) -> Optional[str]:
+        value = frontmatter.get("curation")
+        return str(value) if value is not None else None
+
+    @staticmethod
+    def _classify_workspace(has_ontos: bool, has_readme: bool, doc_count: int) -> str:
+        if has_ontos and doc_count >= 5:
+            return "documented"
+        if (has_readme and not has_ontos) or (has_ontos and doc_count < 5):
+            return "partial"
+        return "undocumented"
+
+    @staticmethod
+    def _safe_json_array(raw_value: Any) -> list[str]:
+        if isinstance(raw_value, str):
+            try:
+                parsed = json.loads(raw_value)
+            except ValueError:
+                return []
+            if isinstance(parsed, list):
+                return [item for item in parsed if isinstance(item, str)]
+        return []
+
+    @staticmethod
+    def _safe_json_object(raw_value: Any) -> dict[str, Any]:
+        if isinstance(raw_value, str):
+            try:
+                parsed = json.loads(raw_value)
+            except ValueError:
+                return {}
+            if isinstance(parsed, dict):
+                return parsed
+        return {}
+
+    @staticmethod
+    def _is_invalid_fts_query(exc: sqlite3.OperationalError) -> bool:
+        message = str(exc).lower()
+        return (
+            "fts5" in message
+            or "malformed match expression" in message
+            or "syntax error" in message
+            or "unterminated string" in message
+            or "unknown special query" in message
+        )
+
+    @staticmethod
+    def _stat_fingerprint(path: Path) -> tuple[int, int] | None:
+        try:
+            stat = path.stat()
+        except OSError:
+            return None
+        return stat.st_mtime_ns, stat.st_size
+
+    def _workspace_fingerprint(self, workspace_root: Path) -> dict[str, list[int] | None]:
+        root = workspace_root.resolve(strict=False)
+        try:
+            config = load_project_config(config_path=root / ".ontos.toml", repo_root=root)
+            effective_scope = resolve_scan_scope(None, config.scanning.default_scope)
+            paths = collect_scoped_documents(
+                root,
+                config,
+                effective_scope,
+                base_skip_patterns=config.scanning.skip_patterns,
+            )
+        except Exception:
+            docs_dir = root / "docs"
+            if not docs_dir.is_dir():
+                return {}
+            paths = sorted(path for path in docs_dir.rglob("*.md") if path.is_file())
+
+        fingerprint: dict[str, list[int] | None] = {}
+        for path in sorted(paths):
+            rel_path = path.resolve(strict=False).relative_to(root).as_posix()
+            stat = self._stat_fingerprint(path)
+            fingerprint[rel_path] = [stat[0], stat[1]] if stat is not None else None
+        return fingerprint

--- a/ontos/mcp/portfolio_config.py
+++ b/ontos/mcp/portfolio_config.py
@@ -1,0 +1,89 @@
+"""Portfolio-mode configuration loading for Ontos MCP."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+try:  # Python 3.11+
+    import tomllib
+except ImportError:  # pragma: no cover - Python 3.10 fallback
+    import tomli as tomllib  # type: ignore
+
+
+@dataclass(frozen=True)
+class PortfolioConfig:
+    scan_roots: list[str] = field(default_factory=lambda: ["~/Dev"])
+    exclude: list[str] = field(default_factory=lambda: ["~/Dev/.dev-hub", "~/Dev/archive"])
+    registry_path: str | None = "~/Dev/.dev-hub/registry/projects.json"
+    bundle_token_budget: int = 8192
+    bundle_max_logs: int = 5
+    bundle_log_window_days: int = 14
+
+
+PORTFOLIO_CONFIG_PATH = Path.home() / ".config" / "ontos" / "portfolio.toml"
+
+_DEFAULT_CONFIG_TEXT = """[portfolio]
+scan_roots = ["~/Dev"]
+exclude = ["~/Dev/.dev-hub", "~/Dev/archive"]
+registry_path = "~/Dev/.dev-hub/registry/projects.json"
+
+[bundle]
+token_budget = 8192
+max_logs = 5
+log_window_days = 14
+"""
+
+
+def ensure_portfolio_config() -> Path:
+    """Ensure the portfolio config file exists and return its path."""
+    PORTFOLIO_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    if not PORTFOLIO_CONFIG_PATH.exists():
+        PORTFOLIO_CONFIG_PATH.write_text(_DEFAULT_CONFIG_TEXT, encoding="utf-8")
+    return PORTFOLIO_CONFIG_PATH
+
+
+def load_portfolio_config() -> PortfolioConfig:
+    """Load portfolio config from ~/.config/ontos/portfolio.toml."""
+    config_path = ensure_portfolio_config()
+    with config_path.open("rb") as handle:
+        data = tomllib.load(handle)
+
+    portfolio = data.get("portfolio", {}) if isinstance(data, dict) else {}
+    bundle = data.get("bundle", {}) if isinstance(data, dict) else {}
+    if not isinstance(portfolio, dict):
+        portfolio = {}
+    if not isinstance(bundle, dict):
+        bundle = {}
+
+    return PortfolioConfig(
+        scan_roots=_coerce_str_list(portfolio.get("scan_roots"), ["~/Dev"]),
+        exclude=_coerce_str_list(portfolio.get("exclude"), ["~/Dev/.dev-hub", "~/Dev/archive"]),
+        registry_path=_coerce_optional_str(portfolio.get("registry_path"), "~/Dev/.dev-hub/registry/projects.json"),
+        bundle_token_budget=_coerce_int(bundle.get("token_budget"), 8192),
+        bundle_max_logs=_coerce_int(bundle.get("max_logs"), 5),
+        bundle_log_window_days=_coerce_int(bundle.get("log_window_days"), 14),
+    )
+
+
+def _coerce_str_list(value: object, default: list[str]) -> list[str]:
+    if isinstance(value, list) and all(isinstance(item, str) for item in value):
+        return value
+    return list(default)
+
+
+def _coerce_optional_str(value: object, default: str | None) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return default
+
+
+def _coerce_int(value: object, default: int) -> int:
+    if isinstance(value, bool):
+        return default
+    if isinstance(value, int):
+        return value
+    return default
+

--- a/ontos/mcp/scanner.py
+++ b/ontos/mcp/scanner.py
@@ -151,6 +151,7 @@ def _load_registry_records(registry_path: Path | None) -> list[_RegistryRecord]:
     except (OSError, ValueError):
         return []
 
+    registry_root = _registry_root(raw, expanded.parent)
     items = _extract_registry_items(raw)
     results: list[_RegistryRecord] = []
     for item in items:
@@ -159,9 +160,11 @@ def _load_registry_records(registry_path: Path | None) -> list[_RegistryRecord]:
         path_text = _first_string(item, "path", "workspace", "root", "repo_root", "repoPath")
         if not path_text:
             continue
-        path = Path(path_text).expanduser().resolve(strict=False)
+        path = Path(path_text).expanduser()
         if not path.is_absolute():
-            path = (expanded.parent / path).resolve(strict=False)
+            path = (registry_root / path).resolve(strict=False)
+        else:
+            path = path.resolve(strict=False)
 
         status = item.get("status")
         tags = item.get("tags")
@@ -186,6 +189,14 @@ def _load_registry_records(registry_path: Path | None) -> list[_RegistryRecord]:
             )
         )
     return results
+
+
+def _registry_root(raw: object, default_root: Path) -> Path:
+    if isinstance(raw, dict):
+        dev_root = raw.get("dev_root")
+        if isinstance(dev_root, str) and dev_root.strip():
+            return Path(dev_root).expanduser().resolve(strict=False)
+    return default_root.resolve(strict=False)
 
 
 def _extract_registry_items(raw: object) -> list[object]:
@@ -260,4 +271,3 @@ def _allocate_slug(base_slug: str, used_slugs: dict[str, int]) -> str:
         return base_slug
     used_slugs[base_slug] += 1
     return f"{base_slug}-{used_slugs[base_slug]}"
-

--- a/ontos/mcp/scanner.py
+++ b/ontos/mcp/scanner.py
@@ -1,0 +1,263 @@
+"""Portfolio project discovery utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import re
+from typing import Any
+
+from ontos.io.snapshot import create_snapshot
+
+
+@dataclass(frozen=True)
+class ProjectEntry:
+    slug: str
+    path: Path
+    status: str
+    has_ontos: bool
+    has_readme: bool
+    doc_count: int
+    tags: list[str]
+    metadata: dict[str, Any]
+
+
+def slugify(directory_name: str) -> str:
+    """Convert a directory name to a URL-safe workspace slug."""
+    slug = directory_name.lower().replace(".", "-").replace(" ", "-")
+    slug = re.sub(r"[^a-z0-9-]+", "-", slug)
+    slug = re.sub(r"-{2,}", "-", slug).strip("-")
+    return slug or "workspace"
+
+
+def discover_projects(
+    scan_roots: list[Path],
+    exclude: list[str],
+    registry_path: Path | None,
+) -> list[ProjectEntry]:
+    """Discover candidate workspaces across scan roots and registry entries."""
+    exclude_prefixes, exclude_patterns = _compile_excludes(exclude)
+    registry_records = _load_registry_records(registry_path)
+
+    discovered_paths: set[Path] = set()
+    for scan_root in scan_roots:
+        root = scan_root.expanduser().resolve(strict=False)
+        if not root.is_dir():
+            continue
+        for candidate in sorted(root.iterdir()):
+            if not candidate.is_dir():
+                continue
+            resolved = candidate.resolve(strict=False)
+            if _is_excluded(resolved, exclude_prefixes, exclude_patterns):
+                continue
+            if (resolved / ".git").is_dir():
+                discovered_paths.add(resolved)
+
+    for registry_record in registry_records:
+        record_path = registry_record.path
+        if not record_path.exists() or not record_path.is_dir():
+            continue
+        if _is_excluded(record_path, exclude_prefixes, exclude_patterns):
+            continue
+        discovered_paths.add(record_path)
+
+    records_by_path = {record.path: record for record in registry_records}
+    used_slugs: dict[str, int] = {}
+    results: list[ProjectEntry] = []
+
+    for path in sorted(discovered_paths):
+        registry_record = records_by_path.get(path)
+        has_ontos = (path / ".ontos.toml").exists()
+        has_readme = (path / "README.md").exists() or (path / "readme.md").exists()
+        doc_count = _count_documents(path, has_ontos)
+
+        registry_tags = registry_record.tags if registry_record else []
+        registry_metadata = dict(registry_record.metadata) if registry_record else {}
+        status = _classify_status(
+            has_ontos=has_ontos,
+            has_readme=has_readme,
+            doc_count=doc_count,
+            metadata=registry_metadata,
+        )
+        if registry_record and registry_record.status:
+            status = registry_record.status
+
+        base_slug = slugify(path.name)
+        slug = _allocate_slug(base_slug, used_slugs)
+        results.append(
+            ProjectEntry(
+                slug=slug,
+                path=path,
+                status=status,
+                has_ontos=has_ontos,
+                has_readme=has_readme,
+                doc_count=doc_count,
+                tags=registry_tags,
+                metadata=registry_metadata,
+            )
+        )
+
+    return sorted(results, key=lambda item: item.slug)
+
+
+@dataclass(frozen=True)
+class _RegistryRecord:
+    path: Path
+    status: str | None
+    tags: list[str]
+    metadata: dict[str, Any]
+
+
+def _compile_excludes(exclude: list[str]) -> tuple[list[Path], list[str]]:
+    prefixes: list[Path] = []
+    patterns: list[str] = []
+    for raw in exclude:
+        text = raw.strip()
+        if not text:
+            continue
+        expanded = Path(text).expanduser()
+        if expanded.is_absolute():
+            prefixes.append(expanded.resolve(strict=False))
+        patterns.append(text)
+    return prefixes, patterns
+
+
+def _is_excluded(path: Path, exclude_prefixes: list[Path], exclude_patterns: list[str]) -> bool:
+    resolved = path.resolve(strict=False)
+    for prefix in exclude_prefixes:
+        if resolved == prefix or resolved.is_relative_to(prefix):
+            return True
+
+    posix_path = resolved.as_posix()
+    for pattern in exclude_patterns:
+        expanded = str(Path(pattern).expanduser())
+        if not expanded:
+            continue
+        if expanded in posix_path:
+            return True
+    return False
+
+
+def _load_registry_records(registry_path: Path | None) -> list[_RegistryRecord]:
+    if registry_path is None:
+        return []
+    expanded = registry_path.expanduser().resolve(strict=False)
+    if not expanded.exists():
+        return []
+
+    try:
+        raw = json.loads(expanded.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+
+    items = _extract_registry_items(raw)
+    results: list[_RegistryRecord] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        path_text = _first_string(item, "path", "workspace", "root", "repo_root", "repoPath")
+        if not path_text:
+            continue
+        path = Path(path_text).expanduser().resolve(strict=False)
+        if not path.is_absolute():
+            path = (expanded.parent / path).resolve(strict=False)
+
+        status = item.get("status")
+        tags = item.get("tags")
+        metadata = item.get("metadata")
+        archived = item.get("archived")
+
+        normalized_tags = [tag for tag in tags if isinstance(tag, str)] if isinstance(tags, list) else []
+        normalized_metadata = metadata if isinstance(metadata, dict) else {}
+        if isinstance(archived, bool):
+            normalized_metadata.setdefault("archived", archived)
+
+        normalized_status: str | None = status if isinstance(status, str) else None
+        if normalized_status is None and bool(normalized_metadata.get("archived")):
+            normalized_status = "archived"
+
+        results.append(
+            _RegistryRecord(
+                path=path,
+                status=normalized_status,
+                tags=normalized_tags,
+                metadata=normalized_metadata,
+            )
+        )
+    return results
+
+
+def _extract_registry_items(raw: object) -> list[object]:
+    if isinstance(raw, list):
+        return raw
+
+    if isinstance(raw, dict):
+        for key in ("projects", "workspaces", "entries", "items"):
+            value = raw.get(key)
+            if isinstance(value, list):
+                return value
+
+        dict_items: list[object] = []
+        for slug, payload in raw.items():
+            if not isinstance(payload, dict):
+                continue
+            merged = dict(payload)
+            merged.setdefault("slug", slug)
+            dict_items.append(merged)
+        return dict_items
+
+    return []
+
+
+def _first_string(item: dict[str, Any], *keys: str) -> str | None:
+    for key in keys:
+        value = item.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _count_documents(workspace_root: Path, has_ontos: bool) -> int:
+    if not has_ontos:
+        return 0
+
+    try:
+        snapshot = create_snapshot(
+            root=workspace_root,
+            include_content=False,
+            filters=None,
+            git_commit_provider=None,
+            scope=None,
+        )
+        return len(snapshot.documents)
+    except Exception:
+        docs_dir = workspace_root / "docs"
+        if not docs_dir.is_dir():
+            return 0
+        return sum(1 for path in docs_dir.rglob("*.md") if path.is_file() and not path.name.startswith("_"))
+
+
+def _classify_status(
+    *,
+    has_ontos: bool,
+    has_readme: bool,
+    doc_count: int,
+    metadata: dict[str, Any],
+) -> str:
+    if bool(metadata.get("archived")):
+        return "archived"
+    if has_ontos and doc_count >= 5:
+        return "documented"
+    if (has_readme and not has_ontos) or (has_ontos and doc_count < 5):
+        return "partial"
+    return "undocumented"
+
+
+def _allocate_slug(base_slug: str, used_slugs: dict[str, int]) -> str:
+    if base_slug not in used_slugs:
+        used_slugs[base_slug] = 1
+        return base_slug
+    used_slugs[base_slug] += 1
+    return f"{base_slug}-{used_slugs[base_slug]}"
+

--- a/ontos/mcp/scanner.py
+++ b/ontos/mcp/scanner.py
@@ -23,6 +23,15 @@ class ProjectEntry:
     metadata: dict[str, Any]
 
 
+@dataclass(frozen=True)
+class RegistryRecord:
+    path: Path
+    status: str | None
+    tags: list[str]
+    metadata: dict[str, Any]
+    has_ontos_raw: object | None
+
+
 def slugify(directory_name: str) -> str:
     """Convert a directory name to a URL-safe workspace slug."""
     slug = directory_name.lower().replace(".", "-").replace(" ", "-")
@@ -38,7 +47,7 @@ def discover_projects(
 ) -> list[ProjectEntry]:
     """Discover candidate workspaces across scan roots and registry entries."""
     exclude_prefixes, exclude_patterns = _compile_excludes(exclude)
-    registry_records = _load_registry_records(registry_path)
+    registry_records = load_registry_records(registry_path)
 
     discovered_paths: set[Path] = set()
     for scan_root in scan_roots:
@@ -84,7 +93,7 @@ def discover_projects(
             status = registry_record.status
 
         base_slug = slugify(path.name)
-        slug = _allocate_slug(base_slug, used_slugs)
+        slug = allocate_slug(base_slug, used_slugs)
         results.append(
             ProjectEntry(
                 slug=slug,
@@ -99,14 +108,6 @@ def discover_projects(
         )
 
     return sorted(results, key=lambda item: item.slug)
-
-
-@dataclass(frozen=True)
-class _RegistryRecord:
-    path: Path
-    status: str | None
-    tags: list[str]
-    metadata: dict[str, Any]
 
 
 def _compile_excludes(exclude: list[str]) -> tuple[list[Path], list[str]]:
@@ -139,7 +140,11 @@ def _is_excluded(path: Path, exclude_prefixes: list[Path], exclude_patterns: lis
     return False
 
 
-def _load_registry_records(registry_path: Path | None) -> list[_RegistryRecord]:
+def load_registry_records(
+    registry_path: Path | None,
+    *,
+    tolerate_errors: bool = True,
+) -> list[RegistryRecord]:
     if registry_path is None:
         return []
     expanded = registry_path.expanduser().resolve(strict=False)
@@ -149,11 +154,13 @@ def _load_registry_records(registry_path: Path | None) -> list[_RegistryRecord]:
     try:
         raw = json.loads(expanded.read_text(encoding="utf-8"))
     except (OSError, ValueError):
-        return []
+        if tolerate_errors:
+            return []
+        raise
 
     registry_root = _registry_root(raw, expanded.parent)
     items = _extract_registry_items(raw)
-    results: list[_RegistryRecord] = []
+    results: list[RegistryRecord] = []
     for item in items:
         if not isinstance(item, dict):
             continue
@@ -181,14 +188,20 @@ def _load_registry_records(registry_path: Path | None) -> list[_RegistryRecord]:
             normalized_status = "archived"
 
         results.append(
-            _RegistryRecord(
+            RegistryRecord(
                 path=path,
                 status=normalized_status,
                 tags=normalized_tags,
                 metadata=normalized_metadata,
+                has_ontos_raw=item.get("has_ontos") if "has_ontos" in item else None,
             )
         )
     return results
+
+
+def _load_registry_records(registry_path: Path | None) -> list[RegistryRecord]:
+    """Backward-compatible alias for internal callers."""
+    return load_registry_records(registry_path)
 
 
 def _registry_root(raw: object, default_root: Path) -> Path:
@@ -265,9 +278,14 @@ def _classify_status(
     return "undocumented"
 
 
-def _allocate_slug(base_slug: str, used_slugs: dict[str, int]) -> str:
+def allocate_slug(base_slug: str, used_slugs: dict[str, int]) -> str:
     if base_slug not in used_slugs:
         used_slugs[base_slug] = 1
         return base_slug
     used_slugs[base_slug] += 1
     return f"{base_slug}-{used_slugs[base_slug]}"
+
+
+def _allocate_slug(base_slug: str, used_slugs: dict[str, int]) -> str:
+    """Backward-compatible alias for internal callers."""
+    return allocate_slug(base_slug, used_slugs)

--- a/ontos/mcp/schemas.py
+++ b/ontos/mcp/schemas.py
@@ -54,6 +54,19 @@ class ToolErrorEnvelope(StrictModel):
     content: List[ToolErrorTextItem]
 
 
+class WriteToolError(StrictModel):
+    error_code: str
+    what: str
+    why: str
+    fix: str
+
+
+class WriteToolErrorEnvelope(StrictModel):
+    isError: Literal[True]
+    error: WriteToolError
+    content: List[ToolErrorTextItem]
+
+
 class KeyDocumentItem(StrictModel):
     id: str
     title: str
@@ -180,6 +193,93 @@ class RefreshResponse(StrictModel):
     duration_ms: int
 
 
+class ProjectItem(StrictModel):
+    slug: str
+    path: str
+    status: str
+    doc_count: int
+    last_updated: Optional[str]
+    tags: List[str]
+    has_ontos: bool
+
+
+class ProjectRegistryResponse(StrictModel):
+    project_count: int
+    projects: List[ProjectItem]
+    summary: str
+
+
+class SearchResultItem(StrictModel):
+    doc_id: str
+    workspace_slug: str
+    type: str
+    status: str
+    path: str
+    snippet: str
+    score: float
+
+
+class SearchResponse(StrictModel):
+    total_hits: int
+    results: List[SearchResultItem]
+
+
+class BundleDocumentItem(StrictModel):
+    id: str
+    type: str
+    score: float
+    token_estimate: int
+
+
+class StaleDocumentItem(StrictModel):
+    id: str
+    reason: str
+
+
+class GetContextBundleResponse(StrictModel):
+    workspace_id: str
+    workspace_slug: str
+    token_estimate: int
+    document_count: int
+    bundle_text: str
+    included_documents: List[BundleDocumentItem]
+    excluded_count: int
+    stale_documents: List[StaleDocumentItem]
+    warnings: List[str]
+
+
+class ScaffoldDocumentResponse(StrictModel):
+    success: Literal[True]
+    path: str
+    id: str
+    type: str
+    status: str
+    curation_level: str
+
+
+class RenameDocumentResponse(StrictModel):
+    success: Literal[True]
+    old_id: str
+    new_id: str
+    path: str
+    references_updated: int
+    updated_files: List[str]
+
+
+class LogSessionResponse(StrictModel):
+    success: Literal[True]
+    path: str
+    id: str
+    date: str
+
+
+class PromoteDocumentResponse(StrictModel):
+    success: Literal[True]
+    document_id: str
+    old_level: str
+    new_level: str
+
+
 TOOL_SUCCESS_MODELS: Dict[str, Type[BaseModel]] = {
     "workspace_overview": WorkspaceOverviewResponse,
     "context_map": ContextMapResponse,
@@ -189,6 +289,9 @@ TOOL_SUCCESS_MODELS: Dict[str, Type[BaseModel]] = {
     "query": QueryResponse,
     "health": HealthResponse,
     "refresh": RefreshResponse,
+    "project_registry": ProjectRegistryResponse,
+    "search": SearchResponse,
+    "get_context_bundle": GetContextBundleResponse,
 }
 
 TOOL_OUTPUT_SCHEMAS: Dict[str, Dict[str, Any]] = {
@@ -196,7 +299,12 @@ TOOL_OUTPUT_SCHEMAS: Dict[str, Dict[str, Any]] = {
     for name, model in TOOL_SUCCESS_MODELS.items()
 }
 
-TOOL_ERROR_SCHEMA: Dict[str, Any] = ToolErrorEnvelope.model_json_schema(by_alias=True)
+TOOL_ERROR_SCHEMA: Dict[str, Any] = {
+    "oneOf": [
+        ToolErrorEnvelope.model_json_schema(by_alias=True),
+        WriteToolErrorEnvelope.model_json_schema(by_alias=True),
+    ]
+}
 EXPORT_GRAPH_ADAPTER = TypeAdapter(
     Union[ExportGraphSummaryResponse, ExportGraphFullResponse, ExportGraphFileResponse]
 )

--- a/ontos/mcp/server.py
+++ b/ontos/mcp/server.py
@@ -1,4 +1,4 @@
-"""FastMCP bootstrap, registration, and shared tool wrapper for Ontos."""
+"""FastMCP bootstrap, registration, and shared tool wrappers for Ontos."""
 
 from __future__ import annotations
 
@@ -23,6 +23,17 @@ from ontos.mcp import tools as tool_impl
 
 
 DEFAULT_USAGE_LOG_PATH = "~/.config/ontos/usage.jsonl"
+DEFAULT_PORTFOLIO_DB_PATH = Path.home() / ".config" / "ontos" / "portfolio.db"
+CORE_TOOL_NAMES = {
+    "workspace_overview",
+    "context_map",
+    "get_document",
+    "list_documents",
+    "export_graph",
+    "query",
+    "health",
+    "refresh",
+}
 
 
 class OntosFastMCP(FastMCP):
@@ -52,38 +63,60 @@ class OntosFastMCP(FastMCP):
         ]
 
 
-def serve(workspace_root: Path) -> int:
-    """Build the cache and start the stdio MCP runtime."""
+def serve(
+    workspace_root: Path,
+    *,
+    portfolio: bool = False,
+    read_only: bool = False,
+) -> int:
+    """Build cache/index state and start the stdio MCP runtime."""
+    _ = read_only
     workspace_root = workspace_root.resolve()
-    config = load_project_config(
-        config_path=workspace_root / ".ontos.toml",
-        repo_root=workspace_root,
-    )
-    snapshot = create_snapshot(
-        root=workspace_root,
-        include_content=True,
-        filters=None,
-        git_commit_provider=_git_commit_provider(workspace_root),
-        scope=None,
-    )
-    cache = SnapshotCache(
-        workspace_root,
-        config,
-        snapshot,
-        git_commit_provider=_git_commit_provider(workspace_root),
-        started_at=datetime.now(timezone.utc),
-    )
-    server = create_server(cache)
-    server.run(transport="stdio")
-    return 0
+    cache = _build_cache(workspace_root)
+
+    portfolio_index: Any = None
+    try:
+        if portfolio:
+            portfolio_index = _build_portfolio_index()
+        server = create_server(
+            cache,
+            portfolio_index=portfolio_index,
+            read_only=read_only,
+            include_bundle_tool=True,
+        )
+        server.run(transport="stdio")
+        return 0
+    finally:
+        if portfolio_index is not None:
+            close = getattr(portfolio_index, "close", None)
+            if callable(close):
+                close()
 
 
-def create_server(cache: SnapshotCache) -> FastMCP:
-    """Create and register the Ontos MCP server for one workspace."""
+def create_server(
+    cache: SnapshotCache,
+    *,
+    portfolio_index: Any = None,
+    read_only: bool = False,
+    include_bundle_tool: bool = False,
+) -> FastMCP:
+    """Create and register the Ontos MCP server."""
+    _ = read_only
     workspace_name = cache.workspace_root.name
+    portfolio_mode = portfolio_index is not None
+
+    # Tool implementations infer scope behavior from these cache attributes.
+    setattr(cache, "portfolio_mode", portfolio_mode)
+    setattr(cache, "portfolio_index", portfolio_index)
+    setattr(cache, "primary_workspace_slug", _workspace_slug(cache.workspace_root))
+
     server = OntosFastMCP(
         name="Ontos",
-        instructions=_render_instructions(cache),
+        instructions=_render_instructions(
+            cache,
+            portfolio_mode=portfolio_mode,
+            include_bundle_tool=include_bundle_tool,
+        ),
         log_level="ERROR",
     )
 
@@ -106,29 +139,71 @@ def create_server(cache: SnapshotCache) -> FastMCP:
         )(handler)
         server.set_output_schema(name, output_schema_for(name))
 
-    def handle_workspace_overview() -> CallToolResult:
-        return _invoke_tool("workspace_overview", cache, tool_impl.workspace_overview)
+    _register_core_tools(
+        cache=cache,
+        workspace_name=workspace_name,
+        register_fn=register,
+    )
 
-    def handle_context_map(compact: str = "tiered") -> CallToolResult:
-        return _invoke_tool(
+    if portfolio_index is not None:
+        _register_portfolio_tools(
+            cache=cache,
+            portfolio_index=portfolio_index,
+            register_fn=register,
+        )
+
+    if include_bundle_tool:
+        _register_bundle_tool(
+            cache=cache,
+            portfolio_index=portfolio_index,
+            register_fn=register,
+        )
+
+    return server
+
+
+def _register_core_tools(
+    *,
+    cache: SnapshotCache,
+    workspace_name: str,
+    register_fn: Callable[..., None],
+) -> None:
+    def handle_workspace_overview(
+        workspace_id: str | None = None,
+    ) -> CallToolResult:
+        return _invoke_read_tool(
+            "workspace_overview",
+            cache,
+            tool_impl.workspace_overview,
+            workspace_id=workspace_id,
+        )
+
+    def handle_context_map(
+        compact: str = "tiered",
+        workspace_id: str | None = None,
+    ) -> CallToolResult:
+        return _invoke_read_tool(
             "context_map",
             cache,
             tool_impl.context_map,
             compact=compact,
+            workspace_id=workspace_id,
         )
 
     def handle_get_document(
         document_id: str | None = None,
         path: str | None = None,
         include_content: bool = True,
+        workspace_id: str | None = None,
     ) -> CallToolResult:
-        return _invoke_tool(
+        return _invoke_read_tool(
             "get_document",
             cache,
             tool_impl.get_document,
             document_id=document_id,
             path=path,
             include_content=include_content,
+            workspace_id=workspace_id,
         )
 
     def handle_list_documents(
@@ -136,8 +211,9 @@ def create_server(cache: SnapshotCache) -> FastMCP:
         status: str | None = None,
         offset: int = 0,
         limit: int = 100,
+        workspace_id: str | None = None,
     ) -> CallToolResult:
-        return _invoke_tool(
+        return _invoke_read_tool(
             "list_documents",
             cache,
             tool_impl.list_documents,
@@ -145,41 +221,54 @@ def create_server(cache: SnapshotCache) -> FastMCP:
             status=status,
             offset=offset,
             limit=limit,
+            workspace_id=workspace_id,
         )
 
     def handle_export_graph(
         summary_only: bool = True,
         export_to_file: str | None = None,
+        workspace_id: str | None = None,
     ) -> CallToolResult:
-        return _invoke_tool(
+        return _invoke_read_tool(
             "export_graph",
             cache,
             tool_impl.export_graph,
             summary_only=summary_only,
             export_to_file=export_to_file,
+            workspace_id=workspace_id,
         )
 
-    def handle_query(entity_id: str) -> CallToolResult:
-        return _invoke_tool(
+    def handle_query(
+        entity_id: str,
+        workspace_id: str | None = None,
+    ) -> CallToolResult:
+        return _invoke_read_tool(
             "query",
             cache,
             tool_impl.query,
             entity_id=entity_id,
+            workspace_id=workspace_id,
         )
 
-    def handle_health() -> CallToolResult:
-        return _invoke_tool("health", cache, tool_impl.health)
+    def handle_health(workspace_id: str | None = None) -> CallToolResult:
+        return _invoke_read_tool(
+            "health",
+            cache,
+            tool_impl.health,
+            workspace_id=workspace_id,
+        )
 
-    def handle_refresh() -> CallToolResult:
-        return _invoke_tool(
+    def handle_refresh(workspace_id: str | None = None) -> CallToolResult:
+        return _invoke_read_tool(
             "refresh",
             cache,
             tool_impl.refresh,
             ensure_fresh=False,
             use_live_cache=True,
+            workspace_id=workspace_id,
         )
 
-    register(
+    register_fn(
         name="workspace_overview",
         title="Workspace Overview",
         description=f"Returns a structured overview of the {workspace_name} workspace.",
@@ -187,7 +276,7 @@ def create_server(cache: SnapshotCache) -> FastMCP:
         annotations=_readonly_annotations(),
         meta={"anthropic/maxResultSizeChars": 4000},
     )
-    register(
+    register_fn(
         name="context_map",
         title="Context Map",
         description=f"Returns the context map for the {workspace_name} workspace.",
@@ -195,7 +284,7 @@ def create_server(cache: SnapshotCache) -> FastMCP:
         annotations=_readonly_annotations(),
         meta={"anthropic/maxResultSizeChars": 64000},
     )
-    register(
+    register_fn(
         name="get_document",
         title="Get Document",
         description=f"Returns a canonical Ontos document from the {workspace_name} workspace.",
@@ -203,7 +292,7 @@ def create_server(cache: SnapshotCache) -> FastMCP:
         annotations=_readonly_annotations(),
         meta={"anthropic/maxResultSizeChars": 120000},
     )
-    register(
+    register_fn(
         name="list_documents",
         title="List Documents",
         description=f"Lists canonical Ontos documents from the {workspace_name} workspace.",
@@ -211,7 +300,7 @@ def create_server(cache: SnapshotCache) -> FastMCP:
         annotations=_readonly_annotations(),
         meta={"anthropic/maxResultSizeChars": 32000},
     )
-    register(
+    register_fn(
         name="export_graph",
         title="Export Graph",
         description=f"Exports the canonical Ontos graph for the {workspace_name} workspace.",
@@ -224,15 +313,17 @@ def create_server(cache: SnapshotCache) -> FastMCP:
         ),
         meta={"anthropic/maxResultSizeChars": 200000},
     )
-    register(
+    register_fn(
         name="query",
         title="Query Document",
-        description=f"Returns dependency details for one canonical document in the {workspace_name} workspace.",
+        description=(
+            f"Returns dependency details for one canonical document in the {workspace_name} workspace."
+        ),
         handler=handle_query,
         annotations=_readonly_annotations(),
         meta={"anthropic/maxResultSizeChars": 8000},
     )
-    register(
+    register_fn(
         name="health",
         title="Server Health",
         description=f"Returns cache and runtime health for the {workspace_name} workspace.",
@@ -240,10 +331,7 @@ def create_server(cache: SnapshotCache) -> FastMCP:
         annotations=_readonly_annotations(),
         meta={"anthropic/maxResultSizeChars": 4000},
     )
-    # Keep these hints false: refresh mutates observable server state
-    # (`snapshot_revision`, `last_indexed`, and cached snapshot contents)
-    # even though it does not write workspace files.
-    register(
+    register_fn(
         name="refresh",
         title="Refresh Cache",
         description=f"Rebuilds the in-memory Ontos snapshot for the {workspace_name} workspace.",
@@ -256,10 +344,123 @@ def create_server(cache: SnapshotCache) -> FastMCP:
         ),
         meta={"anthropic/maxResultSizeChars": 4000},
     )
-    return server
 
 
-def _invoke_tool(
+def _register_portfolio_tools(
+    *,
+    cache: SnapshotCache,
+    portfolio_index: Any,
+    register_fn: Callable[..., None],
+) -> None:
+    def handle_project_registry(workspace_id: str | None = None) -> CallToolResult:
+        _ = workspace_id
+        return _invoke_portfolio_tool(
+            "project_registry",
+            portfolio_index,
+            tool_impl.project_registry,
+            cache=cache,
+        )
+
+    def handle_search(
+        query_string: str,
+        workspace_id: str | None = None,
+        offset: int = 0,
+        limit: int = 20,
+    ) -> CallToolResult:
+        return _invoke_portfolio_tool(
+            "search",
+            portfolio_index,
+            tool_impl.search,
+            cache=cache,
+            query_string=query_string,
+            workspace_id=workspace_id,
+            offset=offset,
+            limit=limit,
+        )
+
+    register_fn(
+        name="project_registry",
+        title="Project Registry",
+        description="Returns indexed portfolio project metadata.",
+        handler=handle_project_registry,
+        annotations=_readonly_annotations(),
+        meta={"anthropic/maxResultSizeChars": 32000},
+    )
+    register_fn(
+        name="search",
+        title="Search Portfolio",
+        description="Searches indexed portfolio documents using full-text search.",
+        handler=handle_search,
+        annotations=_readonly_annotations(),
+        meta={"anthropic/maxResultSizeChars": 120000},
+    )
+
+
+def _register_bundle_tool(
+    *,
+    cache: SnapshotCache,
+    portfolio_index: Any,
+    register_fn: Callable[..., None],
+) -> None:
+    if portfolio_index is None:
+        def handle_get_context_bundle(
+            workspace_id: str | None = None,
+            token_budget: int = 8192,
+        ) -> CallToolResult:
+            return _invoke_read_tool(
+                "get_context_bundle",
+                cache,
+                _get_context_bundle_single_workspace,
+                ensure_fresh=False,
+                use_live_cache=True,
+                workspace_id=workspace_id,
+                token_budget=token_budget,
+            )
+    else:
+        def handle_get_context_bundle(
+            workspace_id: str | None = None,
+            token_budget: int = 8192,
+        ) -> CallToolResult:
+            return _invoke_portfolio_tool(
+                "get_context_bundle",
+                portfolio_index,
+                tool_impl.get_context_bundle,
+                cache=cache,
+                cache_input=cache,
+                workspace_id=workspace_id,
+                token_budget=token_budget,
+            )
+
+    register_fn(
+        name="get_context_bundle",
+        title="Get Context Bundle",
+        description="Returns a token-budgeted context package for a workspace.",
+        handler=handle_get_context_bundle,
+        annotations=ToolAnnotations(
+            readOnlyHint=True,
+            destructiveHint=False,
+            idempotentHint=False,
+            openWorldHint=False,
+        ),
+        meta={"anthropic/maxResultSizeChars": 200000},
+    )
+
+
+def _get_context_bundle_single_workspace(
+    cache: SnapshotCache,
+    *,
+    workspace_id: str | None = None,
+    token_budget: int = 8192,
+) -> dict[str, Any]:
+    return tool_impl.get_context_bundle(
+        None,
+        cache,
+        workspace_id=workspace_id,
+        token_budget=token_budget,
+    )
+
+
+def _invoke_read_tool(
     tool_name: str,
     cache: SnapshotCache,
     tool_fn: Callable[..., Dict[str, Any]],
@@ -272,8 +473,17 @@ def _invoke_tool(
         _log_usage(cache, tool_name)
     except Exception:
         traceback.print_exc(file=sys.stderr)
+
+    workspace_id = kwargs.get("workspace_id")
+    if _is_cross_workspace_read(tool_name, cache, workspace_id):
+        return _tool_error_result(
+            "E_CROSS_WORKSPACE_NOT_SUPPORTED: Cross-workspace reads are not "
+            "supported for this tool. Start a separate `ontos serve` in the "
+            "target workspace."
+        )
+
     try:
-        tool_input = cache.current_view()
+        tool_input: Any = cache.current_view()
         if ensure_fresh:
             tool_input = cache.get_fresh_view()
         if use_live_cache:
@@ -291,6 +501,65 @@ def _invoke_tool(
     except Exception:
         traceback.print_exc(file=sys.stderr)
         return _tool_error_result(f"Internal error in {tool_name}")
+
+
+def _invoke_portfolio_tool(
+    tool_name: str,
+    portfolio_index: Any,
+    tool_fn: Callable[..., Dict[str, Any]],
+    *,
+    cache: SnapshotCache | None = None,
+    **kwargs: Any,
+) -> Union[Dict[str, Any], CallToolResult]:
+    if portfolio_index is None:
+        return _tool_error_result(
+            "E_PORTFOLIO_REQUIRED: Tool is available only in portfolio mode."
+        )
+
+    try:
+        if cache is not None:
+            _log_usage(cache, tool_name)
+    except Exception:
+        traceback.print_exc(file=sys.stderr)
+
+    try:
+        cache_input = kwargs.pop("cache_input", None)
+        if cache_input is None:
+            payload = tool_fn(portfolio_index, **kwargs)
+        else:
+            payload = tool_fn(portfolio_index, cache_input, **kwargs)
+        validated = validate_success_payload(tool_name, payload)
+        return _tool_success_result(validated)
+    except OntosUserError as exc:
+        return _tool_error_result(str(exc))
+    except OntosInternalError as exc:
+        print(f"[ontos-mcp] {exc.code}: {exc}", file=sys.stderr)
+        if exc.details:
+            print(exc.details, file=sys.stderr)
+        return _tool_error_result(f"Internal error: {exc}")
+    except Exception:
+        traceback.print_exc(file=sys.stderr)
+        return _tool_error_result(f"Internal error in {tool_name}")
+
+
+def _invoke_tool(
+    tool_name: str,
+    cache: SnapshotCache,
+    tool_fn: Callable[..., Dict[str, Any]],
+    *,
+    ensure_fresh: bool = True,
+    use_live_cache: bool = False,
+    **kwargs: Any,
+) -> Union[Dict[str, Any], CallToolResult]:
+    """Legacy wrapper retained for existing tests and imports."""
+    return _invoke_read_tool(
+        tool_name,
+        cache,
+        tool_fn,
+        ensure_fresh=ensure_fresh,
+        use_live_cache=use_live_cache,
+        **kwargs,
+    )
 
 
 def _tool_error_result(message: str) -> CallToolResult:
@@ -327,11 +596,16 @@ def _readonly_annotations() -> ToolAnnotations:
     )
 
 
-def _render_instructions(cache: SnapshotCache) -> str:
+def _render_instructions(
+    cache: SnapshotCache,
+    *,
+    portfolio_mode: bool,
+    include_bundle_tool: bool,
+) -> str:
     workspace_name = cache.workspace_root.name
     doc_count = cache.canonical_view.total_count
     last_indexed_relative = _relative_time(cache.last_indexed)
-    return (
+    instructions = (
         f"Ontos is a documentation knowledge graph for {workspace_name} "
         f"({doc_count} documents, last indexed {last_indexed_relative}). "
         "It tracks architecture docs, strategy decisions, and technical "
@@ -340,18 +614,24 @@ def _render_instructions(cache: SnapshotCache) -> str:
         "product (user-facing specs), atom (technical implementation docs), "
         "and log (session history). All tools are deterministic, local-only, "
         "and fast (<100ms cached after warmup). "
-        "Start with `workspace_overview` for project orientation \u2014 it returns "
-        "deterministic IDs, key documents, graph stats, and warnings in a "
-        "structured response under ~1KB. "
-        "Use `context_map` when you need the full human-readable markdown narrative. "
-        "Use `get_document` to read a specific document's content. "
-        "Use `list_documents` to browse the full document set with optional "
-        "type/status filters. "
-        "Use `query` for single-entity dependency lookups. "
-        "Use `export_graph` for structured graph export; `export_to_file` writes "
-        "a JSON dump inside the workspace. "
+        "Start with `workspace_overview` for project orientation. "
+        "Use `context_map` for the full markdown narrative. "
+        "Use `get_document` to read one document. "
+        "Use `list_documents` to browse by type/status. "
+        "Use `query` for dependency lookups. "
+        "Use `export_graph` for structured graph export. "
         "Use `health` to check server status and index freshness."
     )
+    if include_bundle_tool:
+        instructions += (
+            " Use `get_context_bundle` to assemble a token-budgeted context bundle."
+        )
+    if portfolio_mode:
+        instructions += (
+            " Portfolio mode also enables `project_registry` and `search` for "
+            "cross-workspace discovery."
+        )
+    return instructions
 
 
 def _relative_time(value: datetime) -> str:
@@ -398,3 +678,71 @@ def _git_commit_provider(workspace_root: Path) -> Callable[[], Optional[str]]:
         return result.stdout.strip() or None
 
     return provider
+
+
+def _build_cache(workspace_root: Path) -> SnapshotCache:
+    config = load_project_config(
+        config_path=workspace_root / ".ontos.toml",
+        repo_root=workspace_root,
+    )
+    snapshot = create_snapshot(
+        root=workspace_root,
+        include_content=True,
+        filters=None,
+        git_commit_provider=_git_commit_provider(workspace_root),
+        scope=None,
+    )
+    return SnapshotCache(
+        workspace_root,
+        config,
+        snapshot,
+        git_commit_provider=_git_commit_provider(workspace_root),
+        started_at=datetime.now(timezone.utc),
+    )
+
+
+def _build_portfolio_index() -> Any:
+    from ontos.mcp.portfolio import PortfolioIndex
+    from ontos.mcp.portfolio_config import load_portfolio_config
+
+    config = load_portfolio_config()
+    scan_roots = [Path(path).expanduser() for path in config.scan_roots]
+    registry_path = (
+        Path(config.registry_path).expanduser()
+        if config.registry_path
+        else None
+    )
+    index = PortfolioIndex(DEFAULT_PORTFOLIO_DB_PATH)
+    index.open()
+    index.rebuild_all(
+        scan_roots=scan_roots,
+        exclude=list(config.exclude),
+        registry_path=registry_path,
+    )
+    return index
+
+
+def _workspace_slug(workspace_root: Path) -> str:
+    try:
+        from ontos.mcp.scanner import slugify
+    except Exception:
+        slugify = None
+    if slugify is not None:
+        return slugify(workspace_root.name)
+    lowered = workspace_root.name.strip().lower()
+    parts = [char if char.isalnum() else "-" for char in lowered]
+    return "".join(parts).strip("-") or "workspace"
+
+
+def _is_cross_workspace_read(
+    tool_name: str,
+    cache: SnapshotCache,
+    workspace_id: Any,
+) -> bool:
+    if workspace_id is None:
+        return False
+    if tool_name not in CORE_TOOL_NAMES:
+        return False
+    if not getattr(cache, "portfolio_mode", False):
+        return False
+    return str(workspace_id) != _workspace_slug(cache.workspace_root)

--- a/ontos/mcp/server.py
+++ b/ontos/mcp/server.py
@@ -12,12 +12,14 @@ from typing import Any, Callable, Dict, Optional, Union
 
 import ontos
 from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
 from mcp.types import CallToolResult, TextContent, Tool as MCPTool, ToolAnnotations
 
 from ontos.core.errors import OntosInternalError, OntosUserError
 from ontos.io.config import load_project_config
 from ontos.io.snapshot import create_snapshot
 from ontos.mcp.cache import SnapshotCache
+from ontos.mcp.scanner import slugify
 from ontos.mcp.schemas import ToolErrorEnvelope, output_schema_for, validate_success_payload
 from ontos.mcp import tools as tool_impl
 
@@ -34,6 +36,7 @@ CORE_TOOL_NAMES = {
     "health",
     "refresh",
 }
+PORTFOLIO_MODE_TOOL_NAMES = {"project_registry", "search"}
 
 
 class OntosFastMCP(FastMCP):
@@ -61,6 +64,19 @@ class OntosFastMCP(FastMCP):
             )
             for info in tools
         ]
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> Any:
+        try:
+            return await super().call_tool(name, arguments)
+        except ToolError as exc:
+            if (
+                name in PORTFOLIO_MODE_TOOL_NAMES
+                and str(exc).startswith("Unknown tool:")
+            ):
+                return _tool_error_result(
+                    "E_PORTFOLIO_REQUIRED: Tool is available only in portfolio mode."
+                )
+            raise
 
 
 def serve(
@@ -723,15 +739,7 @@ def _build_portfolio_index() -> Any:
 
 
 def _workspace_slug(workspace_root: Path) -> str:
-    try:
-        from ontos.mcp.scanner import slugify
-    except Exception:
-        slugify = None
-    if slugify is not None:
-        return slugify(workspace_root.name)
-    lowered = workspace_root.name.strip().lower()
-    parts = [char if char.isalnum() else "-" for char in lowered]
-    return "".join(parts).strip("-") or "workspace"
+    return slugify(workspace_root.name)
 
 
 def _is_cross_workspace_read(

--- a/ontos/mcp/tools.py
+++ b/ontos/mcp/tools.py
@@ -16,6 +16,7 @@ from ontos.core.errors import OntosUserError
 from ontos.core.snapshot import DocumentSnapshot
 from ontos.core.types import DocumentData, ValidationResult
 from ontos.io.snapshot import create_snapshot
+from ontos.mcp.scanner import slugify
 
 
 TYPE_RANKS = {
@@ -542,27 +543,7 @@ def _primary_workspace_slug(cache: Any) -> str:
 
 
 def _slugify_workspace_name(raw: str) -> str:
-    try:
-        from ontos.mcp.scanner import slugify
-    except Exception:
-        slugify = None
-
-    if slugify is not None:
-        return slugify(raw)
-
-    lowered = raw.strip().lower()
-    result = []
-    previous_dash = False
-    for char in lowered:
-        if char.isalnum():
-            result.append(char)
-            previous_dash = False
-            continue
-        if not previous_dash:
-            result.append("-")
-        previous_dash = True
-    slug = "".join(result).strip("-")
-    return slug or "workspace"
+    return slugify(raw)
 
 
 def _normalize_warnings(

--- a/ontos/mcp/tools.py
+++ b/ontos/mcp/tools.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 import json
 from pathlib import Path
+import sqlite3
 from typing import Any, Dict, Optional
 
 import ontos
@@ -14,6 +15,7 @@ from ontos.commands.map import CompactMode, GenerateMapOptions, generate_context
 from ontos.core.errors import OntosUserError
 from ontos.core.snapshot import DocumentSnapshot
 from ontos.core.types import DocumentData, ValidationResult
+from ontos.io.snapshot import create_snapshot
 
 
 TYPE_RANKS = {
@@ -96,8 +98,9 @@ def build_canonical_snapshot_view(
     )
 
 
-def workspace_overview(cache: Any) -> dict[str, Any]:
+def workspace_overview(cache: Any, *, workspace_id: Optional[str] = None) -> dict[str, Any]:
     """Return structured orientation data for the current workspace."""
+    _enforce_workspace_scope(cache, workspace_id)
     key_documents = sorted(
         cache.snapshot.documents.values(),
         key=lambda doc: (-len(cache.snapshot.graph.reverse_edges.get(doc.id, [])), doc.id),
@@ -134,8 +137,14 @@ def workspace_overview(cache: Any) -> dict[str, Any]:
     }
 
 
-def context_map(cache: Any, compact: str = "tiered") -> dict[str, Any]:
+def context_map(
+    cache: Any,
+    compact: str = "tiered",
+    *,
+    workspace_id: Optional[str] = None,
+) -> dict[str, Any]:
     """Return a wrapped context-map payload."""
+    _enforce_workspace_scope(cache, workspace_id)
     compact_key = str(compact).strip().lower()
     compact_modes = {
         "basic": CompactMode.BASIC,
@@ -175,8 +184,10 @@ def get_document(
     document_id: Optional[str] = None,
     path: Optional[str] = None,
     include_content: bool = True,
+    workspace_id: Optional[str] = None,
 ) -> dict[str, Any]:
     """Return one canonical document."""
+    _enforce_workspace_scope(cache, workspace_id)
     if bool(document_id) == bool(path):
         raise OntosUserError(
             "Provide exactly one of document_id or path.",
@@ -217,8 +228,10 @@ def list_documents(
     status: Optional[str] = None,
     offset: int = 0,
     limit: int = 100,
+    workspace_id: Optional[str] = None,
 ) -> dict[str, Any]:
     """Return paginated canonical document rows."""
+    _enforce_workspace_scope(cache, workspace_id)
     if offset < 0:
         raise OntosUserError("offset must be >= 0.", code="E_INVALID_OFFSET")
     if limit <= 0:
@@ -243,8 +256,10 @@ def export_graph(
     *,
     summary_only: bool = True,
     export_to_file: Optional[str] = None,
+    workspace_id: Optional[str] = None,
 ) -> dict[str, Any]:
     """Return or persist a canonical export payload."""
+    _enforce_workspace_scope(cache, workspace_id)
     raw_payload = _snapshot_to_json(cache.snapshot, filters=None, deterministic=False)
     ordered_payload = _ordered_export_payload(raw_payload, cache.snapshot)
 
@@ -280,8 +295,9 @@ def export_graph(
     return ordered_payload
 
 
-def query(cache: Any, *, entity_id: str) -> dict[str, Any]:
+def query(cache: Any, *, entity_id: str, workspace_id: Optional[str] = None) -> dict[str, Any]:
     """Return structured graph details for one document."""
+    _enforce_workspace_scope(cache, workspace_id)
     doc = cache.snapshot.documents.get(entity_id)
     if doc is None:
         raise OntosUserError("Document not found.", code="E_DOCUMENT_NOT_FOUND")
@@ -297,8 +313,9 @@ def query(cache: Any, *, entity_id: str) -> dict[str, Any]:
     }
 
 
-def health(cache: Any) -> dict[str, Any]:
+def health(cache: Any, *, workspace_id: Optional[str] = None) -> dict[str, Any]:
     """Return server/cache health state."""
+    _enforce_workspace_scope(cache, workspace_id)
     uptime = max(0, int((datetime.now(timezone.utc) - cache.started_at).total_seconds()))
     return {
         "server_uptime": uptime,
@@ -312,8 +329,9 @@ def health(cache: Any) -> dict[str, Any]:
     }
 
 
-def refresh(cache: Any) -> dict[str, Any]:
+def refresh(cache: Any, *, workspace_id: Optional[str] = None) -> dict[str, Any]:
     """Force a cache rebuild and return the observable state change."""
+    _enforce_workspace_scope(cache, workspace_id)
     _snapshot, duration_ms = cache.force_refresh()
     return {
         "refreshed": True,
@@ -322,8 +340,229 @@ def refresh(cache: Any) -> dict[str, Any]:
     }
 
 
+def project_registry(portfolio_index: Any) -> dict[str, Any]:
+    """Return the complete project inventory from the portfolio index."""
+    if portfolio_index is None:
+        raise OntosUserError(
+            "project_registry is available only in portfolio mode.",
+            code="E_PORTFOLIO_REQUIRED",
+        )
+    projects = portfolio_index.get_projects()
+    return {
+        "project_count": len(projects),
+        "projects": [
+            {
+                "slug": p["slug"],
+                "path": p["path"],
+                "status": p["status"],
+                "doc_count": p["doc_count"],
+                "last_updated": p["last_scanned"],
+                "tags": _parse_project_tags(p.get("tags")),
+                "has_ontos": bool(p["has_ontos"]),
+            }
+            for p in projects
+        ],
+        "summary": f"Portfolio contains {len(projects)} projects.",
+    }
+
+
+def search(
+    portfolio_index: Any,
+    *,
+    query_string: str,
+    workspace_id: Optional[str] = None,
+    offset: int = 0,
+    limit: int = 20,
+) -> dict[str, Any]:
+    """Full-text search across the portfolio or a single workspace."""
+    if portfolio_index is None:
+        raise OntosUserError(
+            "search is available only in portfolio mode.",
+            code="E_PORTFOLIO_REQUIRED",
+        )
+    if not query_string or not query_string.strip():
+        raise OntosUserError(
+            "query_string must be non-empty.",
+            code="E_EMPTY_QUERY",
+        )
+    if limit < 1 or limit > 100:
+        raise OntosUserError(
+            "limit must be between 1 and 100.",
+            code="E_INVALID_LIMIT",
+        )
+    if offset < 0:
+        raise OntosUserError(
+            "offset must be >= 0.",
+            code="E_INVALID_OFFSET",
+        )
+    if workspace_id is not None:
+        _validate_workspace_id(portfolio_index, workspace_id)
+    try:
+        return portfolio_index.search_fts(query_string, workspace_id, offset, limit)
+    except sqlite3.OperationalError as exc:
+        raise OntosUserError(
+            "Invalid search query syntax.",
+            code="E_INVALID_QUERY",
+            details=str(exc),
+        ) from exc
+
+
+def get_context_bundle(
+    portfolio_index: Any,
+    cache: Any,
+    *,
+    workspace_id: Optional[str] = None,
+    token_budget: int = 8192,
+) -> dict[str, Any]:
+    """Return a token-budgeted context package for a workspace."""
+    from ontos.mcp.bundler import build_context_bundle
+
+    if token_budget < 1024:
+        raise OntosUserError(
+            "token_budget must be at least 1024.",
+            code="E_INVALID_BUDGET",
+        )
+    if token_budget > 128000:
+        raise OntosUserError(
+            "token_budget must be at most 128000.",
+            code="E_INVALID_BUDGET",
+        )
+
+    if portfolio_index is None:
+        slug = _slugify_workspace_name(cache.workspace_root.name)
+        snapshot = cache.get_fresh_snapshot()
+        workspace_root = cache.workspace_root
+    elif workspace_id is None:
+        raise OntosUserError(
+            "workspace_id is required in portfolio mode. "
+            "Use project_registry() to discover available workspaces.",
+            code="E_MISSING_WORKSPACE",
+        )
+    else:
+        _validate_workspace_id(portfolio_index, workspace_id)
+        projects = portfolio_index.get_projects()
+        project = next((item for item in projects if item["slug"] == workspace_id), None)
+        if project is None:
+            raise OntosUserError(
+                f"Unknown workspace '{workspace_id}'.",
+                code="E_UNKNOWN_WORKSPACE",
+            )
+        if project["status"] == "undocumented":
+            raise OntosUserError(
+                f"Workspace '{workspace_id}' is undocumented. "
+                "Run `ontos init` in that project directory first.",
+                code="E_UNDOCUMENTED_WORKSPACE",
+            )
+        slug = workspace_id
+        workspace_root = Path(project["path"]).resolve()
+        snapshot = create_snapshot(
+            root=workspace_root,
+            include_content=True,
+            filters=None,
+            git_commit_provider=None,
+            scope=None,
+        )
+
+    return build_context_bundle(
+        snapshot,
+        workspace_root,
+        slug,
+        token_budget=token_budget,
+    )
+
+
 def _humanize_id(doc_id: str) -> str:
     return doc_id.replace("_", " ").title()
+
+
+def _parse_project_tags(raw: Any) -> list[str]:
+    if not raw:
+        return []
+    if isinstance(raw, list):
+        return [str(item) for item in raw]
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            return []
+        if isinstance(parsed, list):
+            return [str(item) for item in parsed]
+    return []
+
+
+def _validate_workspace_id(portfolio_index: Any, workspace_id: str) -> None:
+    """Validate workspace_id exists in portfolio. Raise OntosUserError if not."""
+    if portfolio_index is None:
+        raise OntosUserError(
+            "workspace_id requires portfolio mode.",
+            code="E_PORTFOLIO_REQUIRED",
+        )
+    projects = portfolio_index.get_projects()
+    slugs = [project["slug"] for project in projects]
+    if workspace_id not in slugs:
+        sorted_slugs = ", ".join(sorted(slugs))
+        raise OntosUserError(
+            f"Unknown workspace '{workspace_id}'. "
+            f"Valid workspace slugs: {sorted_slugs}. "
+            "Use project_registry() to discover available workspaces.",
+            code="E_UNKNOWN_WORKSPACE",
+        )
+
+
+def _enforce_workspace_scope(cache: Any, workspace_id: Optional[str]) -> None:
+    if workspace_id is None:
+        return
+    if not _is_portfolio_mode(cache):
+        return
+    primary_workspace = _primary_workspace_slug(cache)
+    if workspace_id == primary_workspace:
+        return
+    raise OntosUserError(
+        "Cross-workspace reads are not supported in this tool yet. "
+        "Start a separate `ontos serve` in the target workspace.",
+        code="E_CROSS_WORKSPACE_NOT_SUPPORTED",
+    )
+
+
+def _is_portfolio_mode(cache: Any) -> bool:
+    return bool(
+        getattr(cache, "portfolio_mode", False)
+        or getattr(cache, "is_portfolio_mode", False)
+        or getattr(cache, "portfolio_enabled", False)
+        or getattr(cache, "portfolio_index", None) is not None
+    )
+
+
+def _primary_workspace_slug(cache: Any) -> str:
+    for attr in ("primary_workspace_slug", "workspace_slug", "workspace_id"):
+        value = getattr(cache, attr, None)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return _slugify_workspace_name(cache.workspace_root.name)
+
+
+def _slugify_workspace_name(raw: str) -> str:
+    try:
+        from ontos.mcp.scanner import slugify
+    except Exception:
+        slugify = None
+
+    if slugify is not None:
+        return slugify(raw)
+
+    lowered = raw.strip().lower()
+    result = []
+    previous_dash = False
+    for char in lowered:
+        if char.isalnum():
+            result.append(char)
+            previous_dash = False
+            continue
+        if not previous_dash:
+            result.append("-")
+        previous_dash = True
+    slug = "".join(result).strip("-")
+    return slug or "workspace"
 
 
 def _normalize_warnings(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "ontos"
 version = "4.0.0"
 description = "Local-first documentation management for AI-assisted development"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "Apache-2.0"
 authors = [
     {name = "Ontos Project", email = "ohjonathan@users.noreply.github.com"}
@@ -19,7 +19,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -38,7 +37,7 @@ dev = [
     "pre-commit>=3.0,<5.0",
 ]
 mcp = [
-    "mcp>=1.2",
+    "mcp>=1.27.0,<2.0",
     "pydantic>=2.0",
 ]
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "ontos"
 version = "4.0.0"
 description = "Local-first documentation management for AI-assisted development"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 license = "Apache-2.0"
 authors = [
     {name = "Ontos Project", email = "ohjonathan@users.noreply.github.com"}
@@ -19,6 +19,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/tests/commands/golden/verify_help.txt
+++ b/tests/commands/golden/verify_help.txt
@@ -1,16 +1,19 @@
-usage: ontos_verify.py [-h] [--all] [--date DATE] [--version] [filepath]
-
-Verify documentation as current (update describes_verified)
+usage: ontos verify [-h] [--quiet] [--json] [--all] [--date DATE]
+                    [--portfolio] [--scope {docs,library}]
+                    [path]
 
 positional arguments:
-  filepath       Path to document to verify
+  path                  Specific file to verify
 
-optional arguments:
-  -h, --help     show this help message and exit
-  --all          Interactively verify all stale documents
-  --date DATE    Set specific date (YYYY-MM-DD), default: today
-  --version, -V  show program's version number and exit
-
-Examples: python3 ontos_verify.py docs/reference/Ontos_Manual.md # Single file
-python3 ontos_verify.py --all # Interactive: all stale docs python3
-ontos_verify.py docs/manual.md --date 2025-12-15 # Backdate
+options:
+  -h, --help            show this help message and exit
+  --quiet, -q           Suppress non-essential output
+  --json                Output in JSON format
+  --all, -a             Verify all stale documents interactively (use --scope
+                        library to include .ontos-internal)
+  --date, -d DATE       Verification date (YYYY-MM-DD, default: today)
+  --portfolio           Compare portfolio DB against projects.json and report
+                        discrepancies
+  --scope {docs,library}
+                        Scan scope: docs (default) or library (includes
+                        .ontos-internal)

--- a/tests/commands/test_verify_parity.py
+++ b/tests/commands/test_verify_parity.py
@@ -26,6 +26,7 @@ def test_verify_help_parity(golden_help):
     )
     assert "--all" in result.stdout
     assert "--date" in result.stdout
+    assert "--portfolio" in result.stdout
     assert "verify" in result.stdout.lower()
 
 

--- a/tests/commands/test_verify_portfolio.py
+++ b/tests/commands/test_verify_portfolio.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from argparse import Namespace
 import json
 import os
 from pathlib import Path
@@ -7,6 +8,12 @@ import sqlite3
 import subprocess
 import sys
 from textwrap import dedent
+
+import pytest
+
+from ontos.cli import _cmd_verify
+import ontos.commands.verify as verify_module
+import ontos.mcp.portfolio_config as portfolio_config_module
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -117,6 +124,213 @@ def test_verify_portfolio_cli_errors_when_db_missing(tmp_path):
 
     assert result.returncode == 2
     assert "Run `ontos serve --portfolio` first." in result.stdout
+
+
+def test_verify_portfolio_scopes_to_workspace_id(tmp_path, capsys):
+    db_path = tmp_path / "portfolio.db"
+    alpha_path = tmp_path / "Dev" / "alpha"
+    beta_path = tmp_path / "Dev" / "beta"
+    alpha_path.mkdir(parents=True)
+    beta_path.mkdir(parents=True)
+    (alpha_path / ".ontos.toml").write_text("[ontos]\nversion = '4.0'\n", encoding="utf-8")
+    (beta_path / ".ontos.toml").write_text("[ontos]\nversion = '4.0'\n", encoding="utf-8")
+
+    registry_path = tmp_path / "registry" / "projects.json"
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps({"projects": [{"path": str(alpha_path), "status": "documented"}]}),
+        encoding="utf-8",
+    )
+
+    _write_portfolio_db(
+        db_path,
+        [
+            {"slug": "alpha", "path": str(alpha_path), "status": "documented", "has_ontos": 1},
+            {"slug": "beta", "path": str(beta_path), "status": "documented", "has_ontos": 1},
+        ],
+    )
+
+    result = verify_module.verify_portfolio(
+        portfolio_db_path=db_path,
+        registry_path=registry_path,
+        workspace_id="alpha",
+    )
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "No discrepancies found." in captured.out
+
+
+def test_verify_portfolio_handles_same_basename_collision(tmp_path):
+    db_path = tmp_path / "portfolio.db"
+    root_one = tmp_path / "DevA"
+    root_two = tmp_path / "DevB"
+    workspace_one = root_one / "sample-app"
+    workspace_two = root_two / "sample-app"
+    workspace_one.mkdir(parents=True)
+    workspace_two.mkdir(parents=True)
+    (workspace_one / ".ontos.toml").write_text("[ontos]\nversion = '4.0'\n", encoding="utf-8")
+    (workspace_two / ".ontos.toml").write_text("[ontos]\nversion = '4.0'\n", encoding="utf-8")
+
+    registry_path = tmp_path / "registry" / "projects.json"
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "projects": [
+                    {"path": str(workspace_one), "status": "documented"},
+                    {"path": str(workspace_two), "status": "documented"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    _write_portfolio_db(
+        db_path,
+        [
+            {
+                "slug": "sample-app",
+                "path": str(workspace_one),
+                "status": "documented",
+                "has_ontos": 1,
+            },
+            {
+                "slug": "sample-app-2",
+                "path": str(workspace_two),
+                "status": "documented",
+                "has_ontos": 1,
+            },
+        ],
+    )
+
+    exit_code = verify_module.verify_portfolio(
+        portfolio_db_path=db_path,
+        registry_path=registry_path,
+        json_output=True,
+    )
+
+    assert exit_code == 0
+
+
+@pytest.mark.parametrize("registry_key", ["projects", "workspaces", "entries", "items"])
+def test_verify_portfolio_accepts_all_registry_list_shapes(tmp_path, registry_key):
+    db_path = tmp_path / "portfolio.db"
+    workspace = tmp_path / "Dev" / "alpha"
+    workspace.mkdir(parents=True)
+    (workspace / ".ontos.toml").write_text("[ontos]\nversion = '4.0'\n", encoding="utf-8")
+
+    registry_path = tmp_path / "registry" / "projects.json"
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps({registry_key: [{"path": str(workspace), "status": "documented"}]}),
+        encoding="utf-8",
+    )
+
+    _write_portfolio_db(
+        db_path,
+        [{"slug": "alpha", "path": str(workspace), "status": "documented", "has_ontos": 1}],
+    )
+
+    exit_code = verify_module.verify_portfolio(portfolio_db_path=db_path, registry_path=registry_path)
+    assert exit_code == 0
+
+
+def test_verify_portfolio_accepts_dict_shaped_registry(tmp_path):
+    db_path = tmp_path / "portfolio.db"
+    workspace = tmp_path / "Dev" / "alpha"
+    workspace.mkdir(parents=True)
+    (workspace / ".ontos.toml").write_text("[ontos]\nversion = '4.0'\n", encoding="utf-8")
+
+    registry_path = tmp_path / "registry" / "projects.json"
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps({"alpha": {"path": str(workspace), "status": "documented"}}),
+        encoding="utf-8",
+    )
+
+    _write_portfolio_db(
+        db_path,
+        [{"slug": "alpha", "path": str(workspace), "status": "documented", "has_ontos": 1}],
+    )
+
+    exit_code = verify_module.verify_portfolio(portfolio_db_path=db_path, registry_path=registry_path)
+    assert exit_code == 0
+
+
+def test_verify_portfolio_string_false_not_truthy(tmp_path):
+    db_path = tmp_path / "portfolio.db"
+    workspace = tmp_path / "Dev" / "alpha"
+    workspace.mkdir(parents=True)
+    (workspace / ".ontos.toml").write_text("[ontos]\nversion = '4.0'\n", encoding="utf-8")
+
+    registry_path = tmp_path / "registry" / "projects.json"
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "projects": [
+                    {
+                        "path": str(workspace),
+                        "status": "partial",
+                        "has_ontos": "false",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    _write_portfolio_db(
+        db_path,
+        [{"slug": "alpha", "path": str(workspace), "status": "partial", "has_ontos": 0}],
+    )
+
+    exit_code = verify_module.verify_portfolio(
+        portfolio_db_path=db_path,
+        registry_path=registry_path,
+        json_output=True,
+    )
+
+    assert exit_code == 0
+
+
+def test_cmd_verify_portfolio_handles_malformed_config(monkeypatch, capsys):
+    args = Namespace(portfolio=True, json=False, workspace_id=None)
+
+    def _boom():
+        raise ValueError("Invalid TOML structure")
+
+    monkeypatch.setattr(portfolio_config_module, "load_portfolio_config", _boom)
+
+    result = _cmd_verify(args)
+    captured = capsys.readouterr()
+
+    assert result == 2
+    assert "Invalid portfolio config: Invalid TOML structure" in captured.out
+    assert "Traceback" not in captured.out
+    assert "Traceback" not in captured.err
+
+
+def test_cmd_verify_portfolio_threads_workspace_id(monkeypatch):
+    args = Namespace(portfolio=True, json=False, workspace_id="alpha")
+    calls: list[object] = []
+
+    class _Config:
+        registry_path = None
+
+    def _load_config():
+        return _Config()
+
+    def _fake_verify_portfolio(**kwargs):
+        calls.append(kwargs.get("workspace_id"))
+        return 0
+
+    monkeypatch.setattr(portfolio_config_module, "load_portfolio_config", _load_config)
+    monkeypatch.setattr(verify_module, "verify_portfolio", _fake_verify_portfolio)
+
+    assert _cmd_verify(args) == 0
+    assert calls == ["alpha"]
 
 
 def _run_verify_portfolio(home: Path, *extra_args: str) -> subprocess.CompletedProcess[str]:

--- a/tests/commands/test_verify_portfolio.py
+++ b/tests/commands/test_verify_portfolio.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import sqlite3
+import subprocess
+import sys
+from textwrap import dedent
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_verify_portfolio_cli_accepts_dev_root_relative_registry(tmp_path):
+    home = tmp_path / "home"
+    dev_root = tmp_path / "Dev"
+    workspace = dev_root / "alpha.project"
+    workspace.mkdir(parents=True)
+    (workspace / ".ontos.toml").write_text("[ontos]\nversion = '4.0'\n", encoding="utf-8")
+
+    registry_path = tmp_path / "registry" / "projects.json"
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "dev_root": str(dev_root),
+                "projects": [
+                    {
+                        "path": "alpha.project",
+                        "status": "documented",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    _write_portfolio_config(home, registry_path)
+    _write_portfolio_db(
+        home / ".config" / "ontos" / "portfolio.db",
+        [
+            {
+                "slug": "alpha-project",
+                "path": str(workspace),
+                "status": "documented",
+                "has_ontos": 1,
+            }
+        ],
+    )
+
+    result = _run_verify_portfolio(home)
+
+    assert result.returncode == 0
+    assert "No discrepancies found." in result.stdout
+
+
+def test_verify_portfolio_cli_reports_mismatches_in_json_mode(tmp_path):
+    home = tmp_path / "home"
+    workspace = tmp_path / "Dev" / "alpha"
+    workspace.mkdir(parents=True)
+    (workspace / ".ontos.toml").write_text("[ontos]\nversion = '4.0'\n", encoding="utf-8")
+
+    registry_path = tmp_path / "registry" / "projects.json"
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "projects": [
+                    {
+                        "path": str(workspace),
+                        "status": "documented",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    _write_portfolio_config(home, registry_path)
+    _write_portfolio_db(
+        home / ".config" / "ontos" / "portfolio.db",
+        [
+            {
+                "slug": "alpha",
+                "path": str(workspace),
+                "status": "partial",
+                "has_ontos": 1,
+            }
+        ],
+    )
+
+    result = _run_verify_portfolio(home, "--json")
+    payload = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert payload["clean"] is False
+    assert payload["summary"] == "1 discrepancies found."
+    assert payload["field_mismatches"] == [
+        {
+            "slug": "alpha",
+            "field": "status",
+            "db_value": "partial",
+            "json_value": "documented",
+        }
+    ]
+
+
+def test_verify_portfolio_cli_errors_when_db_missing(tmp_path):
+    home = tmp_path / "home"
+    registry_path = tmp_path / "registry" / "projects.json"
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(json.dumps({"projects": []}), encoding="utf-8")
+    _write_portfolio_config(home, registry_path)
+
+    result = _run_verify_portfolio(home)
+
+    assert result.returncode == 2
+    assert "Run `ontos serve --portfolio` first." in result.stdout
+
+
+def _run_verify_portfolio(home: Path, *extra_args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    return subprocess.run(
+        [sys.executable, "-m", "ontos.cli", "verify", "--portfolio", *extra_args],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+
+
+def _write_portfolio_config(home: Path, registry_path: Path) -> None:
+    config_path = home / ".config" / "ontos" / "portfolio.toml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        dedent(
+            f"""
+            [portfolio]
+            scan_roots = ["~/Dev"]
+            exclude = ["~/Dev/.dev-hub", "~/Dev/archive"]
+            registry_path = "{registry_path}"
+
+            [bundle]
+            token_budget = 8192
+            max_logs = 5
+            log_window_days = 14
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+
+
+def _write_portfolio_db(db_path: Path, rows: list[dict[str, object]]) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    connection = sqlite3.connect(db_path)
+    try:
+        connection.execute(
+            """
+            CREATE TABLE projects (
+                slug TEXT PRIMARY KEY,
+                path TEXT NOT NULL,
+                status TEXT NOT NULL,
+                has_ontos INTEGER NOT NULL
+            )
+            """
+        )
+        connection.executemany(
+            "INSERT INTO projects(slug, path, status, has_ontos) VALUES(?, ?, ?, ?)",
+            [
+                (
+                    str(row["slug"]),
+                    str(row["path"]),
+                    str(row["status"]),
+                    int(row["has_ontos"]),
+                )
+                for row in rows
+            ],
+        )
+        connection.commit()
+    finally:
+        connection.close()

--- a/tests/core/test_config_phase3.py
+++ b/tests/core/test_config_phase3.py
@@ -139,3 +139,22 @@ class TestDictToConfig:
         """dict_to_config validates types."""
         with pytest.raises(ConfigError, match="must be int"):
             dict_to_config({"workflow": {"log_retention_count": "bad"}})
+
+    def test_dict_to_config_maps_legacy_validation_strict_to_hooks(self):
+        """Legacy validation.strict is accepted and preserved via hooks.strict."""
+        config = dict_to_config({"validation": {"strict": True}})
+
+        assert config.hooks.strict is True
+
+    def test_dict_to_config_ignores_unknown_section_keys(self):
+        """Unknown keys do not break config loading for mixed-version projects."""
+        config = dict_to_config(
+            {
+                "workflow": {
+                    "log_retention_count": 30,
+                    "enforce_archive_before_push": True,
+                }
+            }
+        )
+
+        assert config.workflow.log_retention_count == 30

--- a/tests/core/test_config_phase3.py
+++ b/tests/core/test_config_phase3.py
@@ -146,6 +146,17 @@ class TestDictToConfig:
 
         assert config.hooks.strict is True
 
+    def test_dict_to_config_accepts_legacy_project_section(self):
+        """Legacy top-level [project] section remains a compatibility no-op."""
+        config = dict_to_config(
+            {
+                "project": {"name": "legacy-project"},
+                "paths": {"logs_dir": "docs/logs"},
+            }
+        )
+
+        assert config.paths.logs_dir == "docs/logs"
+
     def test_dict_to_config_rejects_unknown_section_key(self):
         """Unknown keys raise ConfigError with the offending dotted key."""
         with pytest.raises(ConfigError, match=r"hooks\.strictt"):

--- a/tests/core/test_config_phase3.py
+++ b/tests/core/test_config_phase3.py
@@ -146,15 +146,12 @@ class TestDictToConfig:
 
         assert config.hooks.strict is True
 
-    def test_dict_to_config_ignores_unknown_section_keys(self):
-        """Unknown keys do not break config loading for mixed-version projects."""
-        config = dict_to_config(
-            {
-                "workflow": {
-                    "log_retention_count": 30,
-                    "enforce_archive_before_push": True,
-                }
-            }
-        )
+    def test_dict_to_config_rejects_unknown_section_key(self):
+        """Unknown keys raise ConfigError with the offending dotted key."""
+        with pytest.raises(ConfigError, match=r"hooks\.strictt"):
+            dict_to_config({"hooks": {"strictt": True}})
 
-        assert config.workflow.log_retention_count == 30
+    def test_dict_to_config_rejects_unknown_top_level_section(self):
+        """Unknown top-level sections raise ConfigError with section name."""
+        with pytest.raises(ConfigError, match="hokks"):
+            dict_to_config({"hokks": {"strict": True}})

--- a/tests/mcp/__init__.py
+++ b/tests/mcp/__init__.py
@@ -269,10 +269,10 @@ def build_cache(root: Path) -> SnapshotCache:
     )
 
 
-def build_server(root: Path):
+def build_server(root: Path, **kwargs: Any):
     from ontos.mcp.server import create_server
 
-    return create_server(build_cache(root))
+    return create_server(build_cache(root), **kwargs)
 
 
 def invoke_tool(*args: Any, **kwargs: Any):

--- a/tests/mcp/test_bundler.py
+++ b/tests/mcp/test_bundler.py
@@ -1,0 +1,112 @@
+from datetime import date, timedelta
+
+from ontos.io.snapshot import create_snapshot
+from ontos.mcp.bundler import build_context_bundle
+
+from tests.mcp import create_empty_workspace, create_workspace, write_file
+
+
+def test_build_context_bundle_scores_kernels_highest(tmp_path):
+    root = create_workspace(tmp_path)
+    snapshot = create_snapshot(root=root, include_content=True, filters=None, git_commit_provider=None, scope=None)
+
+    payload = build_context_bundle(snapshot, root, "workspace")
+    scores = {item["id"]: item["score"] for item in payload["included_documents"]}
+
+    assert scores["kernel_doc"] == 1.0
+    assert all(0.0 <= score <= 1.0 for score in scores.values())
+
+
+def test_build_context_bundle_greedy_packing_excludes_over_budget_docs(tmp_path):
+    root = create_workspace(tmp_path)
+    write_file(
+        root / "docs/heavy.md",
+        f"""
+        ---
+        id: heavy_doc
+        type: reference
+        status: active
+        depends_on: [kernel_doc]
+        ---
+        {"heavy " * 2000}
+        """,
+    )
+    snapshot = create_snapshot(root=root, include_content=True, filters=None, git_commit_provider=None, scope=None)
+
+    payload = build_context_bundle(snapshot, root, "workspace", token_budget=1024)
+
+    included_ids = {item["id"] for item in payload["included_documents"]}
+    assert "kernel_doc" in included_ids
+    assert "heavy_doc" not in included_ids
+    assert payload["excluded_count"] >= 1
+
+
+def test_build_context_bundle_empty_workspace(tmp_path):
+    root = create_empty_workspace(tmp_path)
+    snapshot = create_snapshot(root=root, include_content=True, filters=None, git_commit_provider=None, scope=None)
+
+    payload = build_context_bundle(snapshot, root, "empty")
+
+    assert payload["document_count"] == 0
+    assert payload["included_documents"] == []
+    assert payload["token_estimate"] == 0
+
+
+def test_build_context_bundle_budget_smaller_than_kernel_still_includes_kernel(tmp_path):
+    root = create_workspace(tmp_path)
+    write_file(
+        root / "docs/kernel.md",
+        f"""
+        ---
+        id: kernel_doc
+        type: kernel
+        status: active
+        ---
+        {"kernel " * 1000}
+        """,
+    )
+    snapshot = create_snapshot(root=root, include_content=True, filters=None, git_commit_provider=None, scope=None)
+
+    payload = build_context_bundle(snapshot, root, "workspace", token_budget=10)
+
+    ids = [item["id"] for item in payload["included_documents"]]
+    assert "kernel_doc" in ids
+
+
+def test_build_context_bundle_recent_logs_scored_lower(tmp_path):
+    root = create_workspace(tmp_path)
+    today = date.today().isoformat()
+    old = (date.today() - timedelta(days=40)).isoformat()
+    write_file(
+        root / f"docs/{today}_recent-log.md",
+        f"""
+        ---
+        id: {today}_recent_log
+        type: log
+        status: active
+        date: {today}
+        depends_on: [atom_doc]
+        ---
+        Recent log body.
+        """,
+    )
+    write_file(
+        root / f"docs/{old}_old-log.md",
+        f"""
+        ---
+        id: {old}_old_log
+        type: log
+        status: active
+        date: {old}
+        depends_on: [atom_doc]
+        ---
+        Old log body.
+        """,
+    )
+    snapshot = create_snapshot(root=root, include_content=True, filters=None, git_commit_provider=None, scope=None)
+
+    payload = build_context_bundle(snapshot, root, "workspace")
+    score_map = {item["id"]: item["score"] for item in payload["included_documents"]}
+
+    assert score_map[f"{today}_recent_log"] == 0.3
+    assert score_map[f"{old}_old_log"] >= 0.5

--- a/tests/mcp/test_context_bundle.py
+++ b/tests/mcp/test_context_bundle.py
@@ -1,0 +1,153 @@
+from datetime import date, timedelta
+
+import pytest
+
+from ontos.core.errors import OntosUserError
+from ontos.mcp import tools
+from ontos.mcp.schemas import validate_success_payload
+
+from tests.mcp import build_cache, create_workspace, write_file
+
+
+class FakePortfolioIndex:
+    def __init__(self, projects):
+        self._projects = projects
+
+    def get_projects(self):
+        return list(self._projects)
+
+
+def test_get_context_bundle_single_workspace_mode_uses_cache_snapshot(tmp_path):
+    root = create_workspace(tmp_path)
+    cache = build_cache(root)
+
+    payload = tools.get_context_bundle(None, cache, token_budget=8192, workspace_id="ignored")
+    normalized = validate_success_payload("get_context_bundle", payload)
+
+    assert normalized["workspace_slug"] == "workspace"
+    assert normalized["workspace_id"] == "workspace"
+    assert normalized["document_count"] >= 1
+    score_map = {item["id"]: item["score"] for item in normalized["included_documents"]}
+    assert "kernel_doc" in score_map
+    assert score_map["kernel_doc"] == 1.0
+
+
+def test_get_context_bundle_budget_bounds(tmp_path):
+    cache = build_cache(create_workspace(tmp_path))
+
+    with pytest.raises(OntosUserError) as low_budget:
+        tools.get_context_bundle(None, cache, token_budget=1000)
+    assert low_budget.value.code == "E_INVALID_BUDGET"
+
+    with pytest.raises(OntosUserError) as high_budget:
+        tools.get_context_bundle(None, cache, token_budget=200000)
+    assert high_budget.value.code == "E_INVALID_BUDGET"
+
+
+def test_get_context_bundle_portfolio_mode_requires_workspace(tmp_path):
+    root = create_workspace(tmp_path)
+    cache = build_cache(root)
+    portfolio = FakePortfolioIndex(
+        [
+            {
+                "slug": "alpha",
+                "path": str(root),
+                "status": "active",
+                "doc_count": 8,
+                "last_scanned": None,
+                "tags": "[]",
+                "has_ontos": 1,
+            }
+        ]
+    )
+
+    with pytest.raises(OntosUserError) as exc_info:
+        tools.get_context_bundle(portfolio, cache)
+
+    assert exc_info.value.code == "E_MISSING_WORKSPACE"
+
+
+def test_get_context_bundle_portfolio_mode_rejects_undocumented_workspace(tmp_path):
+    root = create_workspace(tmp_path)
+    cache = build_cache(root)
+    portfolio = FakePortfolioIndex(
+        [
+            {
+                "slug": "alpha",
+                "path": str(root),
+                "status": "undocumented",
+                "doc_count": 0,
+                "last_scanned": None,
+                "tags": "[]",
+                "has_ontos": 0,
+            }
+        ]
+    )
+
+    with pytest.raises(OntosUserError) as exc_info:
+        tools.get_context_bundle(portfolio, cache, workspace_id="alpha")
+
+    assert exc_info.value.code == "E_UNDOCUMENTED_WORKSPACE"
+
+
+def test_get_context_bundle_log_window_and_score(tmp_path):
+    root = create_workspace(tmp_path)
+    cache = build_cache(root)
+    today = date.today().isoformat()
+    old = (date.today() - timedelta(days=60)).isoformat()
+    write_file(
+        root / f"docs/{today}_recent-log.md",
+        f"""
+        ---
+        id: {today}_recent_log
+        type: log
+        status: active
+        date: {today}
+        depends_on: [atom_doc]
+        ---
+        Recent log body.
+        """,
+    )
+    write_file(
+        root / f"docs/{old}_old-log.md",
+        f"""
+        ---
+        id: {old}_old_log
+        type: log
+        status: active
+        date: {old}
+        depends_on: [atom_doc]
+        ---
+        Old log body.
+        """,
+    )
+
+    payload = tools.get_context_bundle(None, cache, token_budget=8192)
+    score_map = {item["id"]: item["score"] for item in payload["included_documents"]}
+
+    assert score_map[f"{today}_recent_log"] == 0.3
+    assert score_map[f"{old}_old_log"] >= 0.5
+
+
+def test_get_context_bundle_detects_stale_documents(tmp_path):
+    root = create_workspace(tmp_path)
+    cache = build_cache(root)
+    write_file(
+        root / "docs/atom.md",
+        """
+        ---
+        id: atom_doc
+        type: atom
+        status: active
+        depends_on: [product_doc]
+        describes: [concept_doc]
+        describes_verified: 2000-01-01
+        ---
+        Atom body for hashing.
+        """,
+    )
+
+    payload = tools.get_context_bundle(None, cache, token_budget=8192)
+    stale_ids = {item["id"] for item in payload["stale_documents"]}
+
+    assert "atom_doc" in stale_ids

--- a/tests/mcp/test_locking.py
+++ b/tests/mcp/test_locking.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from multiprocessing import Event, Process
+from pathlib import Path
+
+import pytest
+
+from ontos.core.errors import OntosUserError
+from ontos.mcp.locking import workspace_lock
+
+
+def _hold_workspace_lock(workspace_root: str, ready: Event, release: Event) -> None:
+    with workspace_lock(Path(workspace_root), timeout=1.0):
+        ready.set()
+        release.wait(timeout=5.0)
+
+
+def test_workspace_lock_acquires_and_releases(tmp_path):
+    lock_path = tmp_path / ".ontos.lock"
+
+    with workspace_lock(tmp_path):
+        assert lock_path.exists()
+
+    with workspace_lock(tmp_path):
+        assert lock_path.exists()
+
+
+def test_workspace_lock_raises_when_busy(tmp_path):
+    ready = Event()
+    release = Event()
+    proc = Process(target=_hold_workspace_lock, args=(str(tmp_path), ready, release))
+    proc.start()
+    try:
+        assert ready.wait(timeout=2.0)
+        with pytest.raises(OntosUserError) as exc:
+            with workspace_lock(tmp_path, timeout=0.2):
+                pass
+        assert exc.value.code == "E_WORKSPACE_BUSY"
+    finally:
+        release.set()
+        proc.join(timeout=2.0)
+        if proc.is_alive():
+            proc.terminate()
+            proc.join(timeout=1.0)

--- a/tests/mcp/test_locking.py
+++ b/tests/mcp/test_locking.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from multiprocessing import Event, Process
+import os
 from pathlib import Path
+import subprocess
+import sys
 
 import pytest
 
@@ -42,3 +45,32 @@ def test_workspace_lock_raises_when_busy(tmp_path):
         if proc.is_alive():
             proc.terminate()
             proc.join(timeout=1.0)
+
+
+def test_workspace_lock_fd_is_not_inherited_by_child_process(tmp_path, monkeypatch):
+    lock_path = tmp_path / ".ontos.lock"
+    original_open = Path.open
+
+    def open_with_inheritable_fd(self, *args, **kwargs):  # noqa: ANN001
+        handle = original_open(self, *args, **kwargs)
+        if self.resolve(strict=False) == lock_path.resolve(strict=False):
+            os.set_inheritable(handle.fileno(), True)
+        return handle
+
+    monkeypatch.setattr(Path, "open", open_with_inheritable_fd)
+
+    child: subprocess.Popen[str] | None = None
+    try:
+        with workspace_lock(tmp_path, timeout=1.0):
+            child = subprocess.Popen(
+                [sys.executable, "-c", "import time; time.sleep(1.0)"],
+                close_fds=False,
+            )
+        assert child is not None
+        with workspace_lock(tmp_path, timeout=0.2):
+            pass
+    finally:
+        if child is not None:
+            if child.poll() is None:
+                child.terminate()
+            child.wait(timeout=2.0)

--- a/tests/mcp/test_portfolio.py
+++ b/tests/mcp/test_portfolio.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from ontos.core.errors import OntosUserError
+from ontos.mcp.portfolio import PortfolioIndex
+from tests.mcp import create_workspace, write_file
+
+
+def test_open_creates_schema_and_sets_user_version(tmp_path):
+    db_path = tmp_path / "portfolio.db"
+    index = PortfolioIndex(db_path)
+
+    index.open()
+    index.close()
+
+    with sqlite3.connect(db_path) as conn:
+        user_version = conn.execute("PRAGMA user_version;").fetchone()[0]
+        journal_mode = conn.execute("PRAGMA journal_mode;").fetchone()[0]
+        table_names = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type IN ('table', 'view')"
+            ).fetchall()
+        }
+
+    assert user_version == 1
+    assert journal_mode == "wal"
+    assert {"projects", "documents", "edges", "scan_state", "fts_content"}.issubset(table_names)
+
+
+def test_open_recovers_from_corrupt_database(tmp_path):
+    db_path = tmp_path / "portfolio.db"
+    db_path.write_text("not a sqlite database", encoding="utf-8")
+
+    index = PortfolioIndex(db_path)
+    index.open()
+
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute("PRAGMA user_version;").fetchone()[0] == 1
+
+
+def test_rebuild_workspace_indexes_documents_and_projects(tmp_path):
+    workspace_root = create_workspace(tmp_path)
+    index = PortfolioIndex(tmp_path / "portfolio.db")
+
+    index.rebuild_workspace("workspace", workspace_root)
+
+    projects = index.get_projects()
+    documents = index.get_workspace_documents("workspace")
+    search = index.search_fts("Atom", workspace="workspace", offset=0, limit=10)
+
+    assert len(projects) == 1
+    assert projects[0]["slug"] == "workspace"
+    assert projects[0]["doc_count"] == 8
+    assert projects[0]["status"] == "documented"
+    assert len(documents) == 8
+    assert search["total_hits"] >= 1
+    assert any(row["doc_id"] == "atom_doc" for row in search["results"])
+
+
+def test_workspace_staleness_detection(tmp_path):
+    workspace_root = create_workspace(tmp_path)
+    index = PortfolioIndex(tmp_path / "portfolio.db")
+
+    index.rebuild_workspace("workspace", workspace_root)
+    assert index.is_workspace_stale("workspace") is False
+
+    write_file(
+        workspace_root / "docs/atom.md",
+        """
+        ---
+        id: atom_doc
+        type: atom
+        status: active
+        depends_on: [product_doc]
+        ---
+        Atom body changed.
+        """,
+    )
+    assert index.is_workspace_stale("workspace") is True
+
+
+def test_search_fts_returns_ranked_results(tmp_path):
+    workspace_root = create_workspace(tmp_path)
+    index = PortfolioIndex(tmp_path / "portfolio.db")
+
+    index.rebuild_workspace("workspace", workspace_root)
+    result = index.search_fts("body", workspace="workspace", offset=0, limit=10)
+    scores = [row["score"] for row in result["results"]]
+
+    assert result["total_hits"] > 0
+    assert scores == sorted(scores)
+
+
+def test_search_fts_rejects_malformed_queries(tmp_path):
+    workspace_root = create_workspace(tmp_path)
+    index = PortfolioIndex(tmp_path / "portfolio.db")
+    index.rebuild_workspace("workspace", workspace_root)
+
+    with pytest.raises(OntosUserError) as exc_info:
+        index.search_fts('"unterminated', workspace=None, offset=0, limit=10)
+
+    assert exc_info.value.code == "E_INVALID_QUERY"
+
+
+def test_rebuild_workspace_keeps_fts_row_parity(tmp_path):
+    workspace_root = create_workspace(tmp_path)
+    db_path = tmp_path / "portfolio.db"
+    index = PortfolioIndex(db_path)
+    index.rebuild_workspace("workspace", workspace_root)
+
+    with sqlite3.connect(db_path) as conn:
+        docs_count = conn.execute(
+            "SELECT COUNT(*) FROM documents WHERE workspace = ?",
+            ("workspace",),
+        ).fetchone()[0]
+        fts_count = conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM fts_content
+            JOIN documents ON documents.rowid = fts_content.rowid
+            WHERE documents.workspace = ?
+            """,
+            ("workspace",),
+        ).fetchone()[0]
+
+    assert docs_count == fts_count
+
+
+def test_search_fts_snippet_uses_body_column(tmp_path):
+    workspace_root = _make_custom_workspace(
+        tmp_path,
+        workspace_name="snippet-workspace",
+        docs={
+            "alpha.md": """
+            ---
+            id: alpha_doc
+            type: atom
+            status: active
+            concepts: [conceptonly]
+            ---
+            This body does not contain that concept token.
+            """,
+        },
+    )
+    index = PortfolioIndex(tmp_path / "portfolio.db")
+    index.rebuild_workspace("snippet", workspace_root)
+
+    result = index.search_fts("conceptonly", workspace="snippet", offset=0, limit=10)
+
+    assert result["total_hits"] == 1
+    snippet = result["results"][0]["snippet"]
+    assert "<mark>conceptonly</mark>" not in snippet.lower()
+
+
+def test_rebuild_all_discovers_projects_and_handles_slug_collisions(tmp_path):
+    root_one = tmp_path / "DevA"
+    root_two = tmp_path / "DevB"
+    root_one.mkdir()
+    root_two.mkdir()
+
+    workspace_one = _make_custom_workspace(
+        root_one,
+        workspace_name="sample-app",
+        docs={"doc-a.md": _doc_content("doc_a", "Alpha body")},
+    )
+    workspace_two = _make_custom_workspace(
+        root_two,
+        workspace_name="sample-app",
+        docs={"doc-b.md": _doc_content("doc_b", "Beta body")},
+    )
+    (workspace_one / ".git").mkdir()
+    (workspace_two / ".git").mkdir()
+
+    index = PortfolioIndex(tmp_path / "portfolio.db")
+    index.rebuild_all([root_one, root_two], exclude=[], registry_path=None)
+    projects = index.get_projects()
+
+    assert [project["slug"] for project in projects] == ["sample-app", "sample-app-2"]
+    assert all(project["doc_count"] == 1 for project in projects)
+
+
+def _make_custom_workspace(tmp_path: Path, *, workspace_name: str, docs: dict[str, str]) -> Path:
+    root = tmp_path / workspace_name
+    root.mkdir(parents=True, exist_ok=True)
+    write_file(
+        root / ".ontos.toml",
+        """
+        [ontos]
+        version = "4.0"
+
+        [scanning]
+        skip_patterns = ["_template.md", "archive/*"]
+        """,
+    )
+    for filename, content in docs.items():
+        write_file(root / "docs" / filename, content)
+    return root
+
+
+def _doc_content(doc_id: str, body: str) -> str:
+    return f"""
+    ---
+    id: {doc_id}
+    type: atom
+    status: active
+    ---
+    {body}
+    """

--- a/tests/mcp/test_portfolio.py
+++ b/tests/mcp/test_portfolio.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
+import threading
+import time
 
 import pytest
 
@@ -34,13 +36,24 @@ def test_open_creates_schema_and_sets_user_version(tmp_path):
 
 def test_open_recovers_from_corrupt_database(tmp_path):
     db_path = tmp_path / "portfolio.db"
+    wal_path = tmp_path / "portfolio.db-wal"
+    shm_path = tmp_path / "portfolio.db-shm"
     db_path.write_text("not a sqlite database", encoding="utf-8")
+    wal_path.write_text("stale wal", encoding="utf-8")
+    shm_path.write_text("stale shm", encoding="utf-8")
 
     index = PortfolioIndex(db_path)
     index.open()
 
     with sqlite3.connect(db_path) as conn:
         assert conn.execute("PRAGMA user_version;").fetchone()[0] == 1
+    expected_markers = {
+        wal_path: "stale wal",
+        shm_path: "stale shm",
+    }
+    for sidecar, marker in expected_markers.items():
+        if sidecar.exists():
+            assert sidecar.read_text(encoding="utf-8", errors="ignore") != marker
 
 
 def test_rebuild_workspace_indexes_documents_and_projects(tmp_path):
@@ -105,6 +118,120 @@ def test_search_fts_rejects_malformed_queries(tmp_path):
         index.search_fts('"unterminated', workspace=None, offset=0, limit=10)
 
     assert exc_info.value.code == "E_INVALID_QUERY"
+
+
+def test_connect_uses_nonzero_timeout(tmp_path, monkeypatch):
+    db_path = tmp_path / "portfolio.db"
+    index = PortfolioIndex(db_path)
+
+    captured: dict[str, float | None] = {"timeout": None}
+    real_connect = sqlite3.connect
+
+    def recording_connect(*args, **kwargs):
+        captured["timeout"] = kwargs.get("timeout")
+        return real_connect(*args, **kwargs)
+
+    monkeypatch.setattr("ontos.mcp.portfolio.sqlite3.connect", recording_connect)
+
+    with index._connect() as conn:
+        conn.execute("SELECT 1;")
+
+    assert isinstance(captured["timeout"], (int, float))
+    assert float(captured["timeout"]) > 0.0
+
+
+def test_search_fts_waits_for_concurrent_writer_and_succeeds(tmp_path):
+    workspace_root = create_workspace(tmp_path)
+    db_path = tmp_path / "portfolio.db"
+    index = PortfolioIndex(db_path)
+    index.rebuild_workspace("workspace", workspace_root)
+
+    holder_started = threading.Event()
+    release_writer = threading.Event()
+    outcome: dict[str, object] = {}
+
+    def hold_writer_lock() -> None:
+        locker = sqlite3.connect(db_path)
+        try:
+            locker.execute("BEGIN IMMEDIATE;")
+            locker.execute(
+                "UPDATE projects SET status = status WHERE slug = ?",
+                ("workspace",),
+            )
+            holder_started.set()
+            release_writer.wait(timeout=2.0)
+            locker.rollback()
+        finally:
+            locker.close()
+
+    def run_search() -> None:
+        try:
+            outcome["value"] = index.search_fts("Atom", workspace="workspace", offset=0, limit=10)
+        except Exception as exc:  # pragma: no cover - assertion below validates no exception
+            outcome["error"] = exc
+
+    writer = threading.Thread(target=hold_writer_lock, daemon=True)
+    reader = threading.Thread(target=run_search, daemon=True)
+    writer.start()
+    assert holder_started.wait(timeout=1.0)
+    reader.start()
+    time.sleep(0.1)
+    release_writer.set()
+    writer.join(timeout=2.0)
+    reader.join(timeout=2.0)
+    assert not writer.is_alive()
+    assert not reader.is_alive()
+
+    assert "error" not in outcome
+    payload = outcome.get("value")
+    assert isinstance(payload, dict)
+    assert payload["total_hits"] >= 1
+
+
+def test_search_fts_translates_busy_errors_to_user_error(tmp_path, monkeypatch):
+    workspace_root = create_workspace(tmp_path)
+    db_path = tmp_path / "portfolio.db"
+    index = PortfolioIndex(db_path)
+    index.rebuild_workspace("workspace", workspace_root)
+
+    class FakeBusyConnection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def execute(self, statement, params=()):  # noqa: ARG002
+            if "fts_content MATCH ?" in statement:
+                raise sqlite3.OperationalError("database is locked")
+            if statement == "BEGIN;":
+                return None
+
+            class _Cursor:
+                @staticmethod
+                def fetchone():
+                    return [1]
+
+                @staticmethod
+                def fetchall():
+                    return []
+
+            return _Cursor()
+
+        @staticmethod
+        def rollback():
+            return None
+
+        @staticmethod
+        def commit():
+            return None
+
+    monkeypatch.setattr(index, "_connect", lambda: FakeBusyConnection())
+
+    with pytest.raises(OntosUserError) as exc_info:
+        index.search_fts("Atom", workspace="workspace", offset=0, limit=10)
+
+    assert exc_info.value.code == "E_PORTFOLIO_BUSY"
 
 
 def test_rebuild_workspace_keeps_fts_row_parity(tmp_path):

--- a/tests/mcp/test_portfolio_config.py
+++ b/tests/mcp/test_portfolio_config.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import ontos.mcp.portfolio_config as portfolio_config_module
+from ontos.mcp.portfolio_config import ensure_portfolio_config, load_portfolio_config
+
+
+def test_load_portfolio_config_creates_defaults_when_missing(tmp_path, monkeypatch):
+    config_path = tmp_path / ".config" / "ontos" / "portfolio.toml"
+    monkeypatch.setattr(portfolio_config_module, "PORTFOLIO_CONFIG_PATH", config_path)
+
+    cfg = load_portfolio_config()
+
+    assert config_path.exists()
+    assert cfg.scan_roots == ["~/Dev"]
+    assert cfg.exclude == ["~/Dev/.dev-hub", "~/Dev/archive"]
+    assert cfg.registry_path == "~/Dev/.dev-hub/registry/projects.json"
+    assert cfg.bundle_token_budget == 8192
+    assert cfg.bundle_max_logs == 5
+    assert cfg.bundle_log_window_days == 14
+
+
+def test_load_portfolio_config_custom_values(tmp_path, monkeypatch):
+    config_path = tmp_path / ".config" / "ontos" / "portfolio.toml"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        """
+        [portfolio]
+        scan_roots = ["~/Dev", "~/Work"]
+        exclude = ["~/Dev/archive"]
+        registry_path = "~/Dev/.dev-hub/registry/projects.json"
+
+        [bundle]
+        token_budget = 4000
+        max_logs = 7
+        log_window_days = 3
+        """,
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(portfolio_config_module, "PORTFOLIO_CONFIG_PATH", config_path)
+
+    cfg = load_portfolio_config()
+
+    assert cfg.scan_roots == ["~/Dev", "~/Work"]
+    assert cfg.exclude == ["~/Dev/archive"]
+    assert cfg.registry_path == "~/Dev/.dev-hub/registry/projects.json"
+    assert cfg.bundle_token_budget == 4000
+    assert cfg.bundle_max_logs == 7
+    assert cfg.bundle_log_window_days == 3
+
+
+def test_load_portfolio_config_invalid_toml_raises(tmp_path, monkeypatch):
+    config_path = tmp_path / ".config" / "ontos" / "portfolio.toml"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text("[portfolio\nscan_roots = [\"~/Dev\"]\n", encoding="utf-8")
+    monkeypatch.setattr(portfolio_config_module, "PORTFOLIO_CONFIG_PATH", config_path)
+
+    with pytest.raises(ValueError):
+        load_portfolio_config()
+
+
+def test_ensure_portfolio_config_is_idempotent(tmp_path, monkeypatch):
+    config_path = tmp_path / ".config" / "ontos" / "portfolio.toml"
+    monkeypatch.setattr(portfolio_config_module, "PORTFOLIO_CONFIG_PATH", config_path)
+
+    first = ensure_portfolio_config()
+    second = ensure_portfolio_config()
+
+    assert first == Path(config_path)
+    assert second == Path(config_path)
+    assert config_path.exists()
+

--- a/tests/mcp/test_portfolio_integration.py
+++ b/tests/mcp/test_portfolio_integration.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from ontos.mcp import tools
+from ontos.mcp.portfolio import PortfolioIndex
+from ontos.mcp.schemas import validate_success_payload
+
+from tests.mcp import build_cache, create_workspace
+
+
+def test_portfolio_index_outputs_validate_against_track_a_tools(tmp_path):
+    root = create_workspace(tmp_path)
+    cache = build_cache(root)
+    index = PortfolioIndex(tmp_path / "portfolio.db")
+
+    index.rebuild_workspace("workspace", root)
+
+    registry_payload = validate_success_payload("project_registry", tools.project_registry(index))
+    search_payload = validate_success_payload(
+        "search",
+        tools.search(index, query_string="Atom", workspace_id="workspace"),
+    )
+    bundle_payload = validate_success_payload(
+        "get_context_bundle",
+        tools.get_context_bundle(index, cache, workspace_id="workspace", token_budget=2048),
+    )
+
+    assert registry_payload["project_count"] == 1
+    assert registry_payload["projects"][0]["slug"] == "workspace"
+    assert search_payload["total_hits"] >= 1
+    assert search_payload["results"][0]["workspace_slug"] == "workspace"
+    assert bundle_payload["workspace_slug"] == "workspace"
+    assert bundle_payload["document_count"] >= 1

--- a/tests/mcp/test_project_registry.py
+++ b/tests/mcp/test_project_registry.py
@@ -1,0 +1,56 @@
+import json
+
+from ontos.mcp import tools
+from ontos.mcp.schemas import validate_success_payload
+
+
+class FakePortfolioIndex:
+    def __init__(self, projects):
+        self._projects = projects
+
+    def get_projects(self):
+        return list(self._projects)
+
+
+def test_project_registry_output_shape_and_tag_parsing():
+    portfolio = FakePortfolioIndex(
+        [
+            {
+                "slug": "alpha",
+                "path": "/tmp/alpha",
+                "status": "active",
+                "doc_count": 12,
+                "last_scanned": "2026-04-11T00:00:00Z",
+                "tags": json.dumps(["backend", "api"]),
+                "has_ontos": 1,
+            },
+            {
+                "slug": "beta",
+                "path": "/tmp/beta",
+                "status": "undocumented",
+                "doc_count": 0,
+                "last_scanned": None,
+                "tags": "",
+                "has_ontos": 0,
+            },
+        ]
+    )
+
+    payload = tools.project_registry(portfolio)
+    normalized = validate_success_payload("project_registry", payload)
+
+    assert normalized["project_count"] == 2
+    assert normalized["projects"][0]["tags"] == ["backend", "api"]
+    assert normalized["projects"][1]["tags"] == []
+    assert normalized["projects"][0]["has_ontos"] is True
+    assert normalized["projects"][1]["has_ontos"] is False
+    assert normalized["summary"] == "Portfolio contains 2 projects."
+
+
+def test_project_registry_empty_portfolio():
+    portfolio = FakePortfolioIndex([])
+    payload = tools.project_registry(portfolio)
+
+    assert payload["project_count"] == 0
+    assert payload["projects"] == []
+    assert payload["summary"] == "Portfolio contains 0 projects."

--- a/tests/mcp/test_scanner.py
+++ b/tests/mcp/test_scanner.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from ontos.mcp.scanner import discover_projects, slugify
+import pytest
+
+from ontos.mcp.scanner import discover_projects, load_registry_records, slugify
 
 
 def test_slugify_normalizes_name():
@@ -121,6 +123,35 @@ def test_discover_projects_handles_slug_collisions(tmp_path):
 
     slugs = sorted(entry.slug for entry in projects)
     assert slugs == ["sample-app", "sample-app-2"]
+
+
+@pytest.mark.parametrize(
+    "payload_factory",
+    [
+        lambda entry: [entry],
+        lambda entry: {"projects": [entry]},
+        lambda entry: {"workspaces": [entry]},
+        lambda entry: {"entries": [entry]},
+        lambda entry: {"items": [entry]},
+        lambda entry: {"alpha-project": entry},
+    ],
+)
+def test_load_registry_records_supports_multiple_shapes(tmp_path, payload_factory):
+    dev_root = tmp_path / "Dev"
+    dev_root.mkdir()
+    project_path = _make_project(dev_root / "alpha", with_ontos=True, with_readme=True, doc_count=1)
+    entry = {"path": str(project_path), "status": "documented", "has_ontos": "false"}
+
+    registry_path = tmp_path / ".dev-hub" / "registry" / "projects.json"
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(json.dumps(payload_factory(entry)), encoding="utf-8")
+
+    records = load_registry_records(registry_path, tolerate_errors=False)
+
+    assert len(records) == 1
+    assert records[0].path == project_path
+    assert records[0].status == "documented"
+    assert records[0].has_ontos_raw == "false"
 
 
 def _make_project(path: Path, *, with_ontos: bool, with_readme: bool, doc_count: int) -> Path:

--- a/tests/mcp/test_scanner.py
+++ b/tests/mcp/test_scanner.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ontos.mcp.scanner import discover_projects, slugify
+
+
+def test_slugify_normalizes_name():
+    assert slugify("My.Project Name") == "my-project-name"
+    assert slugify("___") == "workspace"
+
+
+def test_discover_projects_classifies_and_excludes(tmp_path):
+    scan_root = tmp_path / "Dev"
+    scan_root.mkdir()
+
+    documented = _make_project(scan_root / "documented", with_ontos=True, with_readme=True, doc_count=5)
+    partial = _make_project(scan_root / "partial", with_ontos=False, with_readme=True, doc_count=0)
+    undocumented = _make_project(scan_root / "undocumented", with_ontos=False, with_readme=False, doc_count=0)
+    excluded = _make_project(scan_root / "skip-me", with_ontos=True, with_readme=True, doc_count=5)
+
+    projects = discover_projects(
+        scan_roots=[scan_root],
+        exclude=[str(excluded)],
+        registry_path=None,
+    )
+
+    by_path = {entry.path: entry for entry in projects}
+    assert documented in by_path
+    assert partial in by_path
+    assert undocumented in by_path
+    assert excluded not in by_path
+
+    assert by_path[documented].status == "documented"
+    assert by_path[partial].status == "partial"
+    assert by_path[undocumented].status == "undocumented"
+
+
+def test_discover_projects_merges_registry_metadata(tmp_path):
+    scan_root = tmp_path / "Dev"
+    scan_root.mkdir()
+    project_path = _make_project(scan_root / "alpha", with_ontos=True, with_readme=True, doc_count=5)
+
+    registry_path = tmp_path / ".dev-hub" / "registry" / "projects.json"
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "projects": [
+                    {
+                        "path": str(project_path),
+                        "status": "archived",
+                        "tags": ["legacy"],
+                        "metadata": {"owner": "core"},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    projects = discover_projects(
+        scan_roots=[scan_root],
+        exclude=[],
+        registry_path=registry_path,
+    )
+    assert len(projects) == 1
+    project = projects[0]
+    assert project.status == "archived"
+    assert project.tags == ["legacy"]
+    assert project.metadata == {"owner": "core"}
+
+
+def test_discover_projects_resolves_registry_paths_from_dev_root(tmp_path):
+    dev_root = tmp_path / "Dev"
+    dev_root.mkdir()
+    project_path = _make_project(dev_root / "alpha", with_ontos=True, with_readme=True, doc_count=5)
+
+    registry_path = tmp_path / ".dev-hub" / "registry" / "projects.json"
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "dev_root": str(dev_root),
+                "projects": [
+                    {
+                        "path": "alpha",
+                        "status": "documented",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    projects = discover_projects(
+        scan_roots=[],
+        exclude=[],
+        registry_path=registry_path,
+    )
+
+    assert len(projects) == 1
+    assert projects[0].path == project_path
+
+
+def test_discover_projects_handles_slug_collisions(tmp_path):
+    root_one = tmp_path / "DevA"
+    root_two = tmp_path / "DevB"
+    root_one.mkdir()
+    root_two.mkdir()
+
+    _make_project(root_one / "sample-app", with_ontos=True, with_readme=True, doc_count=5)
+    _make_project(root_two / "sample-app", with_ontos=True, with_readme=True, doc_count=5)
+
+    projects = discover_projects(
+        scan_roots=[root_one, root_two],
+        exclude=[],
+        registry_path=None,
+    )
+
+    slugs = sorted(entry.slug for entry in projects)
+    assert slugs == ["sample-app", "sample-app-2"]
+
+
+def _make_project(path: Path, *, with_ontos: bool, with_readme: bool, doc_count: int) -> Path:
+    path.mkdir(parents=True)
+    (path / ".git").mkdir()
+
+    if with_readme:
+        (path / "README.md").write_text("# Example\n", encoding="utf-8")
+
+    if with_ontos:
+        (path / ".ontos.toml").write_text(
+            """
+            [ontos]
+            version = "4.0"
+
+            [scanning]
+            skip_patterns = ["_template.md", "archive/*"]
+            """,
+            encoding="utf-8",
+        )
+        docs_dir = path / "docs"
+        docs_dir.mkdir()
+        for index in range(doc_count):
+            (docs_dir / f"doc-{index}.md").write_text(
+                f"""
+                ---
+                id: doc_{index}
+                type: atom
+                status: active
+                ---
+                Body {index}.
+                """,
+                encoding="utf-8",
+            )
+
+    return path.resolve()

--- a/tests/mcp/test_schemas.py
+++ b/tests/mcp/test_schemas.py
@@ -1,11 +1,63 @@
+from ontos.mcp import tools
+from ontos.mcp.schemas import (
+    LogSessionResponse,
+    PromoteDocumentResponse,
+    RenameDocumentResponse,
+    ScaffoldDocumentResponse,
+    TOOL_ERROR_SCHEMA,
+    WriteToolErrorEnvelope,
+    output_schema_for,
+    validate_success_payload,
+)
+
 from tests.mcp import build_cache, create_workspace
 
-from ontos.mcp import tools
-from ontos.mcp.schemas import output_schema_for, validate_success_payload
+
+class FakePortfolioIndex:
+    def __init__(self, projects, results):
+        self._projects = projects
+        self._results = results
+
+    def get_projects(self):
+        return list(self._projects)
+
+    def search_fts(self, query, workspace, offset, limit):
+        filtered = self._results
+        if workspace:
+            filtered = [row for row in filtered if row["workspace_slug"] == workspace]
+        return {
+            "total_hits": len(filtered),
+            "results": filtered[offset:offset + limit],
+        }
 
 
 def test_success_payloads_validate_against_declared_schemas(tmp_path):
-    cache = build_cache(create_workspace(tmp_path))
+    root = create_workspace(tmp_path)
+    cache = build_cache(root)
+    portfolio = FakePortfolioIndex(
+        projects=[
+            {
+                "slug": "workspace",
+                "path": str(root),
+                "status": "active",
+                "doc_count": 8,
+                "last_scanned": "2026-04-11T00:00:00Z",
+                "tags": '["core"]',
+                "has_ontos": 1,
+            }
+        ],
+        results=[
+            {
+                "doc_id": "atom_doc",
+                "workspace_slug": "workspace",
+                "type": "atom",
+                "status": "active",
+                "path": "docs/atom.md",
+                "snippet": "Atom <mark>body</mark>",
+                "score": -1.2,
+            }
+        ],
+    )
     payloads = {
         "workspace_overview": tools.workspace_overview(cache),
         "context_map": tools.context_map(cache),
@@ -15,6 +67,9 @@ def test_success_payloads_validate_against_declared_schemas(tmp_path):
         "query": tools.query(cache, entity_id="atom_doc"),
         "health": tools.health(cache),
         "refresh": tools.refresh(cache),
+        "project_registry": tools.project_registry(portfolio),
+        "search": tools.search(portfolio, query_string="body"),
+        "get_context_bundle": tools.get_context_bundle(None, cache, token_budget=2048),
     }
 
     for name, payload in payloads.items():
@@ -27,3 +82,60 @@ def test_export_graph_schema_is_one_of():
     schema = output_schema_for("export_graph")
     assert "oneOf" in schema
     assert len(schema["oneOf"]) == 3
+
+
+def test_write_tool_models_validate_success_payload_shapes():
+    ScaffoldDocumentResponse.model_validate(
+        {
+            "success": True,
+            "path": "docs/new.md",
+            "id": "new_doc",
+            "type": "atom",
+            "status": "scaffold",
+            "curation_level": "L0",
+        }
+    )
+    RenameDocumentResponse.model_validate(
+        {
+            "success": True,
+            "old_id": "old_doc",
+            "new_id": "new_doc",
+            "path": "docs/old.md",
+            "references_updated": 2,
+            "updated_files": ["docs/old.md", "docs/strategy.md"],
+        }
+    )
+    LogSessionResponse.model_validate(
+        {
+            "success": True,
+            "path": "docs/logs/2026-04-11_session.md",
+            "id": "2026-04-11_session",
+            "date": "2026-04-11",
+        }
+    )
+    PromoteDocumentResponse.model_validate(
+        {
+            "success": True,
+            "document_id": "doc_1",
+            "old_level": "L1",
+            "new_level": "L2",
+        }
+    )
+
+
+def test_error_schema_supports_write_tool_error_envelope():
+    envelope = WriteToolErrorEnvelope.model_validate(
+        {
+            "isError": True,
+            "error": {
+                "error_code": "E_DUPLICATE_ID",
+                "what": "Document already exists",
+                "why": "Document IDs must be unique",
+                "fix": "Choose a different ID",
+            },
+            "content": [{"type": "text", "text": "Document already exists."}],
+        }
+    )
+    assert envelope.isError is True
+    assert "oneOf" in TOOL_ERROR_SCHEMA
+    assert len(TOOL_ERROR_SCHEMA["oneOf"]) == 2

--- a/tests/mcp/test_search.py
+++ b/tests/mcp/test_search.py
@@ -1,0 +1,152 @@
+import sqlite3
+
+import pytest
+
+from ontos.core.errors import OntosUserError
+from ontos.mcp import tools
+from ontos.mcp.schemas import validate_success_payload
+
+
+class FakePortfolioIndex:
+    def __init__(self, projects, results):
+        self._projects = projects
+        self._results = results
+        self.calls = []
+
+    def get_projects(self):
+        return list(self._projects)
+
+    def search_fts(self, query, workspace, offset, limit):
+        self.calls.append((query, workspace, offset, limit))
+        if query == "bad:[query":
+            raise sqlite3.OperationalError("malformed MATCH expression")
+
+        filtered = self._results
+        if workspace is not None:
+            filtered = [row for row in filtered if row["workspace_slug"] == workspace]
+
+        return {
+            "total_hits": len(filtered),
+            "results": filtered[offset:offset + limit],
+        }
+
+
+def _portfolio():
+    return FakePortfolioIndex(
+        projects=[
+            {"slug": "alpha"},
+            {"slug": "beta"},
+        ],
+        results=[
+            {
+                "doc_id": "alpha_doc_1",
+                "workspace_slug": "alpha",
+                "type": "atom",
+                "status": "active",
+                "path": "docs/a1.md",
+                "snippet": "Alpha <mark>query</mark> one",
+                "score": -2.5,
+            },
+            {
+                "doc_id": "beta_doc_1",
+                "workspace_slug": "beta",
+                "type": "strategy",
+                "status": "active",
+                "path": "docs/b1.md",
+                "snippet": "Beta <mark>query</mark> two",
+                "score": -1.5,
+            },
+            {
+                "doc_id": "alpha_doc_2",
+                "workspace_slug": "alpha",
+                "type": "kernel",
+                "status": "active",
+                "path": "docs/a2.md",
+                "snippet": "Alpha <mark>query</mark> three",
+                "score": -0.9,
+            },
+        ],
+    )
+
+
+def test_search_basic_query_and_schema_validation():
+    portfolio = _portfolio()
+    payload = tools.search(portfolio, query_string="query")
+    normalized = validate_success_payload("search", payload)
+
+    assert normalized["total_hits"] == 3
+    assert len(normalized["results"]) == 3
+    assert portfolio.calls[-1] == ("query", None, 0, 20)
+
+
+def test_search_workspace_filter_and_pagination():
+    portfolio = _portfolio()
+
+    payload = tools.search(
+        portfolio,
+        query_string="query",
+        workspace_id="alpha",
+        offset=1,
+        limit=1,
+    )
+
+    assert payload["total_hits"] == 2
+    assert len(payload["results"]) == 1
+    assert payload["results"][0]["doc_id"] == "alpha_doc_2"
+    assert portfolio.calls[-1] == ("query", "alpha", 1, 1)
+
+
+def test_search_empty_results():
+    portfolio = FakePortfolioIndex(
+        projects=[{"slug": "alpha"}],
+        results=[],
+    )
+
+    payload = tools.search(portfolio, query_string="nothing")
+    assert payload == {"total_hits": 0, "results": []}
+
+
+def test_search_invalid_workspace_raises_user_error():
+    portfolio = _portfolio()
+
+    with pytest.raises(OntosUserError) as exc_info:
+        tools.search(portfolio, query_string="query", workspace_id="missing")
+
+    assert exc_info.value.code == "E_UNKNOWN_WORKSPACE"
+
+
+def test_search_rejects_invalid_args():
+    portfolio = _portfolio()
+
+    with pytest.raises(OntosUserError) as empty_query:
+        tools.search(portfolio, query_string="   ")
+    assert empty_query.value.code == "E_EMPTY_QUERY"
+
+    with pytest.raises(OntosUserError) as invalid_limit:
+        tools.search(portfolio, query_string="query", limit=0)
+    assert invalid_limit.value.code == "E_INVALID_LIMIT"
+
+    with pytest.raises(OntosUserError) as invalid_offset:
+        tools.search(portfolio, query_string="query", offset=-1)
+    assert invalid_offset.value.code == "E_INVALID_OFFSET"
+
+
+def test_search_maps_sqlite_syntax_errors_to_ontos_user_error():
+    portfolio = _portfolio()
+
+    with pytest.raises(OntosUserError) as exc_info:
+        tools.search(portfolio, query_string="bad:[query")
+
+    assert exc_info.value.code == "E_INVALID_QUERY"
+
+
+def test_search_preserves_snippets_and_bm25_ordering():
+    portfolio = _portfolio()
+    payload = tools.search(portfolio, query_string="query")
+
+    assert [result["doc_id"] for result in payload["results"]] == [
+        "alpha_doc_1",
+        "beta_doc_1",
+        "alpha_doc_2",
+    ]
+    assert all("<mark>" in result["snippet"] for result in payload["results"])

--- a/tests/mcp/test_search.py
+++ b/tests/mcp/test_search.py
@@ -4,6 +4,7 @@ import pytest
 
 from ontos.core.errors import OntosUserError
 from ontos.mcp import tools
+from ontos.mcp.scanner import slugify
 from ontos.mcp.schemas import validate_success_payload
 
 
@@ -150,3 +151,7 @@ def test_search_preserves_snippets_and_bm25_ordering():
         "alpha_doc_2",
     ]
     assert all("<mark>" in result["snippet"] for result in payload["results"])
+
+
+def test_tools_slugify_workspace_name_matches_scanner():
+    assert tools._slugify_workspace_name("my--project") == slugify("my--project")

--- a/tests/mcp/test_server_integration.py
+++ b/tests/mcp/test_server_integration.py
@@ -124,9 +124,10 @@ def test_serve_binds_config_to_workspace_across_cwd(tmp_path, monkeypatch):
         def run(self, transport: str) -> None:
             captured["transport"] = transport
 
-    def fake_create_server(cache):
+    def fake_create_server(cache, **kwargs):
         captured["docs_dir"] = cache.config.paths.docs_dir
         captured["initial_count"] = cache.canonical_view.total_count
+        captured["kwargs"] = kwargs
         write_file(
             target_root / "knowledge/extra.md",
             """
@@ -152,3 +153,4 @@ def test_serve_binds_config_to_workspace_across_cwd(tmp_path, monkeypatch):
     assert captured["docs_dir"] == "knowledge"
     assert captured["initial_count"] == 1
     assert captured["refreshed_count"] == 2
+    assert captured["kwargs"]["include_bundle_tool"] is True

--- a/tests/mcp/test_server_portfolio_mode.py
+++ b/tests/mcp/test_server_portfolio_mode.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from tests.mcp import build_server, create_workspace, list_tools
+
+
+CORE_TOOLS = {
+    "workspace_overview",
+    "context_map",
+    "get_document",
+    "list_documents",
+    "export_graph",
+    "query",
+    "health",
+    "refresh",
+}
+
+
+class FakePortfolioIndex:
+    def get_projects(self):
+        return [
+            {
+                "slug": "workspace",
+                "path": "/tmp/workspace",
+                "status": "documented",
+                "doc_count": 8,
+                "last_scanned": "2026-04-11T00:00:00Z",
+                "tags": [],
+                "has_ontos": 1,
+            }
+        ]
+
+    def search_fts(self, query, workspace, offset, limit):
+        _ = (query, workspace, offset, limit)
+        return {"total_hits": 0, "results": []}
+
+
+def test_create_server_includes_bundle_tool_in_single_workspace_mode(tmp_path):
+    root = create_workspace(tmp_path)
+
+    server = build_server(root, include_bundle_tool=True)
+    tool_map = {tool.name: tool for tool in list_tools(server)}
+
+    assert set(tool_map) == CORE_TOOLS | {"get_context_bundle"}
+    assert len(tool_map) == 9
+    assert tool_map["get_context_bundle"].annotations.readOnlyHint is True
+    assert "workspace_id" in tool_map["get_context_bundle"].inputSchema["properties"]
+    assert "token_budget" in tool_map["get_context_bundle"].inputSchema["properties"]
+
+
+def test_create_server_registers_track_a_portfolio_matrix(tmp_path):
+    root = create_workspace(tmp_path)
+
+    server = build_server(
+        root,
+        portfolio_index=FakePortfolioIndex(),
+        include_bundle_tool=True,
+    )
+    tool_map = {tool.name: tool for tool in list_tools(server)}
+
+    expected = CORE_TOOLS | {"project_registry", "search", "get_context_bundle"}
+
+    assert set(tool_map) == expected
+    assert len(tool_map) == 11
+    assert tool_map["project_registry"].annotations.readOnlyHint is True
+    assert tool_map["search"].annotations.readOnlyHint is True
+    assert tool_map["get_context_bundle"].annotations.readOnlyHint is True
+
+    for name in ("workspace_overview", "search", "project_registry", "get_context_bundle"):
+        assert "workspace_id" in tool_map[name].inputSchema["properties"]

--- a/tests/mcp/test_server_portfolio_mode.py
+++ b/tests/mcp/test_server_portfolio_mode.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import asyncio
+
+from mcp.types import CallToolResult
+
 from tests.mcp import build_server, create_workspace, list_tools
 
 
@@ -67,3 +71,18 @@ def test_create_server_registers_track_a_portfolio_matrix(tmp_path):
 
     for name in ("workspace_overview", "search", "project_registry", "get_context_bundle"):
         assert "workspace_id" in tool_map[name].inputSchema["properties"]
+
+
+def test_single_workspace_call_to_portfolio_tool_returns_structured_error(tmp_path):
+    root = create_workspace(tmp_path)
+    server = build_server(root, include_bundle_tool=True)
+    tool_names = {tool.name for tool in list_tools(server)}
+
+    assert "project_registry" not in tool_names
+    assert "search" not in tool_names
+
+    result = asyncio.run(server.call_tool("project_registry", {}))
+    assert isinstance(result, CallToolResult)
+    assert result.isError is True
+    assert result.structuredContent["isError"] is True
+    assert "E_PORTFOLIO_REQUIRED" in result.content[0].text

--- a/tests/test_session_context.py
+++ b/tests/test_session_context.py
@@ -12,6 +12,7 @@ from multiprocessing import Event, Process
 from pathlib import Path
 import pytest
 
+import ontos.core.context as context_module
 from ontos.core.context import SessionContext, FileOperation, PendingWrite
 
 
@@ -86,8 +87,10 @@ class TestSessionContext:
 
     def test_session_context_docstring_describes_buffered_commit_behavior(self):
         docstring = inspect.getdoc(SessionContext) or ""
+        module_docstring = inspect.getdoc(context_module) or ""
         assert "two-phase commit" not in docstring.lower()
         assert "atomic writes" not in docstring.lower()
+        assert "sequentially" in module_docstring.lower()
 
 
 class TestFileLocking:

--- a/tests/test_session_context.py
+++ b/tests/test_session_context.py
@@ -2,16 +2,24 @@
 
 Tests the v2.8 refactoring deliverables:
 - SessionContext buffer/commit/rollback operations
-- File locking with stale detection
+- File locking with flock
 - Backwards compatibility (old imports reference same objects as new)
 """
 
-import os
-import pytest
+import fcntl
+from multiprocessing import Event, Process
 from pathlib import Path
-from unittest.mock import patch
+import pytest
 
 from ontos.core.context import SessionContext, FileOperation, PendingWrite
+
+
+def _hold_lock(lock_path: str, ready: Event, release: Event) -> None:
+    with Path(lock_path).open("a+", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        ready.set()
+        release.wait(timeout=5.0)
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
 
 class TestSessionContext:
@@ -82,24 +90,32 @@ class TestFileLocking:
     def test_acquire_lock_success(self, tmp_path):
         """Should successfully acquire lock when none exists."""
         ctx = SessionContext(repo_root=tmp_path, config={})
-        lock_path = tmp_path / '.ontos' / 'write.lock'
-        lock_path.parent.mkdir(parents=True)
+        lock_path = tmp_path / ".ontos.lock"
         
         assert ctx._acquire_lock(lock_path)
         assert lock_path.exists()
-        assert lock_path.read_text() == str(os.getpid())
+        assert ctx._lock_handle is not None
         ctx._release_lock(lock_path)
-        assert not lock_path.exists()
+        assert ctx._lock_handle is None
 
-    def test_stale_lock_detection(self, tmp_path):
-        """Lock held by dead process should be removed."""
-        lock_path = tmp_path / '.ontos' / 'write.lock'
-        lock_path.parent.mkdir(parents=True)
-        lock_path.write_text('99999999')  # Non-existent PID
+    def test_acquire_lock_timeout_when_busy(self, tmp_path):
+        """Lock acquisition should timeout while another process holds flock."""
+        lock_path = tmp_path / ".ontos.lock"
+        ready = Event()
+        release = Event()
+        proc = Process(target=_hold_lock, args=(str(lock_path), ready, release))
+        proc.start()
+        try:
+            assert ready.wait(timeout=2.0)
 
-        ctx = SessionContext(repo_root=tmp_path, config={})
-        assert ctx._acquire_lock(lock_path, timeout=1.0)
-        ctx._release_lock(lock_path)
+            ctx = SessionContext(repo_root=tmp_path, config={})
+            assert ctx._acquire_lock(lock_path, timeout=0.2) is False
+        finally:
+            release.set()
+            proc.join(timeout=2.0)
+            if proc.is_alive():
+                proc.terminate()
+                proc.join(timeout=1.0)
 
 
 class TestNewImportPaths:

--- a/tests/test_session_context.py
+++ b/tests/test_session_context.py
@@ -7,6 +7,7 @@ Tests the v2.8 refactoring deliverables:
 """
 
 import fcntl
+import inspect
 from multiprocessing import Event, Process
 from pathlib import Path
 import pytest
@@ -82,6 +83,11 @@ class TestSessionContext:
         (tmp_path / '.ontos').mkdir()
         ctx = SessionContext.from_repo(tmp_path)
         assert ctx.repo_root == tmp_path
+
+    def test_session_context_docstring_describes_buffered_commit_behavior(self):
+        docstring = inspect.getdoc(SessionContext) or ""
+        assert "two-phase commit" not in docstring.lower()
+        assert "atomic writes" not in docstring.lower()
 
 
 class TestFileLocking:


### PR DESCRIPTION
## Summary
Implements Ontos v4.1 Track A only: portfolio indexing, MCP read tools, context bundling, portfolio verification, and the shared flock lock substrate.

This PR follows the v4.1 implementation spec v1.1 final (`.project-internal/v4.1/phaseA/Ontos-v4.1-Implementation-Spec.md`) and the Phase B verdict (`.project-internal/reviews/ontos-v4.1-spec-B-verdict.md`). Codebase behavior won on the known drift points from Phase B, including the existing `verify` command surface, `_cmd_verify()` routing, `SnapshotCache` method names, and the repo-wide `SessionContext._acquire_lock()` migration.

## What Changed
- Portfolio substrate
  - Added `PortfolioIndex`, `PortfolioConfig`, project discovery, registry-aware scan resolution, and SQLite FTS-backed portfolio search.
  - Added context bundle assembly for token-budgeted workspace reads.
- MCP server/read surface
  - Added Track A tool registration and routing for `project_registry`, `search`, and `get_context_bundle`.
  - Threaded `workspace_id` through the read surface and updated output schema coverage, including shared Track B response/error models in `schemas.py` without registering write tools.
  - Kept the Track A availability matrix: the 8 v4.0 tools in both modes, `project_registry` and `search` only in portfolio mode, and `get_context_bundle` in both modes.
- CLI / verify / packaging
  - Extended the existing `verify` command with `--portfolio` and preserved the existing document verification flow.
  - Added portfolio DB vs registry verification, including real `dev_root` registry resolution.
  - Bumped package floor to Python 3.10+ and updated the MCP extra range.
  - Hardened config loading for mixed-version workspaces by mapping legacy `validation.strict` into `hooks.strict` and ignoring unknown section-local keys during load.
- Lock substrate
  - Migrated workspace write locking from PID-file behavior to `fcntl.flock` on `.ontos.lock`.
  - Added the shared MCP locking helper and verified existing CLI write tests still pass.

## Tests
Baseline before Track A in `.venv-mcp`: 983 collected tests.

After this PR:
- Full suite: 1033 collected (`1031 passed, 2 skipped`)
- Delta: +50 collected tests

## Smoke Checks
- `ontos --help`
- `ontos verify --help`
- `ontos serve --help`
- `ontos serve --portfolio`
- `ontos verify --portfolio`
- `rg -n "write\.lock|os\.kill\(|stale lock|PID" ontos tests`

## Notes
- This PR implements Track A only.
- Track B (write tools) will be a separate follow-on PR after this merges, per the v4.1 sequential track plan.
- No write-tool registration or `_invoke_write_tool()` is included here.
