### PR TITLE
test: update legacy SessionContext lock tests for flock

### DIFF
--- a/.ontos/scripts/tests/test_context.py
+++ b/.ontos/scripts/tests/test_context.py
@@ -2,7 +2,7 @@
 
 This test suite validates the core SessionContext functionality:
 - Buffer operations (write/delete/move)
-- Two-phase commit with atomicity
+- Staged commit behavior for buffered writes
 - Rollback behavior
 - Lock acquisition and timeout
 - Factory initialization
@@ -29,6 +29,19 @@ def _hold_flock(lock_path: str, ready, release) -> None:
         fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
         ready.set()
         release.wait(timeout=5.0)
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def _try_flock_once(lock_path: str, acquired) -> None:
+    """Try to acquire the lock once and immediately release it."""
+    path = Path(lock_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a+", encoding="utf-8") as handle:
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            return
+        acquired.set()
         fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
 
@@ -75,7 +88,7 @@ class TestBufferOperations:
 
 
 class TestCommit:
-    """Tests for commit() method - file creation and atomicity."""
+    """Tests for commit() method - file creation and staged updates."""
 
     def test_commit_empty_buffer_returns_empty(self, tmp_path):
         """Commit with no pending writes returns empty list."""
@@ -252,13 +265,21 @@ class TestLocking:
         """Commit properly acquires and releases lock."""
         ctx = SessionContext(repo_root=tmp_path, config={})
         ctx.buffer_write(tmp_path / "test.txt", "content")
-        
-        lock_file = tmp_path / ".ontos" / "write.lock"
-        
+
         ctx.commit()
-        
-        # Lock should be released after commit
-        assert not lock_file.exists()
+
+        lock_file = tmp_path / ".ontos.lock"
+        assert lock_file.exists()
+
+        acquired = Event()
+        proc = Process(target=_try_flock_once, args=(str(lock_file), acquired))
+        proc.start()
+        proc.join(timeout=5.0)
+        if proc.is_alive():
+            proc.terminate()
+            proc.join(timeout=1.0)
+
+        assert acquired.is_set(), "Lock remained held after commit"
 
 
 class TestFromRepo:

--- a/.ontos/scripts/tests/test_context.py
+++ b/.ontos/scripts/tests/test_context.py
@@ -11,14 +11,25 @@ This test suite validates the core SessionContext functionality:
 Per v2.9.5 spec, tests focus on behavior, not internal mechanics.
 """
 
-import os
-import time
+import fcntl
 import types
+from multiprocessing import Event, Process
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 import pytest
 
 from ontos.core.context import SessionContext, FileOperation, PendingWrite
+
+
+def _hold_flock(lock_path: str, ready, release) -> None:
+    """Hold an exclusive flock lock until the caller signals release."""
+    path = Path(lock_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a+", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        ready.set()
+        release.wait(timeout=5.0)
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
 
 class TestBufferOperations:
@@ -159,9 +170,14 @@ class TestCommitFailure:
             with pytest.raises(OSError):
                 ctx.commit()
         
-        # No residual files should exist after cleanup
-        remaining = [f for f in tmp_path.iterdir() if f.is_file()]
-        assert len(remaining) == 0, f"Residual files after cleanup: {remaining}"
+        # The flock substrate keeps a persistent lock file, but temp outputs
+        # from the failed write should still be cleaned up.
+        remaining = sorted(f.name for f in tmp_path.iterdir() if f.is_file())
+        assert remaining == [".ontos.lock"], (
+            f"Unexpected residual files after cleanup: {remaining}"
+        )
+        assert not target.exists()
+        assert not target.with_suffix(target.suffix + ".tmp").exists()
 
     def test_commit_failure_records_error(self, tmp_path):
         """Commit failure records error in context."""
@@ -208,26 +224,29 @@ class TestLocking:
         """Commit raises RuntimeError when lock cannot be acquired."""
         ctx = SessionContext(repo_root=tmp_path, config={})
         ctx.buffer_write(tmp_path / "test.txt", "content")
-        
-        # Pre-create lock file with our own PID (simulates active lock)
-        lock_dir = tmp_path / ".ontos"
-        lock_dir.mkdir(parents=True, exist_ok=True)
-        lock_file = lock_dir / "write.lock"
-        lock_file.write_text(str(os.getpid()))  # Our own PID = not stale
-        
-        # Mock time.time to simulate timeout
-        start_time = time.time()
-        call_count = [0]
-        def mock_time():
-            call_count[0] += 1
-            # First call returns start time, subsequent calls exceed timeout
-            if call_count[0] == 1:
-                return start_time
-            return start_time + 10  # Exceeds 5.0 second timeout
-        
-        with patch('time.time', side_effect=mock_time):
-            with pytest.raises(RuntimeError, match="Could not acquire write lock"):
-                ctx.commit()
+
+        lock_file = tmp_path / ".ontos.lock"
+        ready = Event()
+        release = Event()
+        proc = Process(target=_hold_flock, args=(str(lock_file), ready, release))
+        proc.start()
+
+        try:
+            assert ready.wait(timeout=5.0), "Timed out waiting for lock holder"
+            original_acquire = ctx._acquire_lock
+
+            def short_timeout(lock_path, timeout=5.0):
+                return original_acquire(lock_path, timeout=0.2)
+
+            with patch.object(ctx, "_acquire_lock", side_effect=short_timeout):
+                with pytest.raises(RuntimeError, match="Could not acquire write lock"):
+                    ctx.commit()
+        finally:
+            release.set()
+            proc.join(timeout=5.0)
+            if proc.is_alive():
+                proc.terminate()
+                proc.join(timeout=1.0)
 
     def test_commit_acquires_and_releases_lock(self, tmp_path):
         """Commit properly acquires and releases lock."""

--- a/docs/logs/2026-04-11_merge-pr87-fix-legacy-flock-tests.md
+++ b/docs/logs/2026-04-11_merge-pr87-fix-legacy-flock-tests.md
@@ -1,0 +1,65 @@
+---
+id: log_20260411_merge-pr87-fix-legacy-flock-tests
+type: log
+status: active
+event_type: fix
+source: codex
+branch: codex/fix-main-ci-lock-compat
+created: 2026-04-11
+---
+
+# merge-pr87-fix-legacy-flock-tests
+
+## Goal
+
+Archive the post-merge CI follow-up that fixed the stale legacy
+`SessionContext` lock tests after PR #85 migrated the lock substrate from
+`.ontos/write.lock` PID files to `.ontos.lock` with `fcntl.flock`, and record
+that PR #87 reached green CI and merge-ready state.
+
+## Root Cause
+
+PR #85 correctly changed the production lock implementation, but one legacy test
+file under `.ontos/scripts/tests/` still asserted against the removed
+`.ontos/write.lock` path and expected full file cleanup semantics that no
+longer apply to the persistent flock lock file. That left `main` with a
+false-negative CI failure after the feature PR merged.
+
+## Key Decisions
+
+- Kept the fix test-only and left production code unchanged because the modern
+  `tests/` suite already covered the flock implementation correctly.
+- Replaced the stale PID-file timeout simulation with cross-process flock
+  holders so the legacy tests now exercise the real lock substrate.
+- Updated the remaining release-path assertion to verify that another process
+  can acquire `.ontos.lock` after `commit()` instead of checking for deletion of
+  the old `.ontos/write.lock` path.
+- Updated the legacy test descriptions to describe staged buffered commits
+  rather than a two-phase atomic transaction model.
+
+## Alternatives Considered
+
+- Reintroducing `.ontos/write.lock` compatibility in production code:
+  rejected because it would reverse the intended Track A lock migration.
+- Keeping the old release-path assertion and only fixing the timeout case:
+  rejected because that left a false-green test which did not verify lock
+  release on the current substrate.
+- Skipping the legacy `.ontos/scripts/tests/` suite:
+  rejected because GitHub Actions runs it explicitly, so the fix had to make
+  that suite authoritative again.
+
+## Impacts
+
+- PR #87 restored green CI on `main` for the post-merge Track A follow-up.
+- The legacy and modern `SessionContext` tests now align on `.ontos.lock`
+  semantics.
+- The repository was left otherwise unchanged; unrelated local untracked files
+  remained untouched throughout the fix and merge-prep workflow.
+
+## Testing
+
+- `.venv-mcp/bin/pytest .ontos/scripts/tests/test_context.py -q`
+- `.venv-mcp/bin/pytest tests/test_session_context.py -q`
+- `.venv-mcp/bin/pytest .ontos/scripts/tests/ -q`
+- PR #87 GitHub Actions checks passed on Python 3.9, 3.10, 3.11, 3.12, plus
+  `test-non-editable`.


### PR DESCRIPTION
## Summary
- update the legacy `.ontos/scripts/tests/test_context.py` expectations to match the current `.ontos.lock` + `fcntl.flock` substrate
- replace the stale PID-file timeout simulation with a real cross-process flock holder
- keep the fix scoped to tests only; production code from PR #85 is unchanged

## Root Cause
PR #85 migrated `SessionContext` from `.ontos/write.lock` PID files to `.ontos.lock` with `fcntl.flock`. The main test suite already covered the new behavior, but the legacy script test file still assumed:
- lock contention came from a PID file at `.ontos/write.lock`
- failed commits removed every file, including the persistent flock file

That left `main` with a post-merge CI failure even though the implementation was correct.

## Verification
- `.venv-mcp/bin/pytest .ontos/scripts/tests/test_context.py -v --tb=short`
- `.venv-mcp/bin/pytest tests/test_session_context.py .ontos/scripts/tests/test_context.py -v --tb=short`
- `.venv-mcp/bin/pytest .ontos/scripts/tests/ -v --tb=short`
- `.venv-mcp/bin/pytest tests/ -q --tb=short`

Local result: `1056 passed, 2 skipped` for `tests/`, plus `152 passed` for `.ontos/scripts/tests/`.

## Notes
This is a post-merge CI follow-up for `feat(v4.1): Track A — portfolio index, read tools, flock substrate` on `main`.