### PR TITLE
feat(v4.1 Track B): bundle config wiring + SF-3/4/9 + m-1/3/5/9/10/11 (Dev 4)

### DIFF
--- a/ontos/cli.py
+++ b/ontos/cli.py
@@ -890,9 +890,9 @@ def _cmd_serve(args) -> int:
         from ontos.mcp import serve
         portfolio = bool(getattr(args, "portfolio", False))
         read_only = bool(getattr(args, "read_only", False))
-        if portfolio or read_only:
-            return serve(workspace_root, portfolio=portfolio, read_only=read_only)
-        return serve(workspace_root)
+        # m-3: always forward the same kwargs, regardless of truthiness, so
+        # behavior is uniform and there is a single call path to reason about.
+        return serve(workspace_root, portfolio=portfolio, read_only=read_only)
     except FileNotFoundError as exc:
         raise OntosUserError(str(exc), code="E_WORKSPACE_NOT_FOUND") from exc
     except ModuleNotFoundError as exc:
@@ -1311,9 +1311,11 @@ def _cmd_verify(args) -> int:
     """Handle verify command."""
     if getattr(args, "portfolio", False):
         from ontos.commands.verify import verify_portfolio
-        from ontos.mcp.portfolio_config import load_portfolio_config
+        from ontos.mcp.portfolio_config import ensure_portfolio_config, load_portfolio_config
 
         try:
+            # Write-then-read: init the config on first use, then read it.
+            ensure_portfolio_config()
             config = load_portfolio_config()
         except (OSError, ValueError, TypeError) as exc:
             message = f"Invalid portfolio config: {exc}"

--- a/ontos/commands/export_data.py
+++ b/ontos/commands/export_data.py
@@ -3,13 +3,13 @@ Export data command — bulk document export to JSON.
 """
 
 from __future__ import annotations
-import hashlib
 import json
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Any
 
+from ontos.core.content_hash import compute_content_hash
 from ontos.core.snapshot import SnapshotFilters
 from ontos.io.snapshot import create_snapshot, DocumentSnapshot
 from ontos.core.migration import classify_documents
@@ -36,11 +36,6 @@ def _parse_csv(value: Optional[str]) -> Optional[List[str]]:
     if not value:
         return None
     return [v.strip() for v in value.split(",") if v.strip()]
-
-
-def _compute_content_hash(content: str) -> str:
-    """Compute SHA256 hash of content."""
-    return f"sha256:{hashlib.sha256(content.encode('utf-8')).hexdigest()[:16]}"
 
 
 def _snapshot_to_json(
@@ -88,7 +83,7 @@ def _snapshot_to_json(
             "inferred_migration_status": classification.inferred_status if classification else None,
             "effective_migration_status": classification.effective_status if classification else None,
             "content": doc.content if doc.content else None,
-            "content_hash": _compute_content_hash(doc.content) if doc.content else None,
+            "content_hash": compute_content_hash(doc.content) if doc.content else None,
         }
         documents.append(doc_dict)
 

--- a/ontos/core/content_hash.py
+++ b/ontos/core/content_hash.py
@@ -1,0 +1,20 @@
+"""Shared content-hash utilities.
+
+Lives in ``ontos.core`` so it can be consumed by both command-layer modules
+and the portfolio / bridge modules without creating a layering inversion
+(see m-10 in v4.1 Track A/D verdict).
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+
+def compute_content_hash(content: str) -> str:
+    """Compute SHA256 hash of content, returned as ``sha256:<16-hex-prefix>``.
+
+    The 16-character truncation matches the historical format emitted by
+    ``ontos.commands.export_data`` and consumed by the MCP portfolio index,
+    the MCP tools response bodies, and downstream tests.
+    """
+    return f"sha256:{hashlib.sha256(content.encode('utf-8')).hexdigest()[:16]}"

--- a/ontos/mcp/_types.py
+++ b/ontos/mcp/_types.py
@@ -1,0 +1,43 @@
+"""Shared structural types for the MCP layer.
+
+Kept deliberately minimal: only the surface area that MCP tools and the MCP
+server actually rely on when they accept a portfolio index. Callers who need
+richer behavior should import :class:`ontos.mcp.portfolio.PortfolioIndex`
+directly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Optional, Protocol
+
+
+class PortfolioIndexLike(Protocol):
+    """Structural type for objects consumed as a portfolio index.
+
+    Matches :class:`ontos.mcp.portfolio.PortfolioIndex`. Kept narrow to the
+    methods invoked from :mod:`ontos.mcp.server` and :mod:`ontos.mcp.tools`
+    so that typing stays honest (m-11: replace blanket ``Any``).
+    """
+
+    def get_projects(self) -> list[dict[str, Any]]:
+        """Return portfolio project metadata rows."""
+        ...
+
+    def search_fts(
+        self,
+        query: str,
+        workspace: Optional[str],
+        offset: int,
+        limit: int,
+    ) -> dict[str, Any]:
+        """Execute BM25-ranked full-text search over indexed documents."""
+        ...
+
+    def rebuild_workspace(self, slug: str, workspace_root: Path) -> None:
+        """Rebuild the portfolio index rows for a single workspace."""
+        ...
+
+    def close(self) -> None:
+        """Release any resources held by the index."""
+        ...

--- a/ontos/mcp/bundler.py
+++ b/ontos/mcp/bundler.py
@@ -33,26 +33,40 @@ def build_context_bundle(
     workspace_root: Path,
     workspace_slug: str,
     *,
-    token_budget: int = 8192,
-    max_logs: int = 5,
-    log_window_days: int = 14,
+    token_budget: int = 8000,
+    max_logs: int = 20,
+    log_window_days: int = 30,
 ) -> dict[str, Any]:
-    """Build a token-budgeted context bundle from a workspace snapshot."""
+    """Build a token-budgeted context bundle from a workspace snapshot.
+
+    Defaults mirror the addendum v1.2 §A4 bundle values; the MCP tool layer
+    passes the values loaded from :class:`PortfolioConfig` explicitly.
+
+    SF-9 (deterministic input ordering): every point where the bundler
+    iterates ``snapshot.documents`` is sorted by document ID before any
+    downstream sort. Python dict iteration order is insertion-order since
+    3.7, but the snapshot loader's insertion order is influenced by
+    ``os.listdir``/glob output and so cannot be relied upon for stable
+    bundle output. An explicit sort here decouples bundle determinism from
+    filesystem iteration quirks.
+    """
     docs_by_id = snapshot.documents
+    # SF-9: deterministic iteration — sort doc IDs before consuming dict order.
+    sorted_doc_ids = sorted(docs_by_id)
     in_degree = {
         doc_id: len(snapshot.graph.reverse_edges.get(doc_id, []))
-        for doc_id in docs_by_id
+        for doc_id in sorted_doc_ids
     }
     non_kernel_degrees = [
-        value
-        for doc_id, value in in_degree.items()
+        in_degree[doc_id]
+        for doc_id in sorted_doc_ids
         if docs_by_id[doc_id].type.value != "kernel"
     ]
     max_non_kernel_indegree = max(non_kernel_degrees) if non_kernel_degrees else 0
 
     scored_docs = [
-        _to_bundle_doc(doc, in_degree[doc.id], max_non_kernel_indegree)
-        for doc in docs_by_id.values()
+        _to_bundle_doc(docs_by_id[doc_id], in_degree[doc_id], max_non_kernel_indegree)
+        for doc_id in sorted_doc_ids
     ]
     priority_docs = _build_priority_order(
         scored_docs,
@@ -134,7 +148,14 @@ def _build_priority_order(
     )
     recent_log_ids = {doc.id for doc in recent_logs}
 
-    non_kernel = [doc for doc in docs if doc.type != "kernel" and doc.id not in recent_log_ids]
+    # SF-3 / addendum A4: treat ``max_logs`` and ``log_window_days`` as hard
+    # caps on the log entries in the bundle. Logs only enter the bundle via
+    # the recent-logs pool (scored at 0.3). Stale logs or logs beyond the
+    # ``max_logs`` cap are excluded entirely — otherwise a workspace with
+    # dozens of stale logs would blow past ``max_logs`` by re-entering
+    # through the ``remaining`` bucket (and would also be silently upgraded
+    # to a higher non-kernel score).
+    non_kernel = [doc for doc in docs if doc.type != "kernel" and doc.type != "log"]
     high_indegree = sorted(
         non_kernel,
         key=lambda doc: (-in_degree.get(doc.id, 0), doc.id),
@@ -167,7 +188,9 @@ def _recent_logs(
     cutoff = date.today() - timedelta(days=log_window_days)
     dated_logs: list[tuple[date, BundleDocument]] = []
 
-    for bundle_doc in docs:
+    # SF-9: iterate docs in ID order so the walk that builds `dated_logs`
+    # does not depend on upstream dict order before the explicit sort.
+    for bundle_doc in sorted(docs, key=lambda d: d.id):
         if bundle_doc.type != "log":
             continue
         source = docs_by_id[bundle_doc.id]
@@ -176,7 +199,11 @@ def _recent_logs(
             continue
         dated_logs.append((log_date, replace(bundle_doc, score=0.3)))
 
-    dated_logs.sort(key=lambda item: (item[0], item[1].id), reverse=True)
+    # SF-4: equal-date tiebreak is *ascending* ID (spec v1.1 §4.2 — "sort
+    # alphabetically by document ID" — for LLM-prompt-cache stability).
+    # `reverse=True` on a tuple key would reverse both fields, so we sort by
+    # (-date_ordinal, id) ascending to get newest-first + alpha-tiebreak.
+    dated_logs.sort(key=lambda item: (-item[0].toordinal(), item[1].id))
     return [doc for _, doc in dated_logs[:max_logs]]
 
 

--- a/ontos/mcp/portfolio.py
+++ b/ontos/mcp/portfolio.py
@@ -9,7 +9,7 @@ import sqlite3
 import threading
 from typing import Any, Optional
 
-from ontos.commands.export_data import _compute_content_hash
+from ontos.core.content_hash import compute_content_hash
 from ontos.core.errors import OntosUserError
 from ontos.io.config import load_project_config
 from ontos.io.scan_scope import collect_scoped_documents, resolve_scan_scope
@@ -357,7 +357,7 @@ class PortfolioIndex:
                             rel_path,
                             self._extract_title(doc.frontmatter),
                             self._extract_curation(doc.frontmatter),
-                            _compute_content_hash(doc.content) if doc.content else None,
+                            compute_content_hash(doc.content) if doc.content else None,
                             len(doc.content.split()) if doc.content else 0,
                             concepts,
                             doc.content,
@@ -446,7 +446,10 @@ class PortfolioIndex:
             self._create_schema(conn)
             return
         raise sqlite3.DatabaseError(
-            f"Schema version mismatch: expected {self.SCHEMA_VERSION}, got {version}"
+            f"Schema version mismatch: expected {self.SCHEMA_VERSION}, got {version}. "
+            "The caller (PortfolioIndex.open) recovers by invoking "
+            "_reset_db_file() to delete the on-disk database and recreate the "
+            "schema from scratch; no manual migration is performed."
         )
 
     def _create_schema(self, conn: sqlite3.Connection) -> None:

--- a/ontos/mcp/portfolio_config.py
+++ b/ontos/mcp/portfolio_config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import List, Optional
 
 try:  # Python 3.11+
     import tomllib
@@ -13,12 +14,12 @@ except ImportError:  # pragma: no cover - Python 3.10 fallback
 
 @dataclass(frozen=True)
 class PortfolioConfig:
-    scan_roots: list[str] = field(default_factory=lambda: ["~/Dev"])
-    exclude: list[str] = field(default_factory=lambda: ["~/Dev/.dev-hub", "~/Dev/archive"])
-    registry_path: str | None = "~/Dev/.dev-hub/registry/projects.json"
-    bundle_token_budget: int = 8192
-    bundle_max_logs: int = 5
-    bundle_log_window_days: int = 14
+    scan_roots: List[str] = field(default_factory=lambda: ["~/Dev"])
+    exclude: List[str] = field(default_factory=lambda: ["~/Dev/.dev-hub", "~/Dev/archive"])
+    registry_path: Optional[str] = "~/Dev/.dev-hub/registry/projects.json"
+    bundle_token_budget: int = 8000
+    bundle_max_logs: int = 20
+    bundle_log_window_days: int = 30
 
 
 PORTFOLIO_CONFIG_PATH = Path.home() / ".config" / "ontos" / "portfolio.toml"
@@ -29,14 +30,19 @@ exclude = ["~/Dev/.dev-hub", "~/Dev/archive"]
 registry_path = "~/Dev/.dev-hub/registry/projects.json"
 
 [bundle]
-token_budget = 8192
-max_logs = 5
-log_window_days = 14
+token_budget = 8000
+max_logs = 20
+log_window_days = 30
 """
 
 
 def ensure_portfolio_config() -> Path:
-    """Ensure the portfolio config file exists and return its path."""
+    """Ensure the portfolio config file exists on disk; create from defaults if missing.
+
+    This is the *write* path. Callers that only want to read the config should
+    either call :func:`ensure_portfolio_config` explicitly first (for init flows)
+    or call :func:`load_portfolio_config` directly (which raises if absent).
+    """
     PORTFOLIO_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
     if not PORTFOLIO_CONFIG_PATH.exists():
         PORTFOLIO_CONFIG_PATH.write_text(_DEFAULT_CONFIG_TEXT, encoding="utf-8")
@@ -44,9 +50,18 @@ def ensure_portfolio_config() -> Path:
 
 
 def load_portfolio_config() -> PortfolioConfig:
-    """Load portfolio config from ~/.config/ontos/portfolio.toml."""
-    config_path = ensure_portfolio_config()
-    with config_path.open("rb") as handle:
+    """Load portfolio config from ~/.config/ontos/portfolio.toml.
+
+    Pure read path: this function never writes to disk. Raises
+    :class:`FileNotFoundError` if the config file is absent. Callers that need
+    auto-init semantics should call :func:`ensure_portfolio_config` first.
+    """
+    if not PORTFOLIO_CONFIG_PATH.exists():
+        raise FileNotFoundError(
+            f"Portfolio config not found at {PORTFOLIO_CONFIG_PATH}. "
+            "Call ensure_portfolio_config() to write the default, or create it manually."
+        )
+    with PORTFOLIO_CONFIG_PATH.open("rb") as handle:
         data = tomllib.load(handle)
 
     portfolio = data.get("portfolio", {}) if isinstance(data, dict) else {}
@@ -60,19 +75,19 @@ def load_portfolio_config() -> PortfolioConfig:
         scan_roots=_coerce_str_list(portfolio.get("scan_roots"), ["~/Dev"]),
         exclude=_coerce_str_list(portfolio.get("exclude"), ["~/Dev/.dev-hub", "~/Dev/archive"]),
         registry_path=_coerce_optional_str(portfolio.get("registry_path"), "~/Dev/.dev-hub/registry/projects.json"),
-        bundle_token_budget=_coerce_int(bundle.get("token_budget"), 8192),
-        bundle_max_logs=_coerce_int(bundle.get("max_logs"), 5),
-        bundle_log_window_days=_coerce_int(bundle.get("log_window_days"), 14),
+        bundle_token_budget=_coerce_int(bundle.get("token_budget"), 8000),
+        bundle_max_logs=_coerce_int(bundle.get("max_logs"), 20),
+        bundle_log_window_days=_coerce_int(bundle.get("log_window_days"), 30),
     )
 
 
-def _coerce_str_list(value: object, default: list[str]) -> list[str]:
+def _coerce_str_list(value: object, default: List[str]) -> List[str]:
     if isinstance(value, list) and all(isinstance(item, str) for item in value):
         return value
     return list(default)
 
 
-def _coerce_optional_str(value: object, default: str | None) -> str | None:
+def _coerce_optional_str(value: object, default: Optional[str]) -> Optional[str]:
     if value is None:
         return None
     if isinstance(value, str):
@@ -86,4 +101,3 @@ def _coerce_int(value: object, default: int) -> int:
     if isinstance(value, int):
         return value
     return default
-

--- a/ontos/mcp/scanner.py
+++ b/ontos/mcp/scanner.py
@@ -222,9 +222,20 @@ def _extract_registry_items(raw: object) -> list[object]:
             if isinstance(value, list):
                 return value
 
+        # m-1: the dict fallback previously walked every key at the top
+        # level, which meant any top-level metadata dict (for example a
+        # nested ``metadata`` block, schema info, or a generator note that
+        # happened to be a mapping) was silently coerced into a project
+        # entry. Restrict this path to keys whose values resolve to
+        # project-shaped payloads (path-like field present) and explicitly
+        # skip reserved top-level metadata names.
         dict_items: list[object] = []
         for slug, payload in raw.items():
+            if slug in _REGISTRY_RESERVED_KEYS:
+                continue
             if not isinstance(payload, dict):
+                continue
+            if not _looks_like_project_payload(payload):
                 continue
             merged = dict(payload)
             merged.setdefault("slug", slug)
@@ -232,6 +243,39 @@ def _extract_registry_items(raw: object) -> list[object]:
         return dict_items
 
     return []
+
+
+_REGISTRY_RESERVED_KEYS: frozenset[str] = frozenset(
+    {
+        "dev_root",
+        "generated_at",
+        "generator",
+        "metadata",
+        "projects",
+        "schema",
+        "schema_version",
+        "version",
+        "workspaces",
+        "entries",
+        "items",
+    }
+)
+
+_REGISTRY_PROJECT_PATH_KEYS: tuple[str, ...] = (
+    "path",
+    "workspace",
+    "root",
+    "repo_root",
+    "repoPath",
+)
+
+
+def _looks_like_project_payload(payload: dict[str, Any]) -> bool:
+    """True when the dict payload carries a path-like field identifying a project."""
+    return any(
+        isinstance(payload.get(key), str) and payload.get(key)
+        for key in _REGISTRY_PROJECT_PATH_KEYS
+    )
 
 
 def _first_string(item: dict[str, Any], *keys: str) -> str | None:

--- a/ontos/mcp/server.py
+++ b/ontos/mcp/server.py
@@ -18,6 +18,7 @@ from mcp.types import CallToolResult, TextContent, Tool as MCPTool, ToolAnnotati
 from ontos.core.errors import OntosInternalError, OntosUserError
 from ontos.io.config import load_project_config
 from ontos.io.snapshot import create_snapshot
+from ontos.mcp._types import PortfolioIndexLike
 from ontos.mcp.cache import SnapshotCache
 from ontos.mcp.scanner import slugify
 from ontos.mcp.schemas import ToolErrorEnvelope, output_schema_for, validate_success_payload
@@ -90,7 +91,7 @@ def serve(
     workspace_root = workspace_root.resolve()
     cache = _build_cache(workspace_root)
 
-    portfolio_index: Any = None
+    portfolio_index: Optional[PortfolioIndexLike] = None
     try:
         if portfolio:
             portfolio_index = _build_portfolio_index()
@@ -112,7 +113,7 @@ def serve(
 def create_server(
     cache: SnapshotCache,
     *,
-    portfolio_index: Any = None,
+    portfolio_index: Optional[PortfolioIndexLike] = None,
     read_only: bool = False,
     include_bundle_tool: bool = False,
 ) -> FastMCP:
@@ -365,7 +366,7 @@ def _register_core_tools(
 def _register_portfolio_tools(
     *,
     cache: SnapshotCache,
-    portfolio_index: Any,
+    portfolio_index: PortfolioIndexLike,
     register_fn: Callable[..., None],
 ) -> None:
     def handle_project_registry(workspace_id: str | None = None) -> CallToolResult:
@@ -415,13 +416,13 @@ def _register_portfolio_tools(
 def _register_bundle_tool(
     *,
     cache: SnapshotCache,
-    portfolio_index: Any,
+    portfolio_index: Optional[PortfolioIndexLike],
     register_fn: Callable[..., None],
 ) -> None:
     if portfolio_index is None:
         def handle_get_context_bundle(
             workspace_id: str | None = None,
-            token_budget: int = 8192,
+            token_budget: Optional[int] = None,
         ) -> CallToolResult:
             return _invoke_read_tool(
                 "get_context_bundle",
@@ -435,7 +436,7 @@ def _register_bundle_tool(
     else:
         def handle_get_context_bundle(
             workspace_id: str | None = None,
-            token_budget: int = 8192,
+            token_budget: Optional[int] = None,
         ) -> CallToolResult:
             return _invoke_portfolio_tool(
                 "get_context_bundle",
@@ -466,7 +467,7 @@ def _get_context_bundle_single_workspace(
     cache: SnapshotCache,
     *,
     workspace_id: str | None = None,
-    token_budget: int = 8192,
+    token_budget: Optional[int] = None,
 ) -> dict[str, Any]:
     return tool_impl.get_context_bundle(
         None,
@@ -521,7 +522,7 @@ def _invoke_read_tool(
 
 def _invoke_portfolio_tool(
     tool_name: str,
-    portfolio_index: Any,
+    portfolio_index: Optional[PortfolioIndexLike],
     tool_fn: Callable[..., Dict[str, Any]],
     *,
     cache: SnapshotCache | None = None,
@@ -717,10 +718,13 @@ def _build_cache(workspace_root: Path) -> SnapshotCache:
     )
 
 
-def _build_portfolio_index() -> Any:
+def _build_portfolio_index() -> PortfolioIndexLike:
     from ontos.mcp.portfolio import PortfolioIndex
-    from ontos.mcp.portfolio_config import load_portfolio_config
+    from ontos.mcp.portfolio_config import ensure_portfolio_config, load_portfolio_config
 
+    # Initialize the on-disk config if absent (side-effectful write), then load
+    # it with the pure read path. See m-9 in Track A/D verdict.
+    ensure_portfolio_config()
     config = load_portfolio_config()
     scan_roots = [Path(path).expanduser() for path in config.scan_roots]
     registry_path = (

--- a/ontos/mcp/tools.py
+++ b/ontos/mcp/tools.py
@@ -10,12 +10,14 @@ import sqlite3
 from typing import Any, Dict, Optional
 
 import ontos
-from ontos.commands.export_data import _compute_content_hash, _snapshot_to_json
+from ontos.commands.export_data import _snapshot_to_json
 from ontos.commands.map import CompactMode, GenerateMapOptions, generate_context_map
+from ontos.core.content_hash import compute_content_hash
 from ontos.core.errors import OntosUserError
 from ontos.core.snapshot import DocumentSnapshot
 from ontos.core.types import DocumentData, ValidationResult
 from ontos.io.snapshot import create_snapshot
+from ontos.mcp._types import PortfolioIndexLike
 from ontos.mcp.scanner import slugify
 
 
@@ -205,7 +207,7 @@ def get_document(
     if doc is None:
         raise OntosUserError("Document not found.", code="E_DOCUMENT_NOT_FOUND")
 
-    content_hash = _compute_content_hash(doc.content) if doc.content else None
+    content_hash = compute_content_hash(doc.content) if doc.content else None
     payload = {
         "id": doc.id,
         "type": doc.type.value,
@@ -310,7 +312,7 @@ def query(cache: Any, *, entity_id: str, workspace_id: Optional[str] = None) -> 
         "depends_on": list(doc.depends_on),
         "depended_by": sorted(cache.snapshot.graph.reverse_edges.get(doc.id, [])),
         "depth": cache.depths.get(doc.id, 0),
-        "content_hash": _compute_content_hash(doc.content) if doc.content else None,
+        "content_hash": compute_content_hash(doc.content) if doc.content else None,
     }
 
 
@@ -341,7 +343,7 @@ def refresh(cache: Any, *, workspace_id: Optional[str] = None) -> dict[str, Any]
     }
 
 
-def project_registry(portfolio_index: Any) -> dict[str, Any]:
+def project_registry(portfolio_index: Optional[PortfolioIndexLike]) -> dict[str, Any]:
     """Return the complete project inventory from the portfolio index."""
     if portfolio_index is None:
         raise OntosUserError(
@@ -368,7 +370,7 @@ def project_registry(portfolio_index: Any) -> dict[str, Any]:
 
 
 def search(
-    portfolio_index: Any,
+    portfolio_index: Optional[PortfolioIndexLike],
     *,
     query_string: str,
     workspace_id: Optional[str] = None,
@@ -409,21 +411,47 @@ def search(
 
 
 def get_context_bundle(
-    portfolio_index: Any,
+    portfolio_index: Optional[PortfolioIndexLike],
     cache: Any,
     *,
     workspace_id: Optional[str] = None,
-    token_budget: int = 8192,
+    token_budget: Optional[int] = None,
 ) -> dict[str, Any]:
-    """Return a token-budgeted context package for a workspace."""
-    from ontos.mcp.bundler import build_context_bundle
+    """Return a token-budgeted context package for a workspace.
 
-    if token_budget < 1024:
+    Bundle shape is governed by three fields on the loaded
+    :class:`PortfolioConfig` (SF-3 / addendum A4):
+
+    - ``bundle_token_budget`` — hard cap on total bundle token count
+      (tail-first truncation drops older logs first when exceeded).
+    - ``bundle_max_logs`` — cap on the number of log entries included.
+    - ``bundle_log_window_days`` — exclude logs older than N days.
+
+    The caller may still override ``token_budget`` explicitly (preserving the
+    MCP tool surface). ``max_logs`` and ``log_window_days`` are always
+    sourced from the portfolio config.
+    """
+    from ontos.mcp.bundler import build_context_bundle
+    from ontos.mcp.portfolio_config import PortfolioConfig, load_portfolio_config
+
+    # Load the portfolio config for bundle-shape defaults. Fall back to the
+    # dataclass defaults if the config file is absent — the config's *write*
+    # path is owned by the server bootstrap (or explicit init), not by read
+    # tools (see m-9).
+    try:
+        portfolio_config = load_portfolio_config()
+    except FileNotFoundError:
+        portfolio_config = PortfolioConfig()
+
+    effective_budget: int = (
+        token_budget if token_budget is not None else portfolio_config.bundle_token_budget
+    )
+    if effective_budget < 1024:
         raise OntosUserError(
             "token_budget must be at least 1024.",
             code="E_INVALID_BUDGET",
         )
-    if token_budget > 128000:
+    if effective_budget > 128000:
         raise OntosUserError(
             "token_budget must be at most 128000.",
             code="E_INVALID_BUDGET",
@@ -468,7 +496,9 @@ def get_context_bundle(
         snapshot,
         workspace_root,
         slug,
-        token_budget=token_budget,
+        token_budget=effective_budget,
+        max_logs=portfolio_config.bundle_max_logs,
+        log_window_days=portfolio_config.bundle_log_window_days,
     )
 
 
@@ -491,7 +521,7 @@ def _parse_project_tags(raw: Any) -> list[str]:
     return []
 
 
-def _validate_workspace_id(portfolio_index: Any, workspace_id: str) -> None:
+def _validate_workspace_id(portfolio_index: Optional[PortfolioIndexLike], workspace_id: str) -> None:
     """Validate workspace_id exists in portfolio. Raise OntosUserError if not."""
     if portfolio_index is None:
         raise OntosUserError(

--- a/tests/mcp/test_bundler.py
+++ b/tests/mcp/test_bundler.py
@@ -108,5 +108,89 @@ def test_build_context_bundle_recent_logs_scored_lower(tmp_path):
     payload = build_context_bundle(snapshot, root, "workspace")
     score_map = {item["id"]: item["score"] for item in payload["included_documents"]}
 
+    # Under addendum v1.2 §A4 semantics (Dev 4): logs only enter the bundle
+    # via the recent-logs pool and only if they fall within log_window_days.
+    # The default log_window_days is 30 days, so the 40-day-old log is
+    # excluded from the bundle entirely (it no longer reappears in the
+    # non-kernel "remaining" bucket at score >= 0.5).
     assert score_map[f"{today}_recent_log"] == 0.3
-    assert score_map[f"{old}_old_log"] >= 0.5
+    assert f"{old}_old_log" not in score_map
+
+
+def test_build_context_bundle_equal_date_tiebreak_is_deterministic(tmp_path):
+    """SF-4: when multiple logs share the same date, the tiebreaker must be
+    ascending alphabetical by document ID (per spec v1.1 §4.2 — prompt-cache
+    stability). Repeated invocations must produce identical output; the
+    previous implementation sorted tuples with ``reverse=True`` which
+    flipped the ID tiebreak to *descending* alpha.
+    """
+    root = create_workspace(tmp_path)
+    same_date = date.today().isoformat()
+    # Three logs share the same date; write them in non-alphabetical order so
+    # that insertion order and alphabetical order disagree.
+    for slug in ("zulu", "alpha", "mike"):
+        write_file(
+            root / f"docs/{same_date}_{slug}.md",
+            f"""
+            ---
+            id: {same_date.replace('-', '_')}_{slug}
+            type: log
+            status: active
+            date: {same_date}
+            depends_on: [atom_doc]
+            ---
+            Same-date log body: {slug}.
+            """,
+        )
+
+    snapshot = create_snapshot(
+        root=root, include_content=True, filters=None, git_commit_provider=None, scope=None
+    )
+
+    # Snapshot the order from a few separate builds — all must agree.
+    orderings = []
+    for _ in range(4):
+        payload = build_context_bundle(snapshot, root, "workspace")
+        log_ids = [
+            item["id"]
+            for item in payload["included_documents"]
+            if item["type"] == "log" and item["score"] == 0.3 and item["id"].startswith(same_date.replace("-", "_"))
+        ]
+        orderings.append(tuple(log_ids))
+
+    # Determinism: every invocation produces the same output order.
+    assert len(set(orderings)) == 1, orderings
+
+    # And equal-date ties are broken *ascending* alphabetically: alpha < mike < zulu.
+    # Note: within-day ascending alpha need not correspond to a specific
+    # position in the final reordered bundle, so we verify the sort stability
+    # on the recent-logs pool directly via the private helper.
+    from ontos.mcp.bundler import _build_priority_order, _to_bundle_doc
+
+    docs_by_id = snapshot.documents
+    in_degree = {
+        doc_id: len(snapshot.graph.reverse_edges.get(doc_id, []))
+        for doc_id in sorted(docs_by_id)
+    }
+    non_kernel_degrees = [
+        in_degree[doc_id]
+        for doc_id in in_degree
+        if docs_by_id[doc_id].type.value != "kernel"
+    ]
+    max_non_kernel = max(non_kernel_degrees) if non_kernel_degrees else 0
+    scored = [
+        _to_bundle_doc(docs_by_id[doc_id], in_degree[doc_id], max_non_kernel)
+        for doc_id in sorted(docs_by_id)
+    ]
+    priority = _build_priority_order(
+        scored, docs_by_id, in_degree, root, max_logs=20, log_window_days=30
+    )
+    same_date_logs = [
+        doc.id for doc in priority if doc.type == "log" and doc.id.startswith(same_date.replace("-", "_"))
+    ]
+    # Ascending-alpha tiebreak: alpha before mike before zulu.
+    alpha_id = f"{same_date.replace('-', '_')}_alpha"
+    mike_id = f"{same_date.replace('-', '_')}_mike"
+    zulu_id = f"{same_date.replace('-', '_')}_zulu"
+    assert same_date_logs.index(alpha_id) < same_date_logs.index(mike_id)
+    assert same_date_logs.index(mike_id) < same_date_logs.index(zulu_id)

--- a/tests/mcp/test_context_bundle.py
+++ b/tests/mcp/test_context_bundle.py
@@ -125,8 +125,12 @@ def test_get_context_bundle_log_window_and_score(tmp_path):
     payload = tools.get_context_bundle(None, cache, token_budget=8192)
     score_map = {item["id"]: item["score"] for item in payload["included_documents"]}
 
+    # Under addendum v1.2 §A4 semantics (Dev 4): logs only enter the bundle
+    # via the recent-logs pool and only if they fall within log_window_days
+    # (default 30). The 60-day-old log is now excluded from the bundle
+    # entirely — the previous "demote to 0.5" behavior no longer applies.
     assert score_map[f"{today}_recent_log"] == 0.3
-    assert score_map[f"{old}_old_log"] >= 0.5
+    assert f"{old}_old_log" not in score_map
 
 
 def test_get_context_bundle_detects_stale_documents(tmp_path):

--- a/tests/mcp/test_context_bundle_config.py
+++ b/tests/mcp/test_context_bundle_config.py
@@ -1,0 +1,302 @@
+"""Tests for bundle-config wiring (SF-3 / addendum v1.2 §A4).
+
+Covers:
+- ``get_context_bundle`` consumes all three bundle fields from the loaded
+  :class:`PortfolioConfig` (max_logs, log_window_days, token_budget).
+- Integration: all three fields applied together.
+- ``_DEFAULT_CONFIG_TEXT`` TOML template agrees with the dataclass defaults.
+- Tail-first truncation: when the token budget is exceeded, the newest logs
+  are preserved and older logs are dropped first.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from pathlib import Path
+
+try:  # Python 3.11+
+    import tomllib
+except ImportError:  # pragma: no cover
+    import tomli as tomllib  # type: ignore
+
+import ontos.mcp.portfolio_config as portfolio_config_module
+from ontos.io.snapshot import create_snapshot
+from ontos.mcp import tools as tool_impl
+from ontos.mcp.bundler import build_context_bundle
+from ontos.mcp.cache import SnapshotCache
+from ontos.mcp.portfolio_config import PortfolioConfig, _DEFAULT_CONFIG_TEXT
+
+from tests.mcp import build_cache, create_empty_workspace, create_workspace, write_file
+
+
+# ---------------------------------------------------------------------------
+# Defaults parity: dataclass vs TOML template
+# ---------------------------------------------------------------------------
+
+
+def test_portfolio_config_dataclass_defaults_match_toml_template():
+    """The generated-on-first-run TOML template must reflect the dataclass
+    defaults exactly, or the first-run user ends up with a config whose numbers
+    silently disagree with the in-code defaults.
+    """
+    parsed = tomllib.loads(_DEFAULT_CONFIG_TEXT)
+    bundle = parsed.get("bundle", {})
+    portfolio_block = parsed.get("portfolio", {})
+
+    defaults = PortfolioConfig()
+
+    # Bundle block.
+    assert bundle.get("token_budget") == defaults.bundle_token_budget == 8000
+    assert bundle.get("max_logs") == defaults.bundle_max_logs == 20
+    assert bundle.get("log_window_days") == defaults.bundle_log_window_days == 30
+
+    # Portfolio block scalars/lists.
+    assert portfolio_block.get("scan_roots") == defaults.scan_roots
+    assert portfolio_block.get("exclude") == defaults.exclude
+    assert portfolio_block.get("registry_path") == defaults.registry_path
+
+
+# ---------------------------------------------------------------------------
+# Helpers for log-heavy fixtures
+# ---------------------------------------------------------------------------
+
+
+def _write_log(root: Path, log_date: date, slug: str = "log") -> str:
+    """Write a simple log doc and return its ID."""
+    iso = log_date.isoformat()
+    doc_id = f"{iso.replace('-', '_')}_{slug}"
+    write_file(
+        root / f"docs/{iso}_{slug}.md",
+        f"""
+        ---
+        id: {doc_id}
+        type: log
+        status: active
+        date: {iso}
+        depends_on: [atom_doc]
+        ---
+        Log body for {slug} on {iso}.
+        """,
+    )
+    return doc_id
+
+
+def _snapshot(root: Path):
+    return create_snapshot(
+        root=root,
+        include_content=True,
+        filters=None,
+        git_commit_provider=None,
+        scope=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-field unit tests at the bundler layer (SF-3 wiring verification)
+# ---------------------------------------------------------------------------
+
+
+def test_bundler_max_logs_caps_number_of_log_entries(tmp_path):
+    """`max_logs` must cap the number of log entries in the bundle regardless
+    of token budget.
+    """
+    root = create_empty_workspace(tmp_path)
+    # Provide a kernel doc so there's something non-trivial to bundle.
+    write_file(
+        root / "docs/kernel.md",
+        """
+        ---
+        id: kernel_doc
+        type: kernel
+        status: active
+        ---
+        Kernel body.
+        """,
+    )
+    ids = []
+    # Seven fresh logs, well inside any plausible default window, each with
+    # a distinct ISO date so there are no tie-break ambiguities.
+    for day_offset in range(7):
+        ids.append(
+            _write_log(root, date.today() - timedelta(days=day_offset), slug=f"n{day_offset}")
+        )
+    snapshot = _snapshot(root)
+
+    # Only 2 logs should survive the cap.
+    payload = build_context_bundle(
+        snapshot, root, "workspace", max_logs=2, log_window_days=30, token_budget=128000
+    )
+    log_ids = {item["id"] for item in payload["included_documents"] if item["type"] == "log"}
+    assert len(log_ids) == 2, log_ids
+    # The two most-recent logs should survive (tail-first truncation: older
+    # ones are dropped first).
+    assert ids[0] in log_ids
+    assert ids[1] in log_ids
+
+
+def test_bundler_log_window_days_excludes_logs_outside_window(tmp_path):
+    """Logs dated more than ``log_window_days`` in the past must be excluded
+    from the recent-logs pool.
+    """
+    root = create_workspace(tmp_path)
+    fresh_id = _write_log(root, date.today() - timedelta(days=2), slug="fresh")
+    stale_id = _write_log(root, date.today() - timedelta(days=45), slug="stale")
+    snapshot = _snapshot(root)
+
+    payload = build_context_bundle(
+        snapshot, root, "workspace", max_logs=20, log_window_days=14, token_budget=128000
+    )
+    log_ids = {item["id"] for item in payload["included_documents"] if item["type"] == "log"}
+
+    # Fresh log scored as a recent log (0.3).
+    scored = {item["id"]: item["score"] for item in payload["included_documents"]}
+    assert fresh_id in log_ids
+    assert scored.get(fresh_id) == 0.3
+    # Stale log does not get the recent-log boost.
+    assert scored.get(stale_id) != 0.3
+
+
+def test_bundler_token_budget_hard_caps_total_tokens(tmp_path):
+    """A small ``token_budget`` must drop non-kernel docs to respect the cap.
+
+    Also demonstrates tail-first truncation: when the budget is tight, the
+    older log is dropped before the newer one is.
+    """
+    root = create_empty_workspace(tmp_path)
+    # One kernel doc — always included.
+    write_file(
+        root / "docs/kernel.md",
+        """
+        ---
+        id: kernel_doc
+        type: kernel
+        status: active
+        ---
+        Kernel body.
+        """,
+    )
+    new_id = _write_log(root, date.today(), slug="new")
+    old_id = _write_log(root, date.today() - timedelta(days=5), slug="old")
+    # Pad the logs with content so only one of them can fit alongside the
+    # kernel. estimate_tokens() uses len(content) // 4, so ~4000 chars per
+    # log keeps each log at ~1000 tokens; with a 1500-token budget only the
+    # newest log can fit.
+    for iso, slug in ((date.today().isoformat(), "new"), ((date.today() - timedelta(days=5)).isoformat(), "old")):
+        path = root / f"docs/{iso}_{slug}.md"
+        path.write_text(
+            path.read_text(encoding="utf-8") + ("x " * 2000),
+            encoding="utf-8",
+        )
+    snapshot = _snapshot(root)
+
+    payload = build_context_bundle(
+        snapshot,
+        root,
+        "workspace",
+        token_budget=1500,  # Enough for kernel + ~one padded log.
+        max_logs=20,
+        log_window_days=30,
+    )
+
+    included_ids = {item["id"] for item in payload["included_documents"]}
+    assert "kernel_doc" in included_ids
+    # Tail-first truncation: the newer log survives, the older log is dropped.
+    assert new_id in included_ids, included_ids
+    assert old_id not in included_ids, included_ids
+    # The budget is actually respected (hard cap).
+    assert payload["token_estimate"] <= 1500
+    assert payload["excluded_count"] >= 1
+
+
+def test_bundler_integration_all_three_fields_respected(tmp_path):
+    """Integration: max_logs + log_window_days + token_budget applied together."""
+    root = create_workspace(tmp_path)
+    # Inside window (fresh): 4 logs.
+    for i in range(4):
+        _write_log(root, date.today() - timedelta(days=i), slug=f"fresh{i}")
+    # Outside window: 3 old logs.
+    for i in range(3):
+        _write_log(root, date.today() - timedelta(days=60 + i), slug=f"old{i}")
+    snapshot = _snapshot(root)
+
+    payload = build_context_bundle(
+        snapshot,
+        root,
+        "workspace",
+        token_budget=128000,
+        max_logs=2,
+        log_window_days=14,
+    )
+
+    log_entries = [item for item in payload["included_documents"] if item["type"] == "log"]
+    included_ids = {item["id"] for item in payload["included_documents"]}
+    log_scores = {item["id"]: item["score"] for item in log_entries}
+    # max_logs cap applies: exactly two logs at the recent-log score.
+    recent_scored = [lid for lid, score in log_scores.items() if score == 0.3]
+    assert len(recent_scored) == 2
+    # log_window_days filter applies: none of the explicitly-dated "old*"
+    # logs (60+ days back) should have survived, regardless of their
+    # scoring bucket.
+    for old_slug in ("old0", "old1", "old2"):
+        assert not any(old_slug in doc_id for doc_id in included_ids), included_ids
+    # And because we tightened `_build_priority_order` so that logs only
+    # enter the bundle via the recent-logs pool, the total log count in the
+    # bundle is bounded by max_logs.
+    assert len(log_entries) <= 2
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: MCP tool layer consumes the PortfolioConfig
+# ---------------------------------------------------------------------------
+
+
+def test_get_context_bundle_consumes_portfolio_config(tmp_path, monkeypatch):
+    """``get_context_bundle`` must pull ``max_logs`` / ``log_window_days`` /
+    ``bundle_token_budget`` from the loaded portfolio config (SF-3 / A4).
+    """
+    root = create_workspace(tmp_path)
+    # 5 fresh logs in the workspace (within any reasonable window).
+    for i in range(5):
+        _write_log(root, date.today() - timedelta(days=i), slug=f"n{i}")
+
+    # Override the portfolio config path with one that caps logs at 1.
+    config_path = tmp_path / ".config" / "ontos" / "portfolio.toml"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        """
+        [portfolio]
+        scan_roots = ["~/Dev"]
+        exclude = []
+        registry_path = "~/Dev/.dev-hub/registry/projects.json"
+
+        [bundle]
+        token_budget = 128000
+        max_logs = 1
+        log_window_days = 7
+        """,
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(portfolio_config_module, "PORTFOLIO_CONFIG_PATH", config_path)
+
+    cache = build_cache(root)
+    payload = tool_impl.get_context_bundle(None, cache)
+    log_entries = [item for item in payload["included_documents"] if item["score"] == 0.3]
+    # The config's max_logs=1 is honored by the tool layer.
+    assert len(log_entries) == 1
+
+
+def test_get_context_bundle_falls_back_to_dataclass_defaults_when_config_absent(tmp_path, monkeypatch):
+    """If the portfolio config file is absent, ``get_context_bundle`` must
+    fall back to the dataclass defaults rather than crashing (read-only path
+    does not write the config — see m-9).
+    """
+    root = create_workspace(tmp_path)
+    missing = tmp_path / ".config-missing" / "ontos" / "portfolio.toml"
+    monkeypatch.setattr(portfolio_config_module, "PORTFOLIO_CONFIG_PATH", missing)
+
+    cache = build_cache(root)
+    payload = tool_impl.get_context_bundle(None, cache)
+
+    assert "included_documents" in payload
+    # File must not have been written as a side effect of a read tool.
+    assert not missing.exists()

--- a/tests/mcp/test_error_paths.py
+++ b/tests/mcp/test_error_paths.py
@@ -142,7 +142,7 @@ def test_cmd_serve_redirects_stdout_before_project_root_lookup(tmp_path, monkeyp
     monkeypatch.setattr(sys, "stdout", stdout)
     monkeypatch.setattr(sys, "stderr", stderr)
     monkeypatch.setattr("ontos.io.files.find_project_root", noisy_find_project_root)
-    monkeypatch.setattr(ontos.mcp, "serve", lambda workspace_root: 0)
+    monkeypatch.setattr(ontos.mcp, "serve", lambda workspace_root, **kwargs: 0)
 
     exit_code = cli._cmd_serve(SimpleNamespace(workspace=root))
 

--- a/tests/mcp/test_portfolio_config.py
+++ b/tests/mcp/test_portfolio_config.py
@@ -8,19 +8,38 @@ import ontos.mcp.portfolio_config as portfolio_config_module
 from ontos.mcp.portfolio_config import ensure_portfolio_config, load_portfolio_config
 
 
-def test_load_portfolio_config_creates_defaults_when_missing(tmp_path, monkeypatch):
+def test_load_portfolio_config_raises_when_missing(tmp_path, monkeypatch):
+    """m-9: load_portfolio_config() is now a pure read path.
+
+    It must never write to disk. If the config file is absent the caller is
+    expected to invoke ensure_portfolio_config() explicitly (init flow).
+    """
     config_path = tmp_path / ".config" / "ontos" / "portfolio.toml"
     monkeypatch.setattr(portfolio_config_module, "PORTFOLIO_CONFIG_PATH", config_path)
 
+    with pytest.raises(FileNotFoundError):
+        load_portfolio_config()
+
+    # And it must not have been created as a side effect.
+    assert not config_path.exists()
+
+
+def test_ensure_portfolio_config_then_load_returns_addendum_defaults(tmp_path, monkeypatch):
+    """m-9 + addendum A4 defaults: init path writes, load path reads."""
+    config_path = tmp_path / ".config" / "ontos" / "portfolio.toml"
+    monkeypatch.setattr(portfolio_config_module, "PORTFOLIO_CONFIG_PATH", config_path)
+
+    ensure_portfolio_config()
     cfg = load_portfolio_config()
 
     assert config_path.exists()
     assert cfg.scan_roots == ["~/Dev"]
     assert cfg.exclude == ["~/Dev/.dev-hub", "~/Dev/archive"]
     assert cfg.registry_path == "~/Dev/.dev-hub/registry/projects.json"
-    assert cfg.bundle_token_budget == 8192
-    assert cfg.bundle_max_logs == 5
-    assert cfg.bundle_log_window_days == 14
+    # Addendum v1.2 §A4 default values (Dev 4 updated these from 8192/5/14).
+    assert cfg.bundle_token_budget == 8000
+    assert cfg.bundle_max_logs == 20
+    assert cfg.bundle_log_window_days == 30
 
 
 def test_load_portfolio_config_custom_values(tmp_path, monkeypatch):

--- a/tests/mcp/test_query.py
+++ b/tests/mcp/test_query.py
@@ -1,4 +1,4 @@
-from ontos.commands.export_data import _compute_content_hash
+from ontos.core.content_hash import compute_content_hash
 from ontos.mcp import tools
 
 from tests.mcp import build_cache, create_workspace
@@ -12,6 +12,6 @@ def test_query_returns_graph_details(tmp_path):
     assert payload["depends_on"] == ["product_doc"]
     assert payload["depended_by"] == ["log_doc"]
     assert payload["depth"] >= 0
-    assert payload["content_hash"] == _compute_content_hash(
+    assert payload["content_hash"] == compute_content_hash(
         cache.snapshot.documents["atom_doc"].content
     )

--- a/tests/mcp/test_scanner.py
+++ b/tests/mcp/test_scanner.py
@@ -154,6 +154,42 @@ def test_load_registry_records_supports_multiple_shapes(tmp_path, payload_factor
     assert records[0].has_ontos_raw == "false"
 
 
+def test_load_registry_records_dict_fallback_skips_top_level_metadata(tmp_path):
+    """m-1: when the registry is a dict keyed by slug, top-level metadata
+    fields must NOT be ingested as projects. Only nested mappings that carry
+    a path-shaped field qualify.
+    """
+    dev_root = tmp_path / "Dev"
+    dev_root.mkdir()
+    project_path = _make_project(dev_root / "alpha", with_ontos=True, with_readme=True, doc_count=1)
+    registry_path = tmp_path / ".dev-hub" / "registry" / "projects.json"
+    registry_path.parent.mkdir(parents=True)
+
+    # Mix of a legitimate project entry + reserved top-level keys + a random
+    # metadata dict that should NOT be pulled in as a project.
+    registry_payload = {
+        "dev_root": str(dev_root),
+        "version": "1.0",
+        "metadata": {"generator": "hand", "generated_at": "2026-01-01T00:00:00Z"},
+        "alpha-project": {
+            "path": str(project_path),
+            "status": "documented",
+            "has_ontos": True,
+        },
+        # Dict-valued entry with no path-like field: previously would have been
+        # ingested as a "project" with no path (caller quietly dropped it);
+        # the new filter skips it at extraction time instead.
+        "broken-entry": {"note": "not a project, no path here"},
+    }
+    registry_path.write_text(json.dumps(registry_payload), encoding="utf-8")
+
+    records = load_registry_records(registry_path, tolerate_errors=False)
+
+    # Exactly one record survives: the real project.
+    assert len(records) == 1
+    assert records[0].path == project_path
+
+
 def _make_project(path: Path, *, with_ontos: bool, with_readme: bool, doc_count: int) -> Path:
     path.mkdir(parents=True)
     (path / ".git").mkdir()


### PR DESCRIPTION
## Summary

Dev 4 slice per `.project-internal/v4.1/phaseB/v4.1_TrackB_Implementation_Spec.md`. Commit `8a4069c` was pushed by the Dev 4 worktree before an auth error prevented the original `gh pr create`; this PR opens it against the same commit.

## Closed items

- **A4 / SF-3** — bundle config wired: `get_context_bundle` / `build_context_bundle` consume `bundle_token_budget`, `bundle_max_logs`, `bundle_log_window_days` from `PortfolioConfig`. Tail-first truncation.
- **Defaults update (8192/5/14 → 8000/20/30)** — addendum v1.2 §A4 values. Both dataclass and `_DEFAULT_CONFIG_TEXT` updated in lockstep. Parity test added.
- **SF-4** — deterministic equal-date tiebreaker in `_recent_logs` (sorts `(-date.toordinal(), id)` ascending).
- **SF-9** — deterministic input ordering before sorts in `build_context_bundle` and `_recent_logs`.
- **m-1** — `_extract_registry_items` dict fallback now skips reserved keys and requires path-shaped fields.
- **m-3** — `_cmd_serve` arg forwarding normalized (see commit).
- **m-5** — schema-version error mentions auto-reset.
- **m-9** — `ensure_portfolio_config` split from pure `load_portfolio_config`.
- **m-10** — `_compute_content_hash` moved out of cross-boundary import path.
- **m-11** — `portfolio_index: Any` replaced with a `Protocol`.

## Coordination note

`server.py` / `tools.py` touched for m-11 typing + the `token_budget` sentinel default. Dev 2 will also touch these files; changes here are kept narrow to minimize merge conflicts.

## Test plan

- [ ] `/Library/Developer/CommandLineTools/usr/bin/python3 -m pytest tests/ -v --tb=short` passes at or above the 1056 baseline
- [ ] New parity test for dataclass vs `_DEFAULT_CONFIG_TEXT` passes
- [ ] New determinism tests for SF-4 / SF-9 pass
- [ ] New bundle config wiring tests pass

## References

- Addendum v1.2 §A4 — `.project-internal/reviews/ontos-v4.1-spec-addendum-v1.2.md`
- Verdict §3 + §4 — `.project-internal/reviews/ontos-v4.1-trackA-D-verdict.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)