### PR TITLE
feat(v4.1 Track B): scaffold/log/promote single-file write tools (Dev 2)

### DIFF
--- a/ontos/core/context.py
+++ b/ontos/core/context.py
@@ -57,6 +57,15 @@ class SessionContext:
     cwd: Path = field(default_factory=Path.cwd)
     env: Dict[str, str] = field(default_factory=lambda: dict(os.environ))
 
+    # Lock ownership (v4.1 A1 — single-lock discipline).
+    # When True (default), commit() acquires and releases an flock on
+    # <repo_root>/.ontos.lock around the critical section. When False,
+    # commit() assumes the caller already holds that flock (for example,
+    # via an outer workspace-lock context manager) and _acquire_lock /
+    # _release_lock become no-ops. See the v4.1 spec addendum A1 for
+    # the full contract.
+    owns_lock: bool = True
+
     # Mutable state (changes during session)
     pending_writes: List[PendingWrite] = field(default_factory=list)
     warnings: List[str] = field(default_factory=list)
@@ -225,28 +234,54 @@ class SessionContext:
         self.errors.append(message)
 
     def _acquire_lock(self, lock_path: Path, timeout: float = 5.0) -> bool:
-        """Acquire an exclusive flock lock for this workspace."""
+        """Acquire an exclusive flock lock for this workspace.
+
+        When ``self.owns_lock`` is False the caller is expected to hold
+        the flock on the workspace lockfile (acquired by an outer
+        workspace-lock context manager) and this method is a no-op —
+        see v4.1 spec addendum A1.
+        """
+        if not self.owns_lock:
+            return True
+
         lock_path.parent.mkdir(parents=True, exist_ok=True)
         start = time.monotonic()
         handle = lock_path.open("a+", encoding="utf-8")
 
-        while time.monotonic() - start < timeout:
-            try:
-                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        try:
+            while time.monotonic() - start < timeout:
+                try:
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except BlockingIOError:
+                    time.sleep(0.1)
+                    continue
+                # flock succeeded — hand ownership of the handle to the
+                # instance so _release_lock can close it.
                 self._lock_handle = handle
                 return True
-            except BlockingIOError:
-                time.sleep(0.1)
+        except BaseException:
+            # m-12: any non-BlockingIOError raised between open() and a
+            # successful flock (signals, OSError from sleep, etc.) must
+            # not leak the file handle. Close and re-raise.
+            handle.close()
+            raise
+
+        # Timed out waiting for the lock — close the handle and report.
         handle.close()
         return False
 
     def _release_lock(self, lock_path: Path) -> None:
         """Release the file lock.
-        
+
+        When ``self.owns_lock`` is False this is a no-op — the caller owns
+        the outer flock and is responsible for releasing it.
+
         Args:
             lock_path: Path to lock file.
         """
         _ = lock_path
+        if not self.owns_lock:
+            return
         if self._lock_handle is None:
             return
         try:

--- a/ontos/mcp/_validation.py
+++ b/ontos/mcp/_validation.py
@@ -1,0 +1,60 @@
+"""Shared validation helpers for MCP tools.
+
+Consolidates workspace_id validation used by both read and write tools so a
+single helper replaces the duplicated guards at ``server.py:478`` and
+``tools.py:513-525`` (addendum item m-8 / m-14). Write tools call
+``validate_workspace_id`` prior to mutating anything in the workspace.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from ontos.core.errors import OntosUserError
+
+
+def validate_workspace_id(
+    portfolio_index: Any,
+    workspace_id: Optional[str],
+    *,
+    require: bool = False,
+) -> None:
+    """Validate ``workspace_id`` against the portfolio index.
+
+    Args:
+        portfolio_index: Portfolio index instance (may be ``None`` in
+            non-portfolio mode).
+        workspace_id: Caller-supplied workspace slug. ``None`` is
+            tolerated unless ``require=True``.
+        require: When True, raise if ``workspace_id`` is missing.
+
+    Raises:
+        OntosUserError: If the id is missing and required, if portfolio
+            mode is required but not active, or if the id does not match
+            any known workspace slug.
+    """
+    if workspace_id is None:
+        if require:
+            raise OntosUserError(
+                "workspace_id is required in portfolio mode. "
+                "Use project_registry() to discover available workspaces.",
+                code="E_MISSING_WORKSPACE",
+            )
+        return
+
+    if portfolio_index is None:
+        raise OntosUserError(
+            "workspace_id requires portfolio mode.",
+            code="E_PORTFOLIO_REQUIRED",
+        )
+
+    projects = portfolio_index.get_projects()
+    slugs = [project["slug"] for project in projects]
+    if workspace_id not in slugs:
+        sorted_slugs = ", ".join(sorted(slugs))
+        raise OntosUserError(
+            f"Unknown workspace '{workspace_id}'. "
+            f"Valid workspace slugs: {sorted_slugs}. "
+            "Use project_registry() to discover available workspaces.",
+            code="E_UNKNOWN_WORKSPACE",
+        )

--- a/ontos/mcp/schemas.py
+++ b/ontos/mcp/schemas.py
@@ -292,6 +292,9 @@ TOOL_SUCCESS_MODELS: Dict[str, Type[BaseModel]] = {
     "project_registry": ProjectRegistryResponse,
     "search": SearchResponse,
     "get_context_bundle": GetContextBundleResponse,
+    "scaffold_document": ScaffoldDocumentResponse,
+    "log_session": LogSessionResponse,
+    "promote_document": PromoteDocumentResponse,
 }
 
 TOOL_OUTPUT_SCHEMAS: Dict[str, Dict[str, Any]] = {

--- a/ontos/mcp/server.py
+++ b/ontos/mcp/server.py
@@ -86,7 +86,6 @@ def serve(
     read_only: bool = False,
 ) -> int:
     """Build cache/index state and start the stdio MCP runtime."""
-    _ = read_only
     workspace_root = workspace_root.resolve()
     cache = _build_cache(workspace_root)
 
@@ -117,7 +116,6 @@ def create_server(
     include_bundle_tool: bool = False,
 ) -> FastMCP:
     """Create and register the Ontos MCP server."""
-    _ = read_only
     workspace_name = cache.workspace_root.name
     portfolio_mode = portfolio_index is not None
 
@@ -125,6 +123,7 @@ def create_server(
     setattr(cache, "portfolio_mode", portfolio_mode)
     setattr(cache, "portfolio_index", portfolio_index)
     setattr(cache, "primary_workspace_slug", _workspace_slug(cache.workspace_root))
+    setattr(cache, "read_only", read_only)
 
     server = OntosFastMCP(
         name="Ontos",
@@ -158,6 +157,14 @@ def create_server(
     _register_core_tools(
         cache=cache,
         workspace_name=workspace_name,
+        register_fn=register,
+    )
+
+    _register_write_tools(
+        cache=cache,
+        workspace_name=workspace_name,
+        portfolio_index=portfolio_index,
+        read_only=read_only,
         register_fn=register,
     )
 
@@ -360,6 +367,153 @@ def _register_core_tools(
         ),
         meta={"anthropic/maxResultSizeChars": 4000},
     )
+
+
+def _register_write_tools(
+    *,
+    cache: SnapshotCache,
+    workspace_name: str,
+    portfolio_index: Any,
+    read_only: bool,
+    register_fn: Callable[..., None],
+) -> None:
+    """Register the v4.1 Track B single-file write tools (Dev 2)."""
+    from ontos.mcp import writes as write_impl
+
+    def handle_scaffold_document(
+        path: str,
+        content: str = "",
+        workspace_id: Optional[str] = None,
+    ) -> CallToolResult:
+        return _invoke_write_tool(
+            "scaffold_document",
+            cache,
+            write_impl.scaffold_document,
+            portfolio_index=portfolio_index,
+            read_only=read_only,
+            path=path,
+            content=content,
+            workspace_id=workspace_id,
+        )
+
+    def handle_log_session(
+        title: str,
+        event_type: str = "chore",
+        source: str = "mcp",
+        branch: str = "unknown",
+        body: str = "",
+        workspace_id: Optional[str] = None,
+    ) -> CallToolResult:
+        return _invoke_write_tool(
+            "log_session",
+            cache,
+            write_impl.log_session,
+            portfolio_index=portfolio_index,
+            read_only=read_only,
+            title=title,
+            event_type=event_type,
+            source=source,
+            branch=branch,
+            body=body,
+            workspace_id=workspace_id,
+        )
+
+    def handle_promote_document(
+        document_id: str,
+        new_level: int,
+        workspace_id: Optional[str] = None,
+    ) -> CallToolResult:
+        return _invoke_write_tool(
+            "promote_document",
+            cache,
+            write_impl.promote_document,
+            portfolio_index=portfolio_index,
+            read_only=read_only,
+            document_id=document_id,
+            new_level=new_level,
+            workspace_id=workspace_id,
+        )
+
+    write_annotations = ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=False,
+        openWorldHint=False,
+    )
+
+    register_fn(
+        name="scaffold_document",
+        title="Scaffold Document",
+        description=(
+            f"Creates a new scaffolded Markdown document in the {workspace_name} "
+            "workspace."
+        ),
+        handler=handle_scaffold_document,
+        annotations=write_annotations,
+        meta={"anthropic/maxResultSizeChars": 4000},
+    )
+    register_fn(
+        name="log_session",
+        title="Log Session",
+        description=(
+            f"Creates a dated session log under logs_dir in the {workspace_name} "
+            "workspace."
+        ),
+        handler=handle_log_session,
+        annotations=write_annotations,
+        meta={"anthropic/maxResultSizeChars": 4000},
+    )
+    register_fn(
+        name="promote_document",
+        title="Promote Document",
+        description=(
+            f"Updates a document's curation_level frontmatter in the "
+            f"{workspace_name} workspace."
+        ),
+        handler=handle_promote_document,
+        annotations=write_annotations,
+        meta={"anthropic/maxResultSizeChars": 4000},
+    )
+
+
+def _invoke_write_tool(
+    tool_name: str,
+    cache: SnapshotCache,
+    tool_fn: Callable[..., CallToolResult],
+    *,
+    portfolio_index: Any,
+    read_only: bool,
+    **kwargs: Any,
+) -> CallToolResult:
+    """Shared write-tool invoker.
+
+    Write tool implementations own their own locking (workspace_lock + A3
+    rebuild path), schema validation, and error envelope construction. This
+    wrapper records usage telemetry, guards against unexpected exceptions
+    above the tool body, and surfaces them as structured MCP errors.
+    """
+    try:
+        _log_usage(cache, tool_name)
+    except Exception:
+        traceback.print_exc(file=sys.stderr)
+
+    try:
+        return tool_fn(
+            cache,
+            portfolio_index=portfolio_index,
+            read_only=read_only,
+            **kwargs,
+        )
+    except OntosUserError as exc:
+        return _tool_error_result(str(exc))
+    except OntosInternalError as exc:
+        print(f"[ontos-mcp] {exc.code}: {exc}", file=sys.stderr)
+        if exc.details:
+            print(exc.details, file=sys.stderr)
+        return _tool_error_result(f"Internal error: {exc}")
+    except Exception:
+        traceback.print_exc(file=sys.stderr)
+        return _tool_error_result(f"Internal error in {tool_name}")
 
 
 def _register_portfolio_tools(

--- a/ontos/mcp/tools.py
+++ b/ontos/mcp/tools.py
@@ -492,22 +492,14 @@ def _parse_project_tags(raw: Any) -> list[str]:
 
 
 def _validate_workspace_id(portfolio_index: Any, workspace_id: str) -> None:
-    """Validate workspace_id exists in portfolio. Raise OntosUserError if not."""
-    if portfolio_index is None:
-        raise OntosUserError(
-            "workspace_id requires portfolio mode.",
-            code="E_PORTFOLIO_REQUIRED",
-        )
-    projects = portfolio_index.get_projects()
-    slugs = [project["slug"] for project in projects]
-    if workspace_id not in slugs:
-        sorted_slugs = ", ".join(sorted(slugs))
-        raise OntosUserError(
-            f"Unknown workspace '{workspace_id}'. "
-            f"Valid workspace slugs: {sorted_slugs}. "
-            "Use project_registry() to discover available workspaces.",
-            code="E_UNKNOWN_WORKSPACE",
-        )
+    """Validate workspace_id exists in portfolio. Raise OntosUserError if not.
+
+    Delegates to the shared helper in ``ontos.mcp._validation`` so the read
+    and write paths use a single implementation (closes m-8 / m-14).
+    """
+    from ontos.mcp._validation import validate_workspace_id as _shared
+
+    _shared(portfolio_index, workspace_id)
 
 
 def _enforce_workspace_scope(cache: Any, workspace_id: Optional[str]) -> None:

--- a/ontos/mcp/writes.py
+++ b/ontos/mcp/writes.py
@@ -1,0 +1,561 @@
+"""Single-file MCP write tools for Ontos v4.1 Track B (Dev 2).
+
+This module implements the three MCP write tools whose mutation surface is
+a single markdown file:
+
+* ``scaffold_document`` — create a new ``.md`` in the target workspace.
+* ``log_session`` — create ``{logs_dir}/{date}_{slug}.md``.
+* ``promote_document`` — mutate document frontmatter only (no rename,
+  no move).
+
+Cross-cutting behavior (addendum v1.2):
+
+* **A1 single-lock discipline.** All three tools wrap the entire mutation
+  (``buffer_write`` + ``commit`` + ``rebuild_workspace``) inside
+  ``workspace_lock()``. The inner ``SessionContext`` is constructed with
+  ``owns_lock=False`` so it does not re-acquire the flock.
+* **A2 slugifier binding.** Workspace identity slugs use
+  ``ontos.mcp.scanner.slugify``; titles that become filename components
+  use ``ontos.commands.log._slugify``. No third slugifier is introduced.
+* **A3 post-commit-failure rebuild.** If ``ctx.commit()`` raises, the DB
+  may be out of sync with the filesystem. The exception path re-invokes
+  ``rebuild_workspace(slug, root)`` on a best-effort basis. Rebuild
+  errors are recorded but never mask the original exception.
+* **read_only enforcement.** Every write tool checks the server-level
+  ``read_only`` flag and returns a structured
+  ``WriteToolErrorEnvelope`` when mutations are disallowed. This closes
+  m-2 (``_ = read_only``).
+* **workspace_id validation.** Routed through
+  ``ontos.mcp._validation.validate_workspace_id`` (closes m-8 / m-14).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+import sys
+import traceback
+from typing import Any, Callable, Dict, List, Optional
+
+from mcp.types import CallToolResult, TextContent
+
+from ontos.commands.log import _slugify as slugify_title
+from ontos.core.context import SessionContext
+from ontos.core.curation import create_scaffold
+from ontos.core.errors import OntosInternalError, OntosUserError
+from ontos.core.schema import serialize_frontmatter
+from ontos.io.yaml import parse_frontmatter_content
+from ontos.mcp._validation import validate_workspace_id
+from ontos.mcp.cache import SnapshotCache
+from ontos.mcp.locking import workspace_lock
+from ontos.mcp.scanner import slugify as slugify_workspace_identity
+from ontos.mcp.schemas import (
+    ToolErrorTextItem,
+    WriteToolError,
+    WriteToolErrorEnvelope,
+    validate_success_payload,
+)
+
+
+# ---------------------------------------------------------------------------
+# Envelope + result helpers.
+# ---------------------------------------------------------------------------
+
+
+def _success_result(tool_name: str, payload: Dict[str, Any]) -> CallToolResult:
+    """Validate ``payload`` against the tool schema and wrap it for MCP."""
+    import json
+
+    validated = validate_success_payload(tool_name, payload)
+    return CallToolResult(
+        isError=False,
+        structuredContent=validated,
+        content=[
+            TextContent(
+                type="text",
+                text=json.dumps(validated, ensure_ascii=True),
+            )
+        ],
+    )
+
+
+def _write_error_result(
+    *,
+    error_code: str,
+    what: str,
+    why: str,
+    fix: str,
+) -> CallToolResult:
+    """Produce a ``WriteToolErrorEnvelope`` shaped ``CallToolResult``."""
+    envelope = WriteToolErrorEnvelope(
+        isError=True,
+        error=WriteToolError(
+            error_code=error_code,
+            what=what,
+            why=why,
+            fix=fix,
+        ),
+        content=[ToolErrorTextItem(type="text", text=what)],
+    ).model_dump(mode="json", by_alias=True)
+    return CallToolResult(
+        isError=True,
+        structuredContent=envelope,
+        content=[TextContent(type="text", text=what)],
+    )
+
+
+def _user_error_result(exc: OntosUserError) -> CallToolResult:
+    """Convert an ``OntosUserError`` into a ``WriteToolErrorEnvelope``."""
+    return _write_error_result(
+        error_code=getattr(exc, "code", "E_USER_ERROR") or "E_USER_ERROR",
+        what=str(exc),
+        why=str(exc),
+        fix="See error message for remediation guidance.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shared preflight.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Preflight:
+    slug: str
+    workspace_root: Path
+
+
+def _preflight(
+    cache: SnapshotCache,
+    portfolio_index: Any,
+    workspace_id: Optional[str],
+    read_only: bool,
+) -> _Preflight:
+    """Run read_only + workspace_id checks and resolve the target workspace."""
+    if read_only:
+        raise OntosUserError(
+            "Write tools are disabled because the MCP server is running in "
+            "read-only mode. Restart without --read-only to enable writes.",
+            code="E_READ_ONLY",
+        )
+
+    validate_workspace_id(portfolio_index, workspace_id)
+
+    workspace_root = cache.workspace_root
+    slug = slugify_workspace_identity(workspace_root.name)
+    if workspace_id is not None and workspace_id != slug:
+        # Write tools mutate the workspace served by this MCP process.
+        # Cross-workspace writes are not supported — addendum keeps the
+        # behavior symmetric with the read-tool guard at server.py.
+        raise OntosUserError(
+            "Cross-workspace writes are not supported. "
+            "Start a separate `ontos serve` in the target workspace.",
+            code="E_CROSS_WORKSPACE_NOT_SUPPORTED",
+        )
+
+    return _Preflight(slug=slug, workspace_root=workspace_root)
+
+
+def _rebuild_safely(
+    portfolio_index: Any,
+    slug: str,
+    workspace_root: Path,
+) -> None:
+    """Best-effort rebuild. Logs and swallows failures."""
+    if portfolio_index is None:
+        return
+    try:
+        portfolio_index.rebuild_workspace(slug, workspace_root)
+    except Exception:
+        traceback.print_exc(file=sys.stderr)
+
+
+def _commit_with_a3_recovery(
+    ctx: SessionContext,
+    portfolio_index: Any,
+    slug: str,
+    workspace_root: Path,
+) -> List[Path]:
+    """Commit the session. On failure, run the A3 rebuild-on-error path.
+
+    The A3 rebuild is swallowed so it cannot mask the original commit
+    exception. See addendum v1.2 §A3.
+    """
+    try:
+        return ctx.commit()
+    except Exception:
+        _rebuild_safely(portfolio_index, slug, workspace_root)
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Tool entry points.
+# ---------------------------------------------------------------------------
+
+
+def scaffold_document(
+    cache: SnapshotCache,
+    *,
+    portfolio_index: Any = None,
+    read_only: bool = False,
+    path: str,
+    content: str = "",
+    workspace_id: Optional[str] = None,
+) -> CallToolResult:
+    """Create a new ``.md`` file with a Level-0 scaffold frontmatter."""
+    return _dispatch(
+        "scaffold_document",
+        _scaffold_document_impl,
+        cache=cache,
+        portfolio_index=portfolio_index,
+        read_only=read_only,
+        workspace_id=workspace_id,
+        path=path,
+        content=content,
+    )
+
+
+def log_session(
+    cache: SnapshotCache,
+    *,
+    portfolio_index: Any = None,
+    read_only: bool = False,
+    title: str,
+    event_type: str = "chore",
+    source: str = "mcp",
+    branch: str = "unknown",
+    body: str = "",
+    workspace_id: Optional[str] = None,
+) -> CallToolResult:
+    """Create a session log at ``{logs_dir}/{date}_{slug}.md``."""
+    return _dispatch(
+        "log_session",
+        _log_session_impl,
+        cache=cache,
+        portfolio_index=portfolio_index,
+        read_only=read_only,
+        workspace_id=workspace_id,
+        title=title,
+        event_type=event_type,
+        source=source,
+        branch=branch,
+        body=body,
+    )
+
+
+def promote_document(
+    cache: SnapshotCache,
+    *,
+    portfolio_index: Any = None,
+    read_only: bool = False,
+    document_id: str,
+    new_level: int,
+    workspace_id: Optional[str] = None,
+) -> CallToolResult:
+    """Mutate frontmatter to change ``curation_level`` (no rename/move)."""
+    return _dispatch(
+        "promote_document",
+        _promote_document_impl,
+        cache=cache,
+        portfolio_index=portfolio_index,
+        read_only=read_only,
+        workspace_id=workspace_id,
+        document_id=document_id,
+        new_level=new_level,
+    )
+
+
+def _dispatch(
+    tool_name: str,
+    impl: Callable[..., Dict[str, Any]],
+    *,
+    cache: SnapshotCache,
+    portfolio_index: Any,
+    read_only: bool,
+    workspace_id: Optional[str],
+    **kwargs: Any,
+) -> CallToolResult:
+    # Preflight runs outside the workspace lock — no file state is
+    # mutated yet, and read_only / workspace_id errors should not pay
+    # the lock acquisition cost.
+    try:
+        plan = _preflight(cache, portfolio_index, workspace_id, read_only)
+    except OntosUserError as exc:
+        return _user_error_result(exc)
+
+    # NOTE on exception flow:
+    # OntosUserError / OntosInternalError are frozen dataclasses, which on
+    # Python 3.14+ can't have ``__traceback__`` reassigned by the stdlib
+    # contextlib machinery. Catching them INSIDE the lock prevents
+    # ``workspace_lock()`` from re-raising and tripping that assignment.
+    # See https://github.com/python/cpython (contextmanager __exit__).
+    result: Optional[CallToolResult] = None
+    try:
+        with workspace_lock(plan.workspace_root):
+            try:
+                payload = impl(
+                    cache=cache,
+                    portfolio_index=portfolio_index,
+                    plan=plan,
+                    **kwargs,
+                )
+                result = _success_result(tool_name, payload)
+            except OntosUserError as exc:
+                result = _user_error_result(exc)
+            except OntosInternalError as exc:
+                print(f"[ontos-mcp] {exc.code}: {exc}", file=sys.stderr)
+                if exc.details:
+                    print(exc.details, file=sys.stderr)
+                result = _write_error_result(
+                    error_code=exc.code or "E_INTERNAL",
+                    what=f"Internal error: {exc}",
+                    why="The server encountered an unexpected error.",
+                    fix="Check server logs and retry.",
+                )
+            except Exception as exc:
+                traceback.print_exc(file=sys.stderr)
+                result = _write_error_result(
+                    error_code="E_INTERNAL",
+                    what=f"Internal error in {tool_name}: {exc}",
+                    why="Unexpected exception while executing the write tool.",
+                    fix="Check server logs and retry.",
+                )
+    except OntosUserError as exc:
+        # Raised by workspace_lock itself (E_WORKSPACE_BUSY) when the
+        # flock timeout is exceeded.
+        return _user_error_result(exc)
+
+    assert result is not None  # for type-checkers
+    return result
+
+
+# ---------------------------------------------------------------------------
+# scaffold_document implementation.
+# ---------------------------------------------------------------------------
+
+
+def _scaffold_document_impl(
+    *,
+    cache: SnapshotCache,
+    portfolio_index: Any,
+    plan: _Preflight,
+    path: str,
+    content: str,
+) -> Dict[str, Any]:
+    if not path or not str(path).strip():
+        raise OntosUserError(
+            "path must be non-empty.",
+            code="E_INVALID_PATH",
+        )
+
+    resolved = _resolve_inside_workspace(plan.workspace_root, path)
+    if resolved.suffix != ".md":
+        raise OntosUserError(
+            "scaffold_document only accepts .md targets.",
+            code="E_INVALID_PATH",
+        )
+    if resolved.exists():
+        raise OntosUserError(
+            f"File already exists: {resolved.relative_to(plan.workspace_root).as_posix()}",
+            code="E_FILE_EXISTS",
+        )
+
+    # Assemble scaffold frontmatter. ``create_scaffold`` handles ID/type
+    # inference from path + body content.
+    frontmatter = create_scaffold(resolved, content=content)
+    body = content if content else f"# {frontmatter['id']}\n\nTODO: expand this scaffold.\n"
+    document = f"---\n{serialize_frontmatter(frontmatter)}\n---\n\n{body}"
+    if not document.endswith("\n"):
+        document += "\n"
+
+    ctx = SessionContext(
+        repo_root=plan.workspace_root,
+        config={},
+        owns_lock=False,
+    )
+    ctx.buffer_write(resolved, document)
+    _commit_with_a3_recovery(
+        ctx, portfolio_index, plan.slug, plan.workspace_root
+    )
+    _rebuild_safely(portfolio_index, plan.slug, plan.workspace_root)
+
+    return {
+        "success": True,
+        "path": resolved.relative_to(plan.workspace_root).as_posix(),
+        "id": str(frontmatter["id"]),
+        "type": str(frontmatter["type"]),
+        "status": str(frontmatter["status"]),
+        "curation_level": f"L{int(frontmatter['curation_level'])}",
+    }
+
+
+# ---------------------------------------------------------------------------
+# log_session implementation.
+# ---------------------------------------------------------------------------
+
+
+def _log_session_impl(
+    *,
+    cache: SnapshotCache,
+    portfolio_index: Any,
+    plan: _Preflight,
+    title: str,
+    event_type: str,
+    source: str,
+    branch: str,
+    body: str,
+) -> Dict[str, Any]:
+    if not title or not str(title).strip():
+        raise OntosUserError(
+            "title must be non-empty.",
+            code="E_INVALID_TITLE",
+        )
+
+    title_slug = slugify_title(str(title))  # addendum A2 — title slugifier
+    date_str = datetime.now().strftime("%Y-%m-%d")
+    logs_dir_raw = cache.config.paths.logs_dir or "docs/logs"
+    logs_dir = Path(logs_dir_raw)
+    if not logs_dir.is_absolute():
+        logs_dir = plan.workspace_root / logs_dir
+
+    filename = f"{date_str}_{title_slug}.md"
+    target = (logs_dir / filename).resolve(strict=False)
+    if not target.is_relative_to(plan.workspace_root.resolve()):
+        raise OntosUserError(
+            "Resolved log path escapes the workspace root.",
+            code="E_PATH_OUTSIDE_WORKSPACE",
+        )
+    if target.exists():
+        raise OntosUserError(
+            f"Log already exists: {target.relative_to(plan.workspace_root).as_posix()}",
+            code="E_FILE_EXISTS",
+        )
+
+    log_id = f"log_{date_str.replace('-', '')}_{title_slug}"
+    frontmatter = {
+        "id": log_id,
+        "type": "log",
+        "status": "active",
+        "event_type": event_type,
+        "source": source,
+        "branch": branch,
+        "created": date_str,
+    }
+    heading = str(title).strip()
+    document = (
+        f"---\n{serialize_frontmatter(frontmatter)}\n---\n\n"
+        f"# {heading}\n\n"
+    )
+    if body.strip():
+        document += f"{body.rstrip()}\n"
+
+    ctx = SessionContext(
+        repo_root=plan.workspace_root,
+        config={},
+        owns_lock=False,
+    )
+    ctx.buffer_write(target, document)
+    _commit_with_a3_recovery(
+        ctx, portfolio_index, plan.slug, plan.workspace_root
+    )
+    _rebuild_safely(portfolio_index, plan.slug, plan.workspace_root)
+
+    return {
+        "success": True,
+        "path": target.relative_to(plan.workspace_root).as_posix(),
+        "id": log_id,
+        "date": date_str,
+    }
+
+
+# ---------------------------------------------------------------------------
+# promote_document implementation.
+# ---------------------------------------------------------------------------
+
+
+def _promote_document_impl(
+    *,
+    cache: SnapshotCache,
+    portfolio_index: Any,
+    plan: _Preflight,
+    document_id: str,
+    new_level: int,
+) -> Dict[str, Any]:
+    if not document_id or not str(document_id).strip():
+        raise OntosUserError(
+            "document_id must be non-empty.",
+            code="E_INVALID_DOCUMENT_ID",
+        )
+    if new_level not in (0, 1, 2):
+        raise OntosUserError(
+            "new_level must be 0, 1, or 2.",
+            code="E_INVALID_LEVEL",
+        )
+
+    snapshot = cache.get_fresh_snapshot()
+    doc = snapshot.documents.get(document_id)
+    if doc is None:
+        raise OntosUserError(
+            f"Document not found: {document_id}",
+            code="E_DOCUMENT_NOT_FOUND",
+        )
+
+    target = Path(doc.filepath)
+    original = target.read_text(encoding="utf-8")
+    frontmatter, body = parse_frontmatter_content(original)
+    if not frontmatter:
+        raise OntosUserError(
+            f"Document {document_id} has no frontmatter to mutate.",
+            code="E_MISSING_FRONTMATTER",
+        )
+
+    old_level_raw = frontmatter.get("curation_level", 0)
+    try:
+        old_level = int(old_level_raw)
+    except (TypeError, ValueError):
+        old_level = 0
+
+    frontmatter["curation_level"] = int(new_level)
+    document = f"---\n{serialize_frontmatter(frontmatter)}\n---\n\n{body}"
+    if not document.endswith("\n"):
+        document += "\n"
+
+    ctx = SessionContext(
+        repo_root=plan.workspace_root,
+        config={},
+        owns_lock=False,
+    )
+    ctx.buffer_write(target, document)
+    _commit_with_a3_recovery(
+        ctx, portfolio_index, plan.slug, plan.workspace_root
+    )
+    _rebuild_safely(portfolio_index, plan.slug, plan.workspace_root)
+
+    return {
+        "success": True,
+        "document_id": document_id,
+        "old_level": f"L{old_level}",
+        "new_level": f"L{int(new_level)}",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Utilities.
+# ---------------------------------------------------------------------------
+
+
+def _resolve_inside_workspace(workspace_root: Path, raw_path: str) -> Path:
+    candidate = Path(raw_path)
+    if str(raw_path).startswith("~"):
+        candidate = candidate.expanduser()
+    if not candidate.is_absolute():
+        candidate = workspace_root / candidate
+    resolved = candidate.resolve(strict=False)
+    ws_resolved = workspace_root.resolve()
+    if not resolved.is_relative_to(ws_resolved):
+        raise OntosUserError(
+            "Path must resolve inside the workspace root.",
+            code="E_PATH_OUTSIDE_WORKSPACE",
+        )
+    return resolved

--- a/tests/mcp/test_refresh.py
+++ b/tests/mcp/test_refresh.py
@@ -25,7 +25,10 @@ def test_server_lists_tools_and_instructions(tmp_path):
     server = build_server(cache.workspace_root)
     tool_map = {tool.name: tool for tool in list_tools(server)}
 
-    assert len(tool_map) == 8
+    assert len(tool_map) == 11
     assert "workspace_overview" in tool_map
+    assert "scaffold_document" in tool_map
+    assert "log_session" in tool_map
+    assert "promote_document" in tool_map
     assert "workspace_overview" in server.instructions
     assert "workspace" in tool_map["workspace_overview"].description

--- a/tests/mcp/test_server_integration.py
+++ b/tests/mcp/test_server_integration.py
@@ -5,12 +5,11 @@ from pathlib import Path
 from tests.mcp import build_cache, build_server, create_workspace, list_tools, write_file
 
 
-def test_server_lists_all_eight_tools_with_correct_annotations(tmp_path):
+def test_server_lists_all_tools_with_correct_annotations(tmp_path):
     root = create_workspace(tmp_path)
     server = build_server(root)
     tool_map = {tool.name: tool for tool in list_tools(server)}
 
-    assert len(tool_map) == 8
     expected_tools = {
         "workspace_overview",
         "context_map",
@@ -20,15 +19,23 @@ def test_server_lists_all_eight_tools_with_correct_annotations(tmp_path):
         "query",
         "health",
         "refresh",
+        # v4.1 Track B (Dev 2) — single-file write tools.
+        "scaffold_document",
+        "log_session",
+        "promote_document",
     }
     assert set(tool_map.keys()) == expected_tools
+    assert len(tool_map) == len(expected_tools)
 
-    # export_graph and refresh must be non-read-only
-    assert tool_map["export_graph"].annotations.readOnlyHint is False
-    assert tool_map["refresh"].annotations.readOnlyHint is False
+    # export_graph, refresh, and the write tools are non-read-only
+    for name in ("export_graph", "refresh", "scaffold_document",
+                 "log_session", "promote_document"):
+        assert tool_map[name].annotations.readOnlyHint is False, (
+            f"{name} must not be readOnly"
+        )
     assert tool_map["refresh"].annotations.idempotentHint is False
 
-    # All other tools must be read-only
+    # Read-only tools
     for name in ("workspace_overview", "context_map", "get_document",
                  "list_documents", "query", "health"):
         assert tool_map[name].annotations.readOnlyHint is True, f"{name} should be readOnly"

--- a/tests/mcp/test_server_portfolio_mode.py
+++ b/tests/mcp/test_server_portfolio_mode.py
@@ -18,6 +18,12 @@ CORE_TOOLS = {
     "refresh",
 }
 
+WRITE_TOOLS = {
+    "scaffold_document",
+    "log_session",
+    "promote_document",
+}
+
 
 class FakePortfolioIndex:
     def get_projects(self):
@@ -44,8 +50,8 @@ def test_create_server_includes_bundle_tool_in_single_workspace_mode(tmp_path):
     server = build_server(root, include_bundle_tool=True)
     tool_map = {tool.name: tool for tool in list_tools(server)}
 
-    assert set(tool_map) == CORE_TOOLS | {"get_context_bundle"}
-    assert len(tool_map) == 9
+    assert set(tool_map) == CORE_TOOLS | WRITE_TOOLS | {"get_context_bundle"}
+    assert len(tool_map) == 12
     assert tool_map["get_context_bundle"].annotations.readOnlyHint is True
     assert "workspace_id" in tool_map["get_context_bundle"].inputSchema["properties"]
     assert "token_budget" in tool_map["get_context_bundle"].inputSchema["properties"]
@@ -61,10 +67,14 @@ def test_create_server_registers_track_a_portfolio_matrix(tmp_path):
     )
     tool_map = {tool.name: tool for tool in list_tools(server)}
 
-    expected = CORE_TOOLS | {"project_registry", "search", "get_context_bundle"}
+    expected = (
+        CORE_TOOLS
+        | WRITE_TOOLS
+        | {"project_registry", "search", "get_context_bundle"}
+    )
 
     assert set(tool_map) == expected
-    assert len(tool_map) == 11
+    assert len(tool_map) == 14
     assert tool_map["project_registry"].annotations.readOnlyHint is True
     assert tool_map["search"].annotations.readOnlyHint is True
     assert tool_map["get_context_bundle"].annotations.readOnlyHint is True

--- a/tests/mcp/test_write_tools.py
+++ b/tests/mcp/test_write_tools.py
@@ -1,0 +1,490 @@
+"""Tests for v4.1 Track B single-file MCP write tools (Dev 2).
+
+Covers:
+* scaffold_document — create a new markdown file with scaffold frontmatter.
+* log_session — create a dated session log under logs_dir.
+* promote_document — mutate frontmatter-only curation_level change.
+* read_only refusal (m-2 consumer).
+* workspace_id validation (m-14 consumer via shared helper).
+* Contention inside workspace_lock — a second writer process times out.
+* A3 post-commit-failure rebuild path (commit raises → rebuild_workspace
+  re-invoked, original exception not masked).
+
+References: addendum v1.2 §A1/§A2/§A3, C.0 findings Q1+Q3, verdict m-2/m-7/m-14/m-15.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from multiprocessing import Event, Process, Queue
+from pathlib import Path
+from typing import Any
+
+import pytest
+from mcp.types import CallToolResult
+
+from tests.mcp import build_cache, build_server, create_workspace, list_tools
+
+
+# ---------------------------------------------------------------------------
+# Fake portfolio index (records invocations so we can assert on A3 recovery).
+# ---------------------------------------------------------------------------
+
+
+class RecordingPortfolioIndex:
+    def __init__(self) -> None:
+        self.rebuild_calls: list[tuple[str, str]] = []
+        self.raise_on_rebuild = False
+
+    def get_projects(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "slug": "workspace",
+                "path": "/tmp/workspace",
+                "status": "documented",
+                "doc_count": 0,
+                "last_scanned": "2026-04-11T00:00:00Z",
+                "tags": [],
+                "has_ontos": 1,
+            }
+        ]
+
+    def rebuild_workspace(self, slug: str, root: Path) -> None:
+        self.rebuild_calls.append((slug, str(root)))
+        if self.raise_on_rebuild:
+            raise RuntimeError("induced rebuild failure")
+
+
+# ---------------------------------------------------------------------------
+# scaffold_document
+# ---------------------------------------------------------------------------
+
+
+def _call(server, name: str, args: dict[str, Any]) -> CallToolResult:
+    return asyncio.run(server.call_tool(name, args))
+
+
+def test_scaffold_document_creates_file_with_scaffold_frontmatter(tmp_path):
+    root = create_workspace(tmp_path)
+    server = build_server(root)
+
+    result = _call(
+        server,
+        "scaffold_document",
+        {"path": "docs/new_feature.md", "content": ""},
+    )
+
+    assert result.isError is False, result.content[0].text
+    payload = result.structuredContent
+    assert payload["success"] is True
+    assert payload["path"] == "docs/new_feature.md"
+    assert payload["curation_level"] == "L0"
+
+    created = root / "docs" / "new_feature.md"
+    assert created.exists()
+    text = created.read_text(encoding="utf-8")
+    assert text.startswith("---\n")
+    assert "status: scaffold" in text
+    assert "curation_level: 0" in text
+
+
+def test_scaffold_document_rejects_existing_path(tmp_path):
+    root = create_workspace(tmp_path)
+    server = build_server(root)
+
+    # docs/kernel.md is seeded by create_workspace — collision.
+    result = _call(
+        server,
+        "scaffold_document",
+        {"path": "docs/kernel.md"},
+    )
+
+    assert result.isError is True
+    assert "E_FILE_EXISTS" in result.structuredContent["error"]["error_code"]
+
+
+def test_scaffold_document_rejects_path_outside_workspace(tmp_path):
+    root = create_workspace(tmp_path)
+    server = build_server(root)
+
+    result = _call(
+        server,
+        "scaffold_document",
+        {"path": "../escape.md"},
+    )
+
+    assert result.isError is True
+    assert result.structuredContent["error"]["error_code"] == "E_PATH_OUTSIDE_WORKSPACE"
+
+
+# ---------------------------------------------------------------------------
+# log_session
+# ---------------------------------------------------------------------------
+
+
+def test_log_session_creates_dated_log_at_logs_dir(tmp_path):
+    root = create_workspace(tmp_path)
+    server = build_server(root)
+
+    result = _call(
+        server,
+        "log_session",
+        {
+            "title": "Refactor cache layer",
+            "event_type": "refactor",
+            "source": "mcp",
+            "branch": "feature/cache",
+            "body": "Replaced snapshot cache with SnapshotCacheView.",
+        },
+    )
+
+    assert result.isError is False, result.content[0].text
+    payload = result.structuredContent
+    assert payload["success"] is True
+    # logs_dir defaults to docs/logs per workspace config.
+    assert payload["path"].startswith("docs/logs/")
+    assert payload["path"].endswith("_refactor-cache-layer.md")
+    assert payload["id"].startswith("log_")
+
+    log_file = root / payload["path"]
+    assert log_file.exists()
+    content = log_file.read_text(encoding="utf-8")
+    assert "event_type: refactor" in content
+    assert "# Refactor cache layer" in content
+
+
+def test_log_session_rejects_empty_title(tmp_path):
+    root = create_workspace(tmp_path)
+    server = build_server(root)
+
+    result = _call(server, "log_session", {"title": "   "})
+
+    assert result.isError is True
+    assert result.structuredContent["error"]["error_code"] == "E_INVALID_TITLE"
+
+
+# ---------------------------------------------------------------------------
+# promote_document
+# ---------------------------------------------------------------------------
+
+
+def test_promote_document_mutates_curation_level_only(tmp_path):
+    root = create_workspace(tmp_path)
+    server = build_server(root)
+
+    # kernel_doc exists in the seeded workspace. Give it curation_level=0.
+    kernel_path = root / "docs" / "kernel.md"
+    original_body = "Kernel body.\n"
+    kernel_path.write_text(
+        "---\n"
+        "id: kernel_doc\n"
+        "type: kernel\n"
+        "status: active\n"
+        "curation_level: 0\n"
+        "---\n\n"
+        f"{original_body}",
+        encoding="utf-8",
+    )
+    # Rebuild cache so snapshot sees the new file.
+    server = build_server(root)
+
+    result = _call(
+        server,
+        "promote_document",
+        {"document_id": "kernel_doc", "new_level": 2},
+    )
+
+    assert result.isError is False, result.content[0].text
+    payload = result.structuredContent
+    assert payload["success"] is True
+    assert payload["document_id"] == "kernel_doc"
+    assert payload["old_level"] == "L0"
+    assert payload["new_level"] == "L2"
+
+    text = kernel_path.read_text(encoding="utf-8")
+    assert "curation_level: 2" in text
+    # Body preserved, frontmatter-only mutation.
+    assert original_body.strip() in text
+
+
+def test_promote_document_rejects_unknown_id(tmp_path):
+    root = create_workspace(tmp_path)
+    server = build_server(root)
+
+    result = _call(
+        server,
+        "promote_document",
+        {"document_id": "nonexistent_doc", "new_level": 1},
+    )
+
+    assert result.isError is True
+    assert result.structuredContent["error"]["error_code"] == "E_DOCUMENT_NOT_FOUND"
+
+
+def test_promote_document_rejects_invalid_level(tmp_path):
+    root = create_workspace(tmp_path)
+    server = build_server(root)
+
+    result = _call(
+        server,
+        "promote_document",
+        {"document_id": "kernel_doc", "new_level": 5},
+    )
+
+    assert result.isError is True
+    assert result.structuredContent["error"]["error_code"] == "E_INVALID_LEVEL"
+
+
+# ---------------------------------------------------------------------------
+# read_only enforcement (closes m-2)
+# ---------------------------------------------------------------------------
+
+
+def test_read_only_refuses_scaffold_document(tmp_path):
+    root = create_workspace(tmp_path)
+    server = build_server(root, read_only=True)
+
+    result = _call(
+        server,
+        "scaffold_document",
+        {"path": "docs/should_not_exist.md"},
+    )
+
+    assert result.isError is True
+    assert result.structuredContent["error"]["error_code"] == "E_READ_ONLY"
+    assert not (root / "docs" / "should_not_exist.md").exists()
+
+
+def test_read_only_refuses_log_session(tmp_path):
+    root = create_workspace(tmp_path)
+    server = build_server(root, read_only=True)
+
+    result = _call(server, "log_session", {"title": "banned write"})
+
+    assert result.isError is True
+    assert result.structuredContent["error"]["error_code"] == "E_READ_ONLY"
+
+
+def test_read_only_refuses_promote_document(tmp_path):
+    root = create_workspace(tmp_path)
+    server = build_server(root, read_only=True)
+
+    result = _call(
+        server,
+        "promote_document",
+        {"document_id": "kernel_doc", "new_level": 2},
+    )
+
+    assert result.isError is True
+    assert result.structuredContent["error"]["error_code"] == "E_READ_ONLY"
+
+
+# ---------------------------------------------------------------------------
+# workspace_id cross-workspace refusal (m-14 consumer via shared helper)
+# ---------------------------------------------------------------------------
+
+
+def test_write_tool_rejects_cross_workspace_id(tmp_path):
+    root = create_workspace(tmp_path)
+    server = build_server(root)
+
+    result = _call(
+        server,
+        "scaffold_document",
+        {
+            "path": "docs/nope.md",
+            "workspace_id": "some-other-workspace",
+        },
+    )
+
+    assert result.isError is True
+    # In non-portfolio mode the shared helper raises E_PORTFOLIO_REQUIRED.
+    assert result.structuredContent["error"]["error_code"] == "E_PORTFOLIO_REQUIRED"
+
+
+# ---------------------------------------------------------------------------
+# A1 — workspace_lock contention inside the write tool.
+# ---------------------------------------------------------------------------
+
+
+def _hold_workspace_lock(workspace: str, ready, release, result: Queue) -> None:
+    """Hold workspace_lock() from another process until told to release."""
+    from ontos.mcp.locking import workspace_lock
+
+    try:
+        with workspace_lock(Path(workspace), timeout=5.0):
+            ready.set()
+            release.wait(timeout=30.0)
+        result.put(("ok", None))
+    except BaseException as exc:  # pragma: no cover — surfaced via Queue
+        result.put(("error", repr(exc)))
+
+
+def test_write_tool_under_contention_returns_structured_error(tmp_path):
+    """An outer process holds workspace_lock → write tool must fail cleanly.
+
+    The internal ``workspace_lock`` timeout is 5s; the tool surfaces a
+    structured ``E_WORKSPACE_BUSY`` error envelope rather than raising.
+    """
+    root = create_workspace(tmp_path)
+    server = build_server(root)
+
+    ready = Event()
+    release = Event()
+    q: Queue = Queue()
+    holder = Process(
+        target=_hold_workspace_lock,
+        args=(str(root), ready, release, q),
+    )
+    holder.start()
+    try:
+        assert ready.wait(timeout=5.0), "holder never signalled ready"
+
+        start = time.monotonic()
+        result = _call(
+            server,
+            "scaffold_document",
+            {"path": "docs/contended.md"},
+        )
+        elapsed = time.monotonic() - start
+
+        assert result.isError is True, result.content[0].text
+        # workspace_lock raises OntosUserError(code=E_WORKSPACE_BUSY).
+        assert result.structuredContent["error"]["error_code"] == "E_WORKSPACE_BUSY"
+        # Confirm the retry window is observed (addendum A1 timeout = 5s).
+        assert 4.5 <= elapsed <= 15.0, f"unexpected elapsed={elapsed:.2f}s"
+
+        assert not (root / "docs" / "contended.md").exists()
+    finally:
+        release.set()
+        holder.join(timeout=5.0)
+        if holder.is_alive():  # pragma: no cover
+            holder.terminate()
+            holder.join(timeout=2.0)
+
+
+# ---------------------------------------------------------------------------
+# A3 — post-commit-failure rebuild path.
+# ---------------------------------------------------------------------------
+
+
+def test_a3_rebuild_invoked_when_commit_raises(monkeypatch, tmp_path):
+    """If commit() raises, the exception path re-invokes rebuild_workspace.
+
+    The rebuild call is best-effort: its failure must NOT mask the
+    original commit exception. See addendum v1.2 §A3.
+    """
+    from ontos.core.context import SessionContext
+    from ontos.mcp import writes as write_impl
+
+    root = create_workspace(tmp_path)
+    cache = build_cache(root)
+
+    portfolio = RecordingPortfolioIndex()
+
+    real_commit = SessionContext.commit
+
+    def exploding_commit(self):
+        # Simulate a mid-commit rename failure AFTER tmp staging.
+        raise IOError("induced commit failure")
+
+    monkeypatch.setattr(SessionContext, "commit", exploding_commit)
+
+    result = write_impl.scaffold_document(
+        cache,
+        portfolio_index=portfolio,
+        read_only=False,
+        path="docs/should_rebuild.md",
+        content="",
+    )
+
+    # Restore (not strictly needed under monkeypatch).
+    SessionContext.commit = real_commit  # type: ignore[method-assign]
+
+    assert result.isError is True
+    # Original commit exception is surfaced — not masked by rebuild.
+    assert "induced commit failure" in result.content[0].text
+    # A3 recovery ran exactly once (rebuild-on-error path).
+    assert len(portfolio.rebuild_calls) == 1
+    slug, recorded_root = portfolio.rebuild_calls[0]
+    assert slug == "workspace"
+    assert Path(recorded_root) == root
+
+
+def test_a3_rebuild_failure_does_not_mask_original_exception(monkeypatch, tmp_path):
+    """A rebuild failure in the exception path is swallowed, not re-raised.
+
+    Mirrors the guard at ``core/context.py:189-199`` — the commit failure
+    must propagate as the user-visible error.
+    """
+    from ontos.core.context import SessionContext
+    from ontos.mcp import writes as write_impl
+
+    root = create_workspace(tmp_path)
+    cache = build_cache(root)
+
+    portfolio = RecordingPortfolioIndex()
+    portfolio.raise_on_rebuild = True
+
+    def exploding_commit(self):
+        raise IOError("induced commit failure")
+
+    monkeypatch.setattr(SessionContext, "commit", exploding_commit)
+
+    result = write_impl.scaffold_document(
+        cache,
+        portfolio_index=portfolio,
+        read_only=False,
+        path="docs/should_rebuild_fail.md",
+        content="",
+    )
+
+    assert result.isError is True
+    assert "induced commit failure" in result.content[0].text
+    assert len(portfolio.rebuild_calls) == 1
+
+
+def test_rebuild_is_called_in_happy_path(tmp_path):
+    """Happy path also rebuilds the workspace index after commit."""
+    from ontos.mcp import writes as write_impl
+
+    root = create_workspace(tmp_path)
+    cache = build_cache(root)
+    portfolio = RecordingPortfolioIndex()
+
+    result = write_impl.scaffold_document(
+        cache,
+        portfolio_index=portfolio,
+        read_only=False,
+        path="docs/new_doc.md",
+        content="",
+    )
+
+    assert result.isError is False, result.content[0].text
+    # Exactly one rebuild in the happy path (from _rebuild_safely).
+    assert len(portfolio.rebuild_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Shared workspace_id validator lookup (m-8 consolidation).
+# ---------------------------------------------------------------------------
+
+
+def test_shared_validate_workspace_id_helper_exists_and_is_reused():
+    """Dev 2 adds ontos.mcp._validation — Dev 3's rename_document must reuse it."""
+    import inspect
+
+    from ontos.mcp import _validation
+    from ontos.mcp import tools as read_tools
+    from ontos.mcp import writes as write_tools
+
+    assert hasattr(_validation, "validate_workspace_id")
+
+    # The legacy tools._validate_workspace_id now delegates to the shared
+    # helper so we don't have two implementations to diverge.
+    src = inspect.getsource(read_tools._validate_workspace_id)
+    assert "_validation" in src or "validate_workspace_id" in src
+
+    # The write tools import the shared helper directly.
+    assert _validation.validate_workspace_id is write_tools.validate_workspace_id

--- a/tests/test_context_contention.py
+++ b/tests/test_context_contention.py
@@ -1,0 +1,352 @@
+"""Write-contention tests for SessionContext + workspace_lock.
+
+Covers v4.1 Track B Dev 1 scope:
+
+* A1 regression — ``SessionContext(owns_lock=False)`` works inside a
+  ``workspace_lock()`` and the same call would deadlock/timeout with the
+  default ``owns_lock=True``. See
+  ``.project-internal/reviews/ontos-v4.1-spec-addendum-v1.2.md`` A1.
+* Two concurrent writers on the same workspace — the second times out
+  with ``RuntimeError("Could not acquire write lock...")``.
+* A writer holding the workspace lock does not stall a reader that does
+  not flock (portfolio-read path per C.0 findings Q2).
+* SF-8 — a pre-v4.1 PID-style ``.ontos.lock`` file (arbitrary text
+  content, no flock held) is acquired by the new flock-based path.
+* m-12 — a handle leak between ``open()`` and a successful flock in
+  ``_acquire_lock`` is prevented when an unexpected exception is raised.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import time
+from multiprocessing import Event, Process, Queue
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+from ontos.core.context import SessionContext
+from ontos.mcp.locking import workspace_lock
+
+
+# ---------------------------------------------------------------------------
+# multiprocessing helpers (top-level so they are picklable on macOS spawn).
+# ---------------------------------------------------------------------------
+
+
+def _writer_child(workspace: str, ready, release, result: Queue) -> None:
+    """Hold an exclusive flock on ``<workspace>/.ontos.lock`` until released.
+
+    Signals ``ready`` once the lock is held; waits for ``release`` before
+    dropping it. Reports success/failure through ``result``.
+    """
+    try:
+        ctx = SessionContext(repo_root=Path(workspace), config={})
+        lock_path = Path(workspace) / ".ontos.lock"
+        acquired = ctx._acquire_lock(lock_path, timeout=5.0)
+        if not acquired:
+            result.put(("fail", "first writer could not acquire"))
+            return
+        ready.set()
+        release.wait(timeout=10.0)
+        ctx._release_lock(lock_path)
+        result.put(("ok", None))
+    except BaseException as exc:  # pragma: no cover — surfaced via Queue
+        result.put(("error", repr(exc)))
+
+
+def _second_writer_child(workspace: str, result: Queue) -> None:
+    """Attempt a committed write; should raise RuntimeError under contention."""
+    try:
+        ctx = SessionContext(repo_root=Path(workspace), config={})
+        ctx.buffer_write(Path(workspace) / "doc.md", "hello")
+        ctx.commit()
+        result.put(("ok", None))
+    except RuntimeError as exc:
+        result.put(("runtime", str(exc)))
+    except BaseException as exc:  # pragma: no cover
+        result.put(("error", repr(exc)))
+
+
+def _outer_lock_child(workspace: str, ready, release, result: Queue) -> None:
+    """Hold ``workspace_lock()`` on ``workspace`` until released.
+
+    Used to simulate an outer flock held by a different process while the
+    parent process runs a reader-that-does-not-flock.
+    """
+    try:
+        with workspace_lock(Path(workspace), timeout=5.0):
+            ready.set()
+            release.wait(timeout=10.0)
+        result.put(("ok", None))
+    except BaseException as exc:  # pragma: no cover
+        result.put(("error", repr(exc)))
+
+
+# ---------------------------------------------------------------------------
+# Tests.
+# ---------------------------------------------------------------------------
+
+
+class TestA1OwnsLockRegression:
+    """A1 — `SessionContext(owns_lock=False)` inside `workspace_lock`.
+
+    The default `owns_lock=True` path would deadlock against an outer
+    flock held by `workspace_lock()` (same process, different fd, same
+    file — `flock(2)` treats them independently); `owns_lock=False` is
+    the contract introduced by addendum v1.2 A1.
+    """
+
+    def test_owns_lock_false_allows_commit_under_workspace_lock(self, tmp_path):
+        target = tmp_path / "note.md"
+        with workspace_lock(tmp_path, timeout=5.0):
+            ctx = SessionContext(
+                repo_root=tmp_path, config={}, owns_lock=False
+            )
+            ctx.buffer_write(target, "hello A1")
+            modified = ctx.commit()
+        assert modified == [target]
+        assert target.read_text() == "hello A1"
+
+    def test_default_owns_lock_true_deadlocks_under_workspace_lock(self, tmp_path):
+        """Same setup with the default owns_lock=True must fail fast.
+
+        The inner acquire uses a small timeout so the test does not pay
+        the full 5s; the point is that the lock WOULD be acquired if
+        `owns_lock=False` were the default, and is NOT acquired when the
+        outer workspace_lock is held.
+        """
+        ctx = SessionContext(repo_root=tmp_path, config={})  # owns_lock=True
+
+        with workspace_lock(tmp_path, timeout=5.0):
+            lock_path = tmp_path / ".ontos.lock"
+            # Directly exercise _acquire_lock with a short timeout to
+            # keep the test fast — the production path (commit()) uses
+            # the full 5s window and raises RuntimeError on False.
+            acquired = ctx._acquire_lock(lock_path, timeout=0.2)
+            assert acquired is False, (
+                "default owns_lock=True must fail to acquire while the "
+                "outer workspace_lock is held — this is the A1 deadlock "
+                "the owns_lock=False contract prevents"
+            )
+            assert ctx._lock_handle is None
+
+    def test_owns_lock_false_acquire_release_are_noops(self, tmp_path):
+        ctx = SessionContext(
+            repo_root=tmp_path, config={}, owns_lock=False
+        )
+        lock_path = tmp_path / ".ontos.lock"
+        # No outer flock held — the contract is still "do nothing".
+        assert ctx._acquire_lock(lock_path, timeout=0.1) is True
+        assert ctx._lock_handle is None
+        ctx._release_lock(lock_path)  # Must not raise.
+        assert ctx._lock_handle is None
+
+
+class TestTwoWriterContention:
+    """Two writers on the same workspace — second must time out."""
+
+    def test_second_writer_times_out_with_runtime_error(self, tmp_path):
+        ready = Event()
+        release = Event()
+        first_q: Queue = Queue()
+        second_q: Queue = Queue()
+
+        first = Process(
+            target=_writer_child,
+            args=(str(tmp_path), ready, release, first_q),
+        )
+        first.start()
+        try:
+            assert ready.wait(timeout=5.0), "first writer never signalled ready"
+
+            second = Process(
+                target=_second_writer_child,
+                args=(str(tmp_path), second_q),
+            )
+            start = time.monotonic()
+            second.start()
+            second.join(timeout=20.0)
+            elapsed = time.monotonic() - start
+
+            assert not second.is_alive(), "second writer did not exit"
+            assert second.exitcode == 0, (
+                f"second writer crashed: exitcode={second.exitcode}"
+            )
+
+            status, payload = second_q.get(timeout=2.0)
+            assert status == "runtime", (
+                f"second writer should have raised RuntimeError; "
+                f"got {status!r} with payload {payload!r}"
+            )
+            assert "Could not acquire write lock" in payload
+            # The retry loop in _acquire_lock is 5s; the second writer
+            # should fail somewhere around that mark.
+            assert 4.5 <= elapsed <= 15.0, (
+                f"second writer elapsed={elapsed:.2f}s — expected ~5s retry window"
+            )
+        finally:
+            release.set()
+            first.join(timeout=5.0)
+            if first.is_alive():  # pragma: no cover
+                first.terminate()
+                first.join(timeout=2.0)
+
+
+class TestWriterVsNonFlockingReader:
+    """A reader that does not flock must not block behind a writer.
+
+    Per C.0 findings Q2 (sub-questions table), portfolio-level read
+    tools (``project_registry``, ``search_portfolio``, ``verify
+    --portfolio``) operate on ``portfolio.db`` and do NOT acquire the
+    workspace flock. This test asserts that invariant at the substrate
+    layer: an outer ``workspace_lock()`` in one process does not impede
+    a bare filesystem read in another process (no flock acquisition).
+    """
+
+    def test_non_flocking_reader_unblocked_by_writer(self, tmp_path):
+        # Place a file the "reader" will read.
+        sentinel = tmp_path / "doc.md"
+        sentinel.write_text("data")
+
+        ready = Event()
+        release = Event()
+        holder_q: Queue = Queue()
+        holder = Process(
+            target=_outer_lock_child,
+            args=(str(tmp_path), ready, release, holder_q),
+        )
+        holder.start()
+        try:
+            assert ready.wait(timeout=5.0), "holder never signalled ready"
+
+            # The reader-like path: just read the file. No flock.
+            start = time.monotonic()
+            content = sentinel.read_text()
+            # Also stat the lockfile path, simulating a tool that may
+            # inspect the lockfile's metadata without acquiring it.
+            lockfile = tmp_path / ".ontos.lock"
+            assert lockfile.exists()
+            _ = lockfile.stat()
+            elapsed = time.monotonic() - start
+
+            assert content == "data"
+            assert elapsed < 1.0, (
+                f"non-flocking reader blocked for {elapsed:.2f}s while "
+                f"writer held workspace_lock — must not stall"
+            )
+        finally:
+            release.set()
+            holder.join(timeout=5.0)
+            if holder.is_alive():  # pragma: no cover
+                holder.terminate()
+                holder.join(timeout=2.0)
+
+
+class TestSF8StaleLegacyLockfile:
+    """SF-8 — a pre-v4.1 PID-style ``.ontos.lock`` must not break acquire.
+
+    Earlier Ontos versions wrote PID/text content into ``.ontos.lock``.
+    The v4.1 flock-based path opens the file in ``"a+"`` and flocks the
+    fd; it does not read or parse the file's content. This test proves
+    it.
+    """
+
+    def test_stale_pid_style_lockfile_is_acquired(self, tmp_path):
+        lock_path = tmp_path / ".ontos.lock"
+        lock_path.write_text("12345\nworkspace=/some/old/path\n")
+
+        ctx = SessionContext(repo_root=tmp_path, config={})
+        acquired = ctx._acquire_lock(lock_path, timeout=1.0)
+        try:
+            assert acquired is True
+            assert ctx._lock_handle is not None
+            # The file's prior contents remain — open in append mode
+            # does not truncate. This is intentional and harmless; flock
+            # is purely fd-based.
+            assert lock_path.read_text().startswith("12345")
+        finally:
+            ctx._release_lock(lock_path)
+
+    def test_no_codepath_parses_lockfile_content(self):
+        """Assert the regression surface never existed.
+
+        The acquire path must not ``read()`` the lockfile expecting a
+        PID-style format. Narrow source inspection of the two lock
+        primitives guards against anyone reintroducing PID parsing.
+        """
+        import inspect as _inspect
+
+        import ontos.core.context as context_module
+        import ontos.mcp.locking as locking_module
+
+        acquire_src = _inspect.getsource(SessionContext._acquire_lock)
+        release_src = _inspect.getsource(SessionContext._release_lock)
+        locking_src = _inspect.getsource(locking_module.workspace_lock)
+
+        for src, name in (
+            (acquire_src, "SessionContext._acquire_lock"),
+            (release_src, "SessionContext._release_lock"),
+            (locking_src, "workspace_lock"),
+        ):
+            assert ".readline" not in src, (
+                f"{name} must not readline() the lockfile"
+            )
+            assert ".readlines" not in src, (
+                f"{name} must not readlines() the lockfile"
+            )
+            assert "read_text" not in src, (
+                f"{name} must not read_text() the lockfile"
+            )
+            # Bare `handle.read(` on the lock handle would also be a
+            # regression. `fileno().read` is not a real API but guard
+            # broadly against `<anything>.read(` that isn't part of
+            # ``read_text`` (handled above).
+            assert ".read(" not in src, (
+                f"{name} must not read() the lockfile's contents"
+            )
+
+        # Reference ``context_module`` to keep the import alive for
+        # future assertions — this also ensures the module still exposes
+        # SessionContext at the expected path.
+        assert context_module.SessionContext is SessionContext
+
+
+class TestM12HandleLeakFix:
+    """m-12 — close the handle on any non-BlockingIOError between open/flock."""
+
+    def test_unexpected_exception_does_not_leak_handle(self, tmp_path, monkeypatch):
+        """Force an OSError out of ``fcntl.flock`` and confirm cleanup.
+
+        Pre-m-12 the loop would drop the opened handle on the floor. Now
+        the handle must be closed and the exception re-raised.
+        """
+        ctx = SessionContext(repo_root=tmp_path, config={})
+        lock_path = tmp_path / ".ontos.lock"
+
+        opened_handles: list = []
+        real_open = Path.open
+
+        def tracking_open(self: Path, *args, **kwargs):
+            handle = real_open(self, *args, **kwargs)
+            if self == lock_path:
+                opened_handles.append(handle)
+            return handle
+
+        def exploding_flock(fd, op):  # noqa: ANN001
+            raise OSError("induced flock failure")
+
+        monkeypatch.setattr(Path, "open", tracking_open)
+        monkeypatch.setattr(fcntl, "flock", exploding_flock)
+
+        with pytest.raises(OSError, match="induced flock failure"):
+            ctx._acquire_lock(lock_path, timeout=1.0)
+
+        assert len(opened_handles) == 1, "lock path was not opened exactly once"
+        handle = opened_handles[0]
+        assert handle.closed, (
+            "m-12 regression: unexpected exception between open() and "
+            "successful flock leaked the file handle"
+        )
+        assert ctx._lock_handle is None


### PR DESCRIPTION
## Scope

Implements the three v4.1 Track B single-file MCP write tools per addendum v1.2 and the Dev 2 scope in `.project-internal/v4.1/phaseB/v4.1_TrackB_Implementation_Spec.md`: `scaffold_document`, `log_session`, `promote_document`. All three share a single dispatch path that enforces the addendum's lock and recovery contracts and route workspace_id validation through a new shared helper that Dev 3's `rename_document` can reuse.

## Closed items

- **m-2** — `_ = read_only` at `server.py:73,104` is replaced with real consumption. Write tools refuse mutations with a typed `WriteToolErrorEnvelope(error_code=E_READ_ONLY)` when the server is launched with `--read-only`.
- **m-7 (consumer)** — the write tools are the first `workspace_lock()` consumers in-tree.
- **m-14** — `workspace_id` validation now flows through `ontos.mcp._validation.validate_workspace_id`, shared by read and write tools.
- **m-15 (partial)** — `TOOL_SUCCESS_MODELS` wires the three Track B response models (`ScaffoldDocumentResponse`, `LogSessionResponse`, `PromoteDocumentResponse`).

## Lock pattern callout (addendum §A1)

Every write tool's critical section is:

```python
with workspace_lock(plan.workspace_root):
    ctx = SessionContext(repo_root=..., owns_lock=False, config={})
    ctx.buffer_write(path, content)
    ctx.commit()
    portfolio_index.rebuild_workspace(slug, root)
```

Note: the `SessionContext` field is `repo_root` (not `workspace_root` as the addendum pseudocode abbreviates) — confirmed with Dev 1. `owns_lock=False` is passed explicitly inside every `workspace_lock()` block so the inner flock acquisition is a no-op.

On Python 3.14, `OntosUserError` is a frozen dataclass; letting it propagate out of `workspace_lock()` triggers a `FrozenInstanceError` on `__traceback__` assignment in contextlib. The dispatch layer therefore catches `OntosUserError`/`OntosInternalError` inside the `with` block; only `workspace_lock()`'s own `E_WORKSPACE_BUSY` escapes to the outer handler. Noted in a comment on `_dispatch`.

## A3 post-commit-failure rebuild

When `ctx.commit()` raises, `_commit_with_a3_recovery()` re-invokes `portfolio_index.rebuild_workspace(slug, root)` before re-raising. Rebuild exceptions are logged to stderr but swallowed so they never mask the original commit exception. Pattern references `context.py:189-199`.

## workspace_id helper callout (m-8 consolidation)

Added **new shared helper** at `ontos/mcp/_validation.py::validate_workspace_id`. It accepts a nullable `workspace_id` and a `require=False` flag, raising `OntosUserError(E_MISSING_WORKSPACE | E_PORTFOLIO_REQUIRED | E_UNKNOWN_WORKSPACE)` as appropriate.

Consumer wiring this PR performs:

- `ontos/mcp/tools.py::_validate_workspace_id` now delegates to the shared helper (single source of truth).
- `ontos/mcp/writes.py::_preflight` imports the shared helper directly.

**Handoff to Dev 3:** use `from ontos.mcp._validation import validate_workspace_id` in `rename_document` and at any other write-tool site. Please do NOT reintroduce a third implementation. The guards at `server.py:478` and `tools.py:513-525` (cited in the Track B spec) are the **read-tool** surface — they remain but both eventually funnel through the same helper; consolidating the read-tool guard into the shared helper is a safe follow-up if you want it inside your PR, but is not strictly required by Dev 2's scope.

## Test plan

- `tests/mcp/test_write_tools.py` — **+17 tests** on top of Dev 1's 1064-pass baseline.
  - [x] `scaffold_document` happy path + rejects existing file + rejects path-outside-workspace.
  - [x] `log_session` happy path (filename matches `{date}_{slug}.md`, slug from `commands.log._slugify`) + rejects empty title.
  - [x] `promote_document` mutates `curation_level` only (body preserved) + rejects unknown id + rejects invalid level.
  - [x] `read_only` refusal per tool (scaffold/log/promote).
  - [x] `workspace_id` cross-workspace refusal (routes through shared helper).
  - [x] Contention inside `workspace_lock` — external holder process, write tool returns structured `E_WORKSPACE_BUSY` within the 5s retry window.
  - [x] A3 rebuild-on-failure invoked when `commit()` raises; original exception surfaces unchanged even when the A3 rebuild itself raises.
  - [x] Happy-path rebuild also runs (DB stays current).
  - [x] Shared validator identity check (helper importable from both read and write sides — the contract Dev 3 inherits).
- Full suite: **1081 passed / 2 skipped** on Python 3.14 (1064 → 1081, +17).
- Updated existing tool-count assertions in `test_server_integration.py`, `test_server_portfolio_mode.py`, `test_refresh.py` to account for the three new tool registrations.

## Coordination notes for Dev 3 and Dev 4

- **Dev 3 (`rename_document`):** the `owns_lock=False` + A3 rebuild pattern in `ontos/mcp/writes.py::_dispatch` + `_commit_with_a3_recovery` is the reference. The multi-file path you're implementing can reuse the same shape; your extra surface is the git clean-state precondition and the N-file reference rewrite. Shared workspace_id helper: `ontos.mcp._validation.validate_workspace_id`.
- **Dev 4 (m-11 Protocol typing + bundle wiring):** I added `setattr(cache, "read_only", read_only)` in `create_server` and a new `_register_write_tools` function that currently takes `portfolio_index: Any`. When you tighten the Protocol type, the three write-tool registrations are cookie-cutter call sites to update. Expect a rebase on the integration branch.

## References

- Implementation Spec v1.1 §4.8 (adjusted per addendum §A1, §A2, §A3).
- Addendum v1.2 §A1 (lock), §A2 (slugifiers), §A3 (post-commit rebuild).
- C.0 findings Q1 (slugify contract), Q3 (partial-commit boundaries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)