### PR TITLE
feat(v4.1 Track B): rename_document multi-file tool (Dev 3)

### DIFF
--- a/ontos/commands/rename.py
+++ b/ontos/commands/rename.py
@@ -275,21 +275,49 @@ class _PreparedPlan:
     scope_data: _LoadedScope
 
 
-def _prepare_plan(options: RenameOptions, *, mode: str) -> Tuple[Optional[_PreparedPlan], Optional[RenameError]]:
-    old_id = options.old_id.strip()
-    new_id = options.new_id.strip()
+def build_rename_plan(
+    *,
+    repo_root: Path,
+    config,
+    scope: ScanScope,
+    docs: Dict[str, DocumentData],
+    load_issues: Optional[Sequence[DocumentLoadIssue]] = None,
+    old_id: str,
+    new_id: str,
+    mode: str,
+    check_git: bool = True,
+) -> Tuple[Optional[RenamePlan], Optional[RenameError]]:
+    """Shared rename-plan orchestrator used by both the CLI and the MCP tool.
 
-    try:
-        repo_root = find_project_root()
-    except FileNotFoundError as exc:
-        return None, RenameError(code="project_root_not_found", message=str(exc))
+    The caller supplies the already-loaded ``docs`` dictionary (and optional
+    ``load_issues`` sequence). This function performs the 11 validation +
+    collision + file-plan steps that used to live inside ``_prepare_plan``:
 
-    try:
-        config = load_project_config(repo_root=repo_root)
-    except Exception as exc:  # pragma: no cover - configuration failure path
-        return None, RenameError(code="config_error", message=f"Config error: {exc}")
+    1. Strip ``old_id`` / ``new_id``.
+    2. Same-ID no-op → return empty ``RenamePlan``.
+    3. ``_ID_PATTERN`` regex validation of ``new_id``.
+    4. ``_RESERVED_YAML_WORDS`` guard.
+    5. Optional git clean-state check (CLI enforces here; MCP enforces
+       before acquiring ``workspace_lock()`` and passes ``check_git=False``).
+    6. ``old_id`` must exist exactly once as an explicit frontmatter id.
+    7. ``new_id`` must not already exist in scope.
+    8. Cross-scope collision check when ``scope == ScanScope.DOCS``.
+    9. ``load_issues`` parse-failed-sighting check (skipped when ``None``).
+    10. Per-document ``_build_file_plan`` loop (sorted by filepath).
+    11. Summary + ``RenamePlan`` assembly.
 
-    scope = resolve_scan_scope(options.scope, config.scanning.default_scope)
+    ``check_git=False`` exists because MCP validates git-clean ex-ante —
+    ``workspace_lock()`` materialises ``.ontos.lock`` as an untracked file,
+    so a post-lock check would false-positive for callers that don't ignore
+    the lock file.
+
+    ``load_issues=None`` allows the MCP caller to skip the parse-failed
+    sightings check, because the live snapshot doesn't carry per-doc parse
+    issues. This is a documented limitation, not a regression.
+    """
+
+    old_id = old_id.strip()
+    new_id = new_id.strip()
 
     if old_id == new_id:
         empty_plan = RenamePlan(
@@ -310,17 +338,7 @@ def _prepare_plan(options: RenameOptions, *, mode: str) -> Tuple[Optional[_Prepa
             warnings=[],
             no_op=True,
         )
-        return _PreparedPlan(
-            scope=scope,
-            plan=empty_plan,
-            scope_data=_LoadedScope(
-                repo_root=repo_root,
-                scope=scope,
-                doc_paths=[],
-                load_result=None,
-                docs={},
-            ),
-        ), None
+        return empty_plan, None
 
     if not _ID_PATTERN.match(new_id):
         return None, RenameError(
@@ -336,7 +354,7 @@ def _prepare_plan(options: RenameOptions, *, mode: str) -> Tuple[Optional[_Prepa
             ),
         )
 
-    if mode == "apply":
+    if check_git and mode == "apply":
         clean, git_error = _check_clean_git_state(repo_root)
         if not clean:
             return None, RenameError(
@@ -344,25 +362,6 @@ def _prepare_plan(options: RenameOptions, *, mode: str) -> Tuple[Optional[_Prepa
                 message=git_error
                 or "Git working tree must be clean for --apply.",
             )
-
-    doc_paths = collect_scoped_documents(
-        repo_root,
-        config,
-        scope,
-        base_skip_patterns=list(config.scanning.skip_patterns),
-    )
-    load_result = load_documents(doc_paths, parse_frontmatter_content)
-    docs = load_result.documents
-
-    if load_result.duplicate_ids:
-        details = []
-        for doc_id, paths in sorted(load_result.duplicate_ids.items()):
-            joined = ", ".join(str(path) for path in paths)
-            details.append(f"{doc_id}: {joined}")
-        return None, RenameError(
-            code="duplicate_ids",
-            message="Duplicate IDs detected in scope: " + "; ".join(details),
-        )
 
     old_docs = [
         doc
@@ -395,19 +394,20 @@ def _prepare_plan(options: RenameOptions, *, mode: str) -> Tuple[Optional[_Prepa
                 ),
             )
 
-    sightings = _scan_parse_failed_files_for_target(
-        issues=load_result.issues,
-        old_id=old_id,
-    )
-    if sightings:
-        first = sightings[0]
-        return None, RenameError(
-            code="parse_failed_target_sighting",
-            message=(
-                "Found target ID in parse-failed file(s), cannot guarantee safe rewrite: "
-                f"{first.path}:{first.line} ({first.match_type})."
-            ),
+    if load_issues is not None:
+        sightings = _scan_parse_failed_files_for_target(
+            issues=load_issues,
+            old_id=old_id,
         )
+        if sightings:
+            first = sightings[0]
+            return None, RenameError(
+                code="parse_failed_target_sighting",
+                message=(
+                    "Found target ID in parse-failed file(s), cannot guarantee safe rewrite: "
+                    f"{first.path}:{first.line} ({first.match_type})."
+                ),
+            )
 
     file_plans: List[FilePlan] = []
     all_warnings: List[RenameWarning] = []
@@ -423,7 +423,7 @@ def _prepare_plan(options: RenameOptions, *, mode: str) -> Tuple[Optional[_Prepa
         all_warnings.extend(file_plan.warnings)
 
     summary = RenameSummary(
-        files_scanned=len(doc_paths),
+        files_scanned=len(docs),
         documents_loaded=len(docs),
         planned_files=len([item for item in file_plans if item.has_changes]),
         frontmatter_edits=sum(len(item.frontmatter_edits) for item in file_plans),
@@ -446,6 +446,109 @@ def _prepare_plan(options: RenameOptions, *, mode: str) -> Tuple[Optional[_Prepa
         summary=summary,
         files=file_plans,
         warnings=all_warnings,
+    )
+
+    return plan, None
+
+
+def _prepare_plan(options: RenameOptions, *, mode: str) -> Tuple[Optional[_PreparedPlan], Optional[RenameError]]:
+    try:
+        repo_root = find_project_root()
+    except FileNotFoundError as exc:
+        return None, RenameError(code="project_root_not_found", message=str(exc))
+
+    try:
+        config = load_project_config(repo_root=repo_root)
+    except Exception as exc:  # pragma: no cover - configuration failure path
+        return None, RenameError(code="config_error", message=f"Config error: {exc}")
+
+    scope = resolve_scan_scope(options.scope, config.scanning.default_scope)
+
+    # Same-ID no-op short-circuit — avoid scanning the filesystem entirely.
+    # The orchestrator also handles this, but the CLI wrapper skips the scan
+    # to preserve the prior zero-IO behaviour for no-ops.
+    old_id = options.old_id.strip()
+    new_id = options.new_id.strip()
+    if old_id == new_id:
+        plan, error = build_rename_plan(
+            repo_root=repo_root,
+            config=config,
+            scope=scope,
+            docs={},
+            load_issues=None,
+            old_id=old_id,
+            new_id=new_id,
+            mode=mode,
+        )
+        assert error is None and plan is not None
+        return _PreparedPlan(
+            scope=scope,
+            plan=plan,
+            scope_data=_LoadedScope(
+                repo_root=repo_root,
+                scope=scope,
+                doc_paths=[],
+                load_result=None,
+                docs={},
+            ),
+        ), None
+
+    doc_paths = collect_scoped_documents(
+        repo_root,
+        config,
+        scope,
+        base_skip_patterns=list(config.scanning.skip_patterns),
+    )
+    load_result = load_documents(doc_paths, parse_frontmatter_content)
+    docs = load_result.documents
+
+    # Duplicate-ID detection is a CLI-only error path (MCP operates on the
+    # live snapshot, which de-duplicates by id automatically). Kept in the
+    # wrapper per plan §"Design — _prepare_plan becomes thin wrapper".
+    if load_result.duplicate_ids:
+        details = []
+        for doc_id, paths in sorted(load_result.duplicate_ids.items()):
+            joined = ", ".join(str(path) for path in paths)
+            details.append(f"{doc_id}: {joined}")
+        return None, RenameError(
+            code="duplicate_ids",
+            message="Duplicate IDs detected in scope: " + "; ".join(details),
+        )
+
+    plan, error = build_rename_plan(
+        repo_root=repo_root,
+        config=config,
+        scope=scope,
+        docs=docs,
+        load_issues=load_result.issues,
+        old_id=old_id,
+        new_id=new_id,
+        mode=mode,
+    )
+    if error is not None:
+        return None, error
+    assert plan is not None
+
+    # Refresh files_scanned with the real scan count (the orchestrator only
+    # sees len(docs), not the scan pre-filter count).
+    refreshed_summary = RenameSummary(
+        files_scanned=len(doc_paths),
+        documents_loaded=plan.summary.documents_loaded,
+        planned_files=plan.summary.planned_files,
+        frontmatter_edits=plan.summary.frontmatter_edits,
+        body_edits=plan.summary.body_edits,
+        skipped_zone_sightings=plan.summary.skipped_zone_sightings,
+        warnings=plan.summary.warnings,
+    )
+    plan = RenamePlan(
+        mode=plan.mode,
+        scope=plan.scope,
+        old_id=plan.old_id,
+        new_id=plan.new_id,
+        summary=refreshed_summary,
+        files=plan.files,
+        warnings=plan.warnings,
+        no_op=plan.no_op,
     )
 
     return _PreparedPlan(

--- a/ontos/core/context.py
+++ b/ontos/core/context.py
@@ -57,6 +57,15 @@ class SessionContext:
     cwd: Path = field(default_factory=Path.cwd)
     env: Dict[str, str] = field(default_factory=lambda: dict(os.environ))
 
+    # Lock ownership (v4.1 A1 — single-lock discipline).
+    # When True (default), commit() acquires and releases an flock on
+    # <repo_root>/.ontos.lock around the critical section. When False,
+    # commit() assumes the caller already holds that flock (for example,
+    # via an outer workspace-lock context manager) and _acquire_lock /
+    # _release_lock become no-ops. See the v4.1 spec addendum A1 for
+    # the full contract.
+    owns_lock: bool = True
+
     # Mutable state (changes during session)
     pending_writes: List[PendingWrite] = field(default_factory=list)
     warnings: List[str] = field(default_factory=list)
@@ -225,28 +234,54 @@ class SessionContext:
         self.errors.append(message)
 
     def _acquire_lock(self, lock_path: Path, timeout: float = 5.0) -> bool:
-        """Acquire an exclusive flock lock for this workspace."""
+        """Acquire an exclusive flock lock for this workspace.
+
+        When ``self.owns_lock`` is False the caller is expected to hold
+        the flock on the workspace lockfile (acquired by an outer
+        workspace-lock context manager) and this method is a no-op —
+        see v4.1 spec addendum A1.
+        """
+        if not self.owns_lock:
+            return True
+
         lock_path.parent.mkdir(parents=True, exist_ok=True)
         start = time.monotonic()
         handle = lock_path.open("a+", encoding="utf-8")
 
-        while time.monotonic() - start < timeout:
-            try:
-                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        try:
+            while time.monotonic() - start < timeout:
+                try:
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except BlockingIOError:
+                    time.sleep(0.1)
+                    continue
+                # flock succeeded — hand ownership of the handle to the
+                # instance so _release_lock can close it.
                 self._lock_handle = handle
                 return True
-            except BlockingIOError:
-                time.sleep(0.1)
+        except BaseException:
+            # m-12: any non-BlockingIOError raised between open() and a
+            # successful flock (signals, OSError from sleep, etc.) must
+            # not leak the file handle. Close and re-raise.
+            handle.close()
+            raise
+
+        # Timed out waiting for the lock — close the handle and report.
         handle.close()
         return False
 
     def _release_lock(self, lock_path: Path) -> None:
         """Release the file lock.
-        
+
+        When ``self.owns_lock`` is False this is a no-op — the caller owns
+        the outer flock and is responsible for releasing it.
+
         Args:
             lock_path: Path to lock file.
         """
         _ = lock_path
+        if not self.owns_lock:
+            return
         if self._lock_handle is None:
             return
         try:

--- a/ontos/core/git.py
+++ b/ontos/core/git.py
@@ -1,0 +1,63 @@
+"""Git helpers shared by commands and MCP tools.
+
+The helpers in this module exist to keep git-shell-out logic in one place so
+that both the CLI rename command and the MCP ``rename_document`` tool share a
+single source of truth about what "clean" means for workspace mutation paths.
+
+Semantics (v4.1 Track B):
+
+* ``is_workspace_clean`` shells out to ``git status --porcelain``. Any
+  non-empty output (including untracked files) is treated as *dirty*. This
+  matches the v1.1 spec §4.8.2 recovery contract: the ``rename_document``
+  precondition must guarantee that ``git checkout -- .`` restores the
+  pre-mutation state, which is only safe when the working tree has nothing
+  to lose.
+* ``is_workspace_clean`` returns ``False`` (with a reason string) when git
+  is unavailable or the repository cannot be inspected — the tool is a
+  precondition for destructive multi-file edits, so we fail closed.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Optional, Tuple
+
+
+def is_workspace_clean(
+    root: Path,
+    *,
+    timeout: float = 10.0,
+) -> Tuple[bool, Optional[str]]:
+    """Check whether ``root`` is a clean git working tree.
+
+    Args:
+        root: Absolute path to the workspace root (passed as ``cwd`` to git).
+        timeout: Seconds to wait on the git invocation before giving up.
+
+    Returns:
+        ``(True, None)`` when the working tree has no modifications and no
+        untracked files; ``(False, reason)`` otherwise, where ``reason``
+        is a short human-readable explanation.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=str(root),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except FileNotFoundError:
+        return False, "git executable not found on PATH"
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return False, f"Unable to check git state: {exc}"
+
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        return False, stderr or "git status failed"
+
+    if result.stdout.strip():
+        return False, "working tree has uncommitted or untracked changes"
+    return True, None

--- a/ontos/mcp/_validation.py
+++ b/ontos/mcp/_validation.py
@@ -1,0 +1,60 @@
+"""Shared validation helpers for MCP tools.
+
+Consolidates workspace_id validation used by both read and write tools so a
+single helper replaces the duplicated guards at ``server.py:478`` and
+``tools.py:513-525`` (addendum item m-8 / m-14). Write tools call
+``validate_workspace_id`` prior to mutating anything in the workspace.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from ontos.core.errors import OntosUserError
+
+
+def validate_workspace_id(
+    portfolio_index: Any,
+    workspace_id: Optional[str],
+    *,
+    require: bool = False,
+) -> None:
+    """Validate ``workspace_id`` against the portfolio index.
+
+    Args:
+        portfolio_index: Portfolio index instance (may be ``None`` in
+            non-portfolio mode).
+        workspace_id: Caller-supplied workspace slug. ``None`` is
+            tolerated unless ``require=True``.
+        require: When True, raise if ``workspace_id`` is missing.
+
+    Raises:
+        OntosUserError: If the id is missing and required, if portfolio
+            mode is required but not active, or if the id does not match
+            any known workspace slug.
+    """
+    if workspace_id is None:
+        if require:
+            raise OntosUserError(
+                "workspace_id is required in portfolio mode. "
+                "Use project_registry() to discover available workspaces.",
+                code="E_MISSING_WORKSPACE",
+            )
+        return
+
+    if portfolio_index is None:
+        raise OntosUserError(
+            "workspace_id requires portfolio mode.",
+            code="E_PORTFOLIO_REQUIRED",
+        )
+
+    projects = portfolio_index.get_projects()
+    slugs = [project["slug"] for project in projects]
+    if workspace_id not in slugs:
+        sorted_slugs = ", ".join(sorted(slugs))
+        raise OntosUserError(
+            f"Unknown workspace '{workspace_id}'. "
+            f"Valid workspace slugs: {sorted_slugs}. "
+            "Use project_registry() to discover available workspaces.",
+            code="E_UNKNOWN_WORKSPACE",
+        )

--- a/ontos/mcp/rename_tool.py
+++ b/ontos/mcp/rename_tool.py
@@ -1,0 +1,541 @@
+"""Multi-file MCP ``rename_document`` tool for Ontos v4.1 Track B (Dev 3).
+
+This module implements the one Track B write tool whose mutation surface
+spans N files: renaming a document ID updates every referencing file in
+the workspace. It sits next to the single-file tools in
+``ontos.mcp.writes`` and reuses the same substrate (workspace_lock + A1
+``owns_lock=False`` pattern, shared ``validate_workspace_id``, shared
+``WriteToolErrorEnvelope`` shapes) but keeps the multi-file control flow
+separate so Dev 2's single-file surface is untouched.
+
+A6 semantics — verified (TrackB-Design §9, v1.1 §4.8.2):
+    ``ontos/commands/rename.py:221`` writes new content with
+    ``ctx.buffer_write(path, new_content)`` — no ``os.rename`` / no
+    ``buffer_move``. The MCP tool matches exactly: "rename" edits file
+    content in place and rewrites references via
+    ``scan_body_references``; filenames are NOT changed.
+
+A3 post-rollback rebuild (addendum v1.2 §A3):
+    If ``ctx.commit()`` raises, the DB may be out of sync with the
+    filesystem. This tool performs ``git checkout -- .`` to revert
+    uncommitted writes (the git clean-state precondition guarantees this
+    is safe), then re-invokes ``rebuild_workspace(slug, root)`` so the
+    index re-converges with the reverted files. Rebuild failures are
+    recorded via ``ctx.error(...)`` but never mask the original commit
+    exception.
+
+m-13 — FTS5 parity recoverable rebuild:
+    The parity check in ``portfolio.py:410-422`` raises after
+    ``conn.commit()`` has already mutated the DB. Because
+    ``rebuild_workspace`` starts with a ``DELETE FROM documents`` it is
+    idempotent; a single retry re-converges on success. This module
+    retries once on parity-mismatch ``RuntimeError`` before surfacing
+    failure. See PR description for rationale.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import subprocess
+import sys
+import traceback
+from typing import Any, Dict, List, Optional
+
+from mcp.types import CallToolResult, TextContent
+
+from ontos.commands.rename import (
+    FilePlan,
+    _build_file_plan,
+)
+from ontos.core.context import SessionContext
+from ontos.core.errors import OntosInternalError, OntosUserError
+from ontos.core.git import is_workspace_clean
+from ontos.mcp._validation import validate_workspace_id
+from ontos.mcp.cache import SnapshotCache
+from ontos.mcp.locking import workspace_lock
+from ontos.mcp.scanner import slugify as slugify_workspace_identity
+from ontos.mcp.schemas import (
+    ToolErrorTextItem,
+    WriteToolError,
+    WriteToolErrorEnvelope,
+    validate_success_payload,
+)
+
+
+# Same ID regex the CLI rename command uses. Kept here so we don't import a
+# private module-level constant.
+import re as _re
+_ID_PATTERN = _re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9_.-]*[A-Za-z0-9])?$")
+_RESERVED_YAML_WORDS = {"true", "false", "yes", "no", "null", "on", "off"}
+
+
+# ---------------------------------------------------------------------------
+# Envelope helpers (mirror Dev 2's writes.py so error shapes stay uniform).
+# ---------------------------------------------------------------------------
+
+
+def _success_result(tool_name: str, payload: Dict[str, Any]) -> CallToolResult:
+    import json
+
+    validated = validate_success_payload(tool_name, payload)
+    return CallToolResult(
+        isError=False,
+        structuredContent=validated,
+        content=[
+            TextContent(
+                type="text",
+                text=json.dumps(validated, ensure_ascii=True),
+            )
+        ],
+    )
+
+
+def _write_error_result(
+    *,
+    error_code: str,
+    what: str,
+    why: str,
+    fix: str,
+) -> CallToolResult:
+    envelope = WriteToolErrorEnvelope(
+        isError=True,
+        error=WriteToolError(
+            error_code=error_code,
+            what=what,
+            why=why,
+            fix=fix,
+        ),
+        content=[ToolErrorTextItem(type="text", text=what)],
+    ).model_dump(mode="json", by_alias=True)
+    return CallToolResult(
+        isError=True,
+        structuredContent=envelope,
+        content=[TextContent(type="text", text=what)],
+    )
+
+
+def _user_error_result(exc: OntosUserError) -> CallToolResult:
+    return _write_error_result(
+        error_code=getattr(exc, "code", "E_USER_ERROR") or "E_USER_ERROR",
+        what=str(exc),
+        why=str(exc),
+        fix="See error message for remediation guidance.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Preflight + A3/m-13 helpers.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Preflight:
+    slug: str
+    workspace_root: Path
+
+
+def _preflight(
+    cache: SnapshotCache,
+    portfolio_index: Any,
+    workspace_id: Optional[str],
+    read_only: bool,
+) -> _Preflight:
+    if read_only:
+        raise OntosUserError(
+            "Write tools are disabled because the MCP server is running in "
+            "read-only mode. Restart without --read-only to enable writes.",
+            code="E_READ_ONLY",
+        )
+
+    # Shared helper — closes m-8 by reusing Dev 2's single guard.
+    validate_workspace_id(portfolio_index, workspace_id)
+
+    workspace_root = cache.workspace_root
+    slug = slugify_workspace_identity(workspace_root.name)
+    if workspace_id is not None and workspace_id != slug:
+        raise OntosUserError(
+            "Cross-workspace writes are not supported. "
+            "Start a separate `ontos serve` in the target workspace.",
+            code="E_CROSS_WORKSPACE_NOT_SUPPORTED",
+        )
+
+    # Git clean-state precondition (§4.8.2 Step 4).
+    #
+    # This runs BEFORE ``workspace_lock()`` because the lock context
+    # materialises ``.ontos.lock`` as an untracked file; checking dirty
+    # state after the lock is held would always see at least that file
+    # and trigger false-positive E_DIRTY_WORKSPACE for any caller that
+    # hasn't added ``.ontos.lock`` to ``.gitignore``. Untracked files
+    # elsewhere also count as dirty: the recovery action is ``git
+    # checkout -- .``, which only restores tracked files, so untracked
+    # state we'd write during the tool run would linger after rollback.
+    clean, reason = is_workspace_clean(workspace_root)
+    if not clean:
+        raise OntosUserError(
+            "Workspace has uncommitted changes. "
+            "Commit or stash before renaming so you can recover with "
+            "`git checkout -- .` if needed. "
+            f"(Reason: {reason})",
+            code="E_DIRTY_WORKSPACE",
+        )
+
+    return _Preflight(slug=slug, workspace_root=workspace_root)
+
+
+def _rebuild_with_m13_retry(
+    portfolio_index: Any,
+    slug: str,
+    workspace_root: Path,
+    *,
+    ctx: Optional[SessionContext] = None,
+) -> None:
+    """Best-effort rebuild that retries once on FTS5 parity mismatch.
+
+    Because ``rebuild_workspace`` begins with a ``DELETE FROM documents``,
+    it is fully idempotent: a second invocation re-converges. The retry
+    only runs for parity-mismatch ``RuntimeError``s raised by the
+    post-commit check at ``portfolio.py:410-422``. Other exceptions are
+    re-raised so they don't get silently swallowed.
+    """
+    if portfolio_index is None:
+        return
+
+    try:
+        portfolio_index.rebuild_workspace(slug, workspace_root)
+    except RuntimeError as exc:
+        if "FTS parity mismatch" not in str(exc):
+            raise
+        # m-13: retry once. If the second pass also fails, surface it.
+        try:
+            portfolio_index.rebuild_workspace(slug, workspace_root)
+        except Exception as retry_exc:
+            if ctx is not None:
+                ctx.error(
+                    f"Portfolio rebuild failed after retry: {retry_exc}"
+                )
+            raise
+
+
+def _rebuild_safely(
+    portfolio_index: Any,
+    slug: str,
+    workspace_root: Path,
+    *,
+    ctx: Optional[SessionContext] = None,
+) -> None:
+    """Same contract as Dev 2's ``_rebuild_safely``: swallow + log."""
+    if portfolio_index is None:
+        return
+    try:
+        _rebuild_with_m13_retry(
+            portfolio_index, slug, workspace_root, ctx=ctx
+        )
+    except Exception:
+        traceback.print_exc(file=sys.stderr)
+
+
+def _git_checkout_rollback(root: Path) -> Optional[str]:
+    """Revert all uncommitted changes via ``git checkout -- .``.
+
+    Returns ``None`` on success or a reason string on failure.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "checkout", "--", "."],
+            cwd=str(root),
+            capture_output=True,
+            text=True,
+            timeout=10.0,
+            check=False,
+        )
+    except FileNotFoundError:
+        return "git executable not found on PATH"
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return f"Unable to run git checkout: {exc}"
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        return stderr or "git checkout failed"
+    return None
+
+
+def _commit_with_a3_rollback_and_rebuild(
+    ctx: SessionContext,
+    portfolio_index: Any,
+    slug: str,
+    workspace_root: Path,
+) -> List[Path]:
+    """Commit, or rollback + rebuild on failure (addendum v1.2 §A3).
+
+    This is the multi-file mainline: the git clean-state precondition
+    guarantees ``git checkout -- .`` is a safe recovery action. After
+    reverting, we re-invoke ``rebuild_workspace`` so the portfolio DB
+    re-converges with the reverted filesystem state.
+    """
+    try:
+        return ctx.commit()
+    except Exception:
+        # Rollback the working tree. The precondition (clean at entry)
+        # means "revert to HEAD" restores the pre-mutation state.
+        reason = _git_checkout_rollback(workspace_root)
+        if reason is not None:
+            ctx.error(f"Post-commit rollback failed: {reason}")
+        # Now reconcile the DB with the reverted filesystem.
+        _rebuild_safely(portfolio_index, slug, workspace_root, ctx=ctx)
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Public entry point.
+# ---------------------------------------------------------------------------
+
+
+def rename_document(
+    cache: SnapshotCache,
+    *,
+    portfolio_index: Any = None,
+    read_only: bool = False,
+    document_id: str,
+    new_id: str,
+    workspace_id: Optional[str] = None,
+) -> CallToolResult:
+    """Rename a document ID and rewrite all references across the workspace.
+
+    Matches ``ontos/commands/rename.py:221`` semantics — ID-only rename,
+    no filesystem moves, all edits flow through ``ctx.buffer_write``.
+    """
+    try:
+        plan = _preflight(cache, portfolio_index, workspace_id, read_only)
+    except OntosUserError as exc:
+        return _user_error_result(exc)
+
+    # Result holder so we can shape error returns outside the lock while
+    # keeping OntosUserError/OntosInternalError caught INSIDE the lock
+    # (Python 3.14 frozen-dataclass __traceback__ gotcha documented in
+    # writes.py dispatcher comments).
+    result: Optional[CallToolResult] = None
+    try:
+        with workspace_lock(plan.workspace_root):
+            try:
+                payload = _rename_document_impl(
+                    cache=cache,
+                    portfolio_index=portfolio_index,
+                    plan=plan,
+                    document_id=document_id,
+                    new_id=new_id,
+                )
+                result = _success_result("rename_document", payload)
+            except OntosUserError as exc:
+                result = _user_error_result(exc)
+            except OntosInternalError as exc:
+                print(
+                    f"[ontos-mcp] {exc.code}: {exc}", file=sys.stderr
+                )
+                if exc.details:
+                    print(exc.details, file=sys.stderr)
+                result = _write_error_result(
+                    error_code=exc.code or "E_INTERNAL",
+                    what=f"Internal error: {exc}",
+                    why="The server encountered an unexpected error.",
+                    fix="Check server logs and retry.",
+                )
+            except Exception as exc:
+                traceback.print_exc(file=sys.stderr)
+                result = _write_error_result(
+                    error_code="E_INTERNAL",
+                    what=f"Internal error in rename_document: {exc}",
+                    why="Unexpected exception while executing the write tool.",
+                    fix="Check server logs and retry.",
+                )
+    except OntosUserError as exc:
+        # workspace_lock E_WORKSPACE_BUSY escapes as documented.
+        return _user_error_result(exc)
+
+    assert result is not None  # for type-checkers
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Implementation.
+# ---------------------------------------------------------------------------
+
+
+def _rename_document_impl(
+    *,
+    cache: SnapshotCache,
+    portfolio_index: Any,
+    plan: _Preflight,
+    document_id: str,
+    new_id: str,
+) -> Dict[str, Any]:
+    old_id = str(document_id).strip() if document_id is not None else ""
+    target_id = str(new_id).strip() if new_id is not None else ""
+
+    if not old_id:
+        raise OntosUserError(
+            "document_id must be non-empty.",
+            code="E_INVALID_DOCUMENT_ID",
+        )
+    if not target_id:
+        raise OntosUserError(
+            "new_id must be non-empty.",
+            code="E_INVALID_ID",
+        )
+
+    # No-op rename: report success without touching files.
+    if old_id == target_id:
+        snapshot = cache.get_fresh_snapshot()
+        doc = snapshot.documents.get(old_id)
+        if doc is None:
+            raise OntosUserError(
+                f"Document not found: {old_id}",
+                code="E_DOCUMENT_NOT_FOUND",
+            )
+        rel = _rel_to_workspace(plan.workspace_root, Path(doc.filepath))
+        return {
+            "success": True,
+            "old_id": old_id,
+            "new_id": target_id,
+            "path": rel,
+            "references_updated": 0,
+            "updated_files": [],
+        }
+
+    if not _ID_PATTERN.match(target_id):
+        raise OntosUserError(
+            "new_id must match ^[A-Za-z0-9](?:[A-Za-z0-9_.-]*[A-Za-z0-9])?$",
+            code="E_INVALID_ID",
+        )
+    if target_id.lower() in _RESERVED_YAML_WORDS:
+        raise OntosUserError(
+            "new_id cannot be a YAML reserved word: "
+            + ", ".join(sorted(_RESERVED_YAML_WORDS)),
+            code="E_INVALID_ID",
+        )
+
+    # Workspace-scoped lookup: the MCP tool operates on the live snapshot
+    # rather than re-invoking the CLI's scope resolver. This avoids the
+    # find_project_root/cwd dependency that _prepare_plan carries.
+    snapshot = cache.get_fresh_snapshot()
+    documents = snapshot.documents
+
+    if old_id not in documents:
+        raise OntosUserError(
+            f"Document not found: {old_id}",
+            code="E_DOCUMENT_NOT_FOUND",
+        )
+
+    if target_id in documents:
+        raise OntosUserError(
+            f"new_id already exists: {target_id}",
+            code="E_DUPLICATE_ID",
+        )
+
+    target_doc = documents[old_id]
+    target_rel = _rel_to_workspace(plan.workspace_root, Path(target_doc.filepath))
+
+    # Build per-file edit plans. ``_build_file_plan`` is pure (path + ids)
+    # and returns None for files that need no edits — perfect for reuse.
+    file_plans: List[FilePlan] = []
+    for doc in sorted(documents.values(), key=lambda item: str(item.filepath)):
+        file_plan = _build_file_plan(
+            path=Path(doc.filepath),
+            old_id=old_id,
+            new_id=target_id,
+        )
+        if file_plan is None:
+            continue
+        file_plans.append(file_plan)
+
+    # Fail if any file plan raised a blocking warning (unsupported
+    # frontmatter format). This mirrors the CLI's blocking_warnings gate.
+    blocking = []
+    for fp in file_plans:
+        blocking.extend(w for w in fp.warnings if w.blocking)
+    if blocking:
+        first = blocking[0]
+        raise OntosUserError(
+            "Rename plan contains unsupported frontmatter formats. "
+            f"First blocker: {first.path} — {first.reason_message}",
+            code="E_UNSUPPORTED_TARGET_FORMAT",
+        )
+
+    files_to_apply = [fp for fp in file_plans if fp.has_changes]
+    if not files_to_apply:
+        # Target exists but no references anywhere — still a valid rename
+        # even though we shouldn't reach here (target_doc has its own
+        # `id:` field which must change). Treat as a no-op.
+        return {
+            "success": True,
+            "old_id": old_id,
+            "new_id": target_id,
+            "path": target_rel,
+            "references_updated": 0,
+            "updated_files": [],
+        }
+
+    # Count body edits that actually rewrite (matches CLI summary).
+    references_updated = 0
+    for fp in files_to_apply:
+        references_updated += len(fp.frontmatter_edits)
+        references_updated += sum(1 for edit in fp.body_edits if edit.rewritable)
+
+    ctx = SessionContext(
+        repo_root=plan.workspace_root,
+        config={},
+        owns_lock=False,  # addendum v1.2 §A1
+    )
+    for fp in files_to_apply:
+        ctx.buffer_write(fp.path, fp.new_content)
+
+    # Commit + A3 rollback+rebuild path. On failure we re-raise so the
+    # outer dispatcher turns it into a WriteToolErrorEnvelope.
+    modified_paths = _commit_with_a3_rollback_and_rebuild(
+        ctx, portfolio_index, plan.slug, plan.workspace_root
+    )
+
+    # Verify planned vs actual commit set (matches rename.py guard).
+    planned = {p.path.resolve() for p in files_to_apply}
+    committed = {p.resolve() for p in modified_paths}
+    if planned != committed:
+        # Best-effort rollback — git checkout even here, then rebuild.
+        rollback_reason = _git_checkout_rollback(plan.workspace_root)
+        if rollback_reason is not None:
+            ctx.error(f"Partial-commit rollback failed: {rollback_reason}")
+        _rebuild_safely(
+            portfolio_index, plan.slug, plan.workspace_root, ctx=ctx
+        )
+        raise OntosInternalError(
+            "Commit result does not match planned file set. "
+            "Repository has been rolled back via `git checkout -- .`.",
+            code="E_PARTIAL_COMMIT_MISMATCH",
+        )
+
+    # Happy-path post-commit rebuild with m-13 retry.
+    _rebuild_safely(
+        portfolio_index, plan.slug, plan.workspace_root, ctx=ctx
+    )
+
+    updated_files = sorted(
+        _rel_to_workspace(plan.workspace_root, p) for p in committed
+    )
+    return {
+        "success": True,
+        "old_id": old_id,
+        "new_id": target_id,
+        "path": target_rel,
+        "references_updated": references_updated,
+        "updated_files": updated_files,
+    }
+
+
+def _rel_to_workspace(root: Path, path: Path) -> str:
+    try:
+        return path.resolve().relative_to(root.resolve()).as_posix()
+    except ValueError:
+        return path.name
+
+
+# Public symbol used by tests that assert the shared helper binding.
+# (Mirrors writes.py's re-export of validate_workspace_id.)
+__all__ = ["rename_document", "validate_workspace_id"]

--- a/ontos/mcp/rename_tool.py
+++ b/ontos/mcp/rename_tool.py
@@ -45,12 +45,14 @@ from typing import Any, Dict, List, Optional
 from mcp.types import CallToolResult, TextContent
 
 from ontos.commands.rename import (
-    FilePlan,
-    _build_file_plan,
+    RenameError,
+    build_rename_plan,
 )
 from ontos.core.context import SessionContext
 from ontos.core.errors import OntosInternalError, OntosUserError
 from ontos.core.git import is_workspace_clean
+from ontos.io.config import load_project_config
+from ontos.io.scan_scope import resolve_scan_scope
 from ontos.mcp._validation import validate_workspace_id
 from ontos.mcp.cache import SnapshotCache
 from ontos.mcp.locking import workspace_lock
@@ -63,11 +65,35 @@ from ontos.mcp.schemas import (
 )
 
 
-# Same ID regex the CLI rename command uses. Kept here so we don't import a
-# private module-level constant.
-import re as _re
-_ID_PATTERN = _re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9_.-]*[A-Za-z0-9])?$")
-_RESERVED_YAML_WORDS = {"true", "false", "yes", "no", "null", "on", "off"}
+# Mapping from shared-orchestrator ``RenameError.code`` to the MCP
+# write-tool error taxonomy. The orchestrator is source-of-truth for
+# validation + collision logic; this helper preserves the stable MCP
+# envelope codes the existing tests assert.
+_RENAME_ERROR_TO_USER_CODE: Dict[str, str] = {
+    "invalid_new_id": "E_INVALID_ID",
+    "reserved_new_id": "E_INVALID_ID",
+    "old_id_not_found": "E_DOCUMENT_NOT_FOUND",
+    "new_id_exists": "E_DUPLICATE_ID",
+    "cross_scope_collision": "E_CROSS_SCOPE_COLLISION",
+    "duplicate_ids": "E_DUPLICATE_ID",
+    "parse_failed_target_sighting": "E_UNSUPPORTED_TARGET_FORMAT",
+    "config_error": "E_CONFIG_ERROR",
+    "dirty_git_state": "E_DIRTY_WORKSPACE",
+    "project_root_not_found": "E_PROJECT_ROOT_NOT_FOUND",
+}
+
+
+def _rename_error_to_user_exc(error: RenameError) -> OntosUserError:
+    """Translate a shared ``RenameError`` into an ``OntosUserError``.
+
+    Unknown codes fall back to ``E_USER_INPUT`` (the ``OntosUserError``
+    default) so new orchestrator codes surface as user errors by default
+    rather than crashing the MCP dispatcher.
+    """
+    return OntosUserError(
+        error.message,
+        code=_RENAME_ERROR_TO_USER_CODE.get(error.code, "E_USER_INPUT"),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -382,16 +408,53 @@ def _rename_document_impl(
             code="E_INVALID_ID",
         )
 
-    # No-op rename: report success without touching files.
-    if old_id == target_id:
-        snapshot = cache.get_fresh_snapshot()
+    # Route through the shared orchestrator. It performs ID validation,
+    # old/new collision checks, the docs-scope cross-scope guard, and the
+    # sorted per-file plan loop. The CLI and MCP now share this single
+    # plan-builder — closing the CB-6-style divergence risk where each
+    # call site had its own hand-rolled orchestration loop.
+    snapshot = cache.get_fresh_snapshot()
+    try:
+        config = load_project_config(repo_root=plan.workspace_root)
+    except Exception as exc:  # pragma: no cover - config failure path
+        raise OntosUserError(
+            f"Config error: {exc}",
+            code="E_CONFIG_ERROR",
+        )
+    # Use the same scope resolution the snapshot cache used, so the docs
+    # dict and the scope parameter stay consistent. This keeps MCP's
+    # pre-refactor behaviour (whatever scope the snapshot was built with)
+    # while gaining the docs-scope cross-scope collision check whenever
+    # the effective scope is DOCS.
+    scope = resolve_scan_scope(None, config.scanning.default_scope)
+
+    rename_plan, error = build_rename_plan(
+        repo_root=plan.workspace_root,
+        config=config,
+        scope=scope,
+        docs=snapshot.documents,
+        load_issues=None,
+        old_id=old_id,
+        new_id=target_id,
+        mode="apply",
+        # Git clean-state was already enforced by ``_preflight`` before
+        # we acquired ``workspace_lock()``. Re-checking here would
+        # false-positive because ``.ontos.lock`` is now an untracked file.
+        check_git=False,
+    )
+    if error is not None:
+        raise _rename_error_to_user_exc(error)
+    assert rename_plan is not None
+
+    # No-op rename: report success without touching files or acquiring any
+    # further write-side state.
+    if rename_plan.no_op:
         doc = snapshot.documents.get(old_id)
-        if doc is None:
-            raise OntosUserError(
-                f"Document not found: {old_id}",
-                code="E_DOCUMENT_NOT_FOUND",
-            )
-        rel = _rel_to_workspace(plan.workspace_root, Path(doc.filepath))
+        rel = (
+            _rel_to_workspace(plan.workspace_root, Path(doc.filepath))
+            if doc is not None
+            else ""
+        )
         return {
             "success": True,
             "old_id": old_id,
@@ -401,57 +464,12 @@ def _rename_document_impl(
             "updated_files": [],
         }
 
-    if not _ID_PATTERN.match(target_id):
-        raise OntosUserError(
-            "new_id must match ^[A-Za-z0-9](?:[A-Za-z0-9_.-]*[A-Za-z0-9])?$",
-            code="E_INVALID_ID",
-        )
-    if target_id.lower() in _RESERVED_YAML_WORDS:
-        raise OntosUserError(
-            "new_id cannot be a YAML reserved word: "
-            + ", ".join(sorted(_RESERVED_YAML_WORDS)),
-            code="E_INVALID_ID",
-        )
-
-    # Workspace-scoped lookup: the MCP tool operates on the live snapshot
-    # rather than re-invoking the CLI's scope resolver. This avoids the
-    # find_project_root/cwd dependency that _prepare_plan carries.
-    snapshot = cache.get_fresh_snapshot()
-    documents = snapshot.documents
-
-    if old_id not in documents:
-        raise OntosUserError(
-            f"Document not found: {old_id}",
-            code="E_DOCUMENT_NOT_FOUND",
-        )
-
-    if target_id in documents:
-        raise OntosUserError(
-            f"new_id already exists: {target_id}",
-            code="E_DUPLICATE_ID",
-        )
-
-    target_doc = documents[old_id]
+    target_doc = snapshot.documents[old_id]
     target_rel = _rel_to_workspace(plan.workspace_root, Path(target_doc.filepath))
 
-    # Build per-file edit plans. ``_build_file_plan`` is pure (path + ids)
-    # and returns None for files that need no edits — perfect for reuse.
-    file_plans: List[FilePlan] = []
-    for doc in sorted(documents.values(), key=lambda item: str(item.filepath)):
-        file_plan = _build_file_plan(
-            path=Path(doc.filepath),
-            old_id=old_id,
-            new_id=target_id,
-        )
-        if file_plan is None:
-            continue
-        file_plans.append(file_plan)
-
-    # Fail if any file plan raised a blocking warning (unsupported
-    # frontmatter format). This mirrors the CLI's blocking_warnings gate.
-    blocking = []
-    for fp in file_plans:
-        blocking.extend(w for w in fp.warnings if w.blocking)
+    # Blocking-warning gate (unsupported frontmatter formats). Mirrors the
+    # CLI's ``plan.blocking_warnings()`` check.
+    blocking = rename_plan.blocking_warnings()
     if blocking:
         first = blocking[0]
         raise OntosUserError(
@@ -460,11 +478,9 @@ def _rename_document_impl(
             code="E_UNSUPPORTED_TARGET_FORMAT",
         )
 
-    files_to_apply = [fp for fp in file_plans if fp.has_changes]
+    files_to_apply = [fp for fp in rename_plan.files if fp.has_changes]
     if not files_to_apply:
-        # Target exists but no references anywhere — still a valid rename
-        # even though we shouldn't reach here (target_doc has its own
-        # `id:` field which must change). Treat as a no-op.
+        # Target exists but no references anywhere — treat as a no-op.
         return {
             "success": True,
             "old_id": old_id,

--- a/ontos/mcp/schemas.py
+++ b/ontos/mcp/schemas.py
@@ -292,6 +292,9 @@ TOOL_SUCCESS_MODELS: Dict[str, Type[BaseModel]] = {
     "project_registry": ProjectRegistryResponse,
     "search": SearchResponse,
     "get_context_bundle": GetContextBundleResponse,
+    "scaffold_document": ScaffoldDocumentResponse,
+    "log_session": LogSessionResponse,
+    "promote_document": PromoteDocumentResponse,
 }
 
 TOOL_OUTPUT_SCHEMAS: Dict[str, Dict[str, Any]] = {

--- a/ontos/mcp/schemas.py
+++ b/ontos/mcp/schemas.py
@@ -295,6 +295,7 @@ TOOL_SUCCESS_MODELS: Dict[str, Type[BaseModel]] = {
     "scaffold_document": ScaffoldDocumentResponse,
     "log_session": LogSessionResponse,
     "promote_document": PromoteDocumentResponse,
+    "rename_document": RenameDocumentResponse,
 }
 
 TOOL_OUTPUT_SCHEMAS: Dict[str, Dict[str, Any]] = {

--- a/ontos/mcp/server.py
+++ b/ontos/mcp/server.py
@@ -86,7 +86,6 @@ def serve(
     read_only: bool = False,
 ) -> int:
     """Build cache/index state and start the stdio MCP runtime."""
-    _ = read_only
     workspace_root = workspace_root.resolve()
     cache = _build_cache(workspace_root)
 
@@ -117,7 +116,6 @@ def create_server(
     include_bundle_tool: bool = False,
 ) -> FastMCP:
     """Create and register the Ontos MCP server."""
-    _ = read_only
     workspace_name = cache.workspace_root.name
     portfolio_mode = portfolio_index is not None
 
@@ -125,6 +123,7 @@ def create_server(
     setattr(cache, "portfolio_mode", portfolio_mode)
     setattr(cache, "portfolio_index", portfolio_index)
     setattr(cache, "primary_workspace_slug", _workspace_slug(cache.workspace_root))
+    setattr(cache, "read_only", read_only)
 
     server = OntosFastMCP(
         name="Ontos",
@@ -158,6 +157,14 @@ def create_server(
     _register_core_tools(
         cache=cache,
         workspace_name=workspace_name,
+        register_fn=register,
+    )
+
+    _register_write_tools(
+        cache=cache,
+        workspace_name=workspace_name,
+        portfolio_index=portfolio_index,
+        read_only=read_only,
         register_fn=register,
     )
 
@@ -360,6 +367,153 @@ def _register_core_tools(
         ),
         meta={"anthropic/maxResultSizeChars": 4000},
     )
+
+
+def _register_write_tools(
+    *,
+    cache: SnapshotCache,
+    workspace_name: str,
+    portfolio_index: Any,
+    read_only: bool,
+    register_fn: Callable[..., None],
+) -> None:
+    """Register the v4.1 Track B single-file write tools (Dev 2)."""
+    from ontos.mcp import writes as write_impl
+
+    def handle_scaffold_document(
+        path: str,
+        content: str = "",
+        workspace_id: Optional[str] = None,
+    ) -> CallToolResult:
+        return _invoke_write_tool(
+            "scaffold_document",
+            cache,
+            write_impl.scaffold_document,
+            portfolio_index=portfolio_index,
+            read_only=read_only,
+            path=path,
+            content=content,
+            workspace_id=workspace_id,
+        )
+
+    def handle_log_session(
+        title: str,
+        event_type: str = "chore",
+        source: str = "mcp",
+        branch: str = "unknown",
+        body: str = "",
+        workspace_id: Optional[str] = None,
+    ) -> CallToolResult:
+        return _invoke_write_tool(
+            "log_session",
+            cache,
+            write_impl.log_session,
+            portfolio_index=portfolio_index,
+            read_only=read_only,
+            title=title,
+            event_type=event_type,
+            source=source,
+            branch=branch,
+            body=body,
+            workspace_id=workspace_id,
+        )
+
+    def handle_promote_document(
+        document_id: str,
+        new_level: int,
+        workspace_id: Optional[str] = None,
+    ) -> CallToolResult:
+        return _invoke_write_tool(
+            "promote_document",
+            cache,
+            write_impl.promote_document,
+            portfolio_index=portfolio_index,
+            read_only=read_only,
+            document_id=document_id,
+            new_level=new_level,
+            workspace_id=workspace_id,
+        )
+
+    write_annotations = ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=False,
+        idempotentHint=False,
+        openWorldHint=False,
+    )
+
+    register_fn(
+        name="scaffold_document",
+        title="Scaffold Document",
+        description=(
+            f"Creates a new scaffolded Markdown document in the {workspace_name} "
+            "workspace."
+        ),
+        handler=handle_scaffold_document,
+        annotations=write_annotations,
+        meta={"anthropic/maxResultSizeChars": 4000},
+    )
+    register_fn(
+        name="log_session",
+        title="Log Session",
+        description=(
+            f"Creates a dated session log under logs_dir in the {workspace_name} "
+            "workspace."
+        ),
+        handler=handle_log_session,
+        annotations=write_annotations,
+        meta={"anthropic/maxResultSizeChars": 4000},
+    )
+    register_fn(
+        name="promote_document",
+        title="Promote Document",
+        description=(
+            f"Updates a document's curation_level frontmatter in the "
+            f"{workspace_name} workspace."
+        ),
+        handler=handle_promote_document,
+        annotations=write_annotations,
+        meta={"anthropic/maxResultSizeChars": 4000},
+    )
+
+
+def _invoke_write_tool(
+    tool_name: str,
+    cache: SnapshotCache,
+    tool_fn: Callable[..., CallToolResult],
+    *,
+    portfolio_index: Any,
+    read_only: bool,
+    **kwargs: Any,
+) -> CallToolResult:
+    """Shared write-tool invoker.
+
+    Write tool implementations own their own locking (workspace_lock + A3
+    rebuild path), schema validation, and error envelope construction. This
+    wrapper records usage telemetry, guards against unexpected exceptions
+    above the tool body, and surfaces them as structured MCP errors.
+    """
+    try:
+        _log_usage(cache, tool_name)
+    except Exception:
+        traceback.print_exc(file=sys.stderr)
+
+    try:
+        return tool_fn(
+            cache,
+            portfolio_index=portfolio_index,
+            read_only=read_only,
+            **kwargs,
+        )
+    except OntosUserError as exc:
+        return _tool_error_result(str(exc))
+    except OntosInternalError as exc:
+        print(f"[ontos-mcp] {exc.code}: {exc}", file=sys.stderr)
+        if exc.details:
+            print(exc.details, file=sys.stderr)
+        return _tool_error_result(f"Internal error: {exc}")
+    except Exception:
+        traceback.print_exc(file=sys.stderr)
+        return _tool_error_result(f"Internal error in {tool_name}")
 
 
 def _register_portfolio_tools(

--- a/ontos/mcp/server.py
+++ b/ontos/mcp/server.py
@@ -377,8 +377,10 @@ def _register_write_tools(
     read_only: bool,
     register_fn: Callable[..., None],
 ) -> None:
-    """Register the v4.1 Track B single-file write tools (Dev 2)."""
+    """Register the v4.1 Track B single-file write tools (Dev 2) and the
+    multi-file ``rename_document`` tool (Dev 3)."""
     from ontos.mcp import writes as write_impl
+    from ontos.mcp import rename_tool as rename_impl
 
     def handle_scaffold_document(
         path: str,
@@ -434,6 +436,22 @@ def _register_write_tools(
             workspace_id=workspace_id,
         )
 
+    def handle_rename_document(
+        document_id: str,
+        new_id: str,
+        workspace_id: Optional[str] = None,
+    ) -> CallToolResult:
+        return _invoke_write_tool(
+            "rename_document",
+            cache,
+            rename_impl.rename_document,
+            portfolio_index=portfolio_index,
+            read_only=read_only,
+            document_id=document_id,
+            new_id=new_id,
+            workspace_id=workspace_id,
+        )
+
     write_annotations = ToolAnnotations(
         readOnlyHint=False,
         destructiveHint=False,
@@ -473,6 +491,19 @@ def _register_write_tools(
         handler=handle_promote_document,
         annotations=write_annotations,
         meta={"anthropic/maxResultSizeChars": 4000},
+    )
+    register_fn(
+        name="rename_document",
+        title="Rename Document",
+        description=(
+            f"Renames a document ID in the {workspace_name} workspace and "
+            "rewrites every referencing file. Requires a clean git working "
+            "tree; on commit failure the workspace is rolled back via "
+            "`git checkout -- .`."
+        ),
+        handler=handle_rename_document,
+        annotations=write_annotations,
+        meta={"anthropic/maxResultSizeChars": 8000},
     )
 
 

--- a/ontos/mcp/tools.py
+++ b/ontos/mcp/tools.py
@@ -492,22 +492,14 @@ def _parse_project_tags(raw: Any) -> list[str]:
 
 
 def _validate_workspace_id(portfolio_index: Any, workspace_id: str) -> None:
-    """Validate workspace_id exists in portfolio. Raise OntosUserError if not."""
-    if portfolio_index is None:
-        raise OntosUserError(
-            "workspace_id requires portfolio mode.",
-            code="E_PORTFOLIO_REQUIRED",
-        )
-    projects = portfolio_index.get_projects()
-    slugs = [project["slug"] for project in projects]
-    if workspace_id not in slugs:
-        sorted_slugs = ", ".join(sorted(slugs))
-        raise OntosUserError(
-            f"Unknown workspace '{workspace_id}'. "
-            f"Valid workspace slugs: {sorted_slugs}. "
-            "Use project_registry() to discover available workspaces.",
-            code="E_UNKNOWN_WORKSPACE",
-        )
+    """Validate workspace_id exists in portfolio. Raise OntosUserError if not.
+
+    Delegates to the shared helper in ``ontos.mcp._validation`` so the read
+    and write paths use a single implementation (closes m-8 / m-14).
+    """
+    from ontos.mcp._validation import validate_workspace_id as _shared
+
+    _shared(portfolio_index, workspace_id)
 
 
 def _enforce_workspace_scope(cache: Any, workspace_id: Optional[str]) -> None:

--- a/ontos/mcp/writes.py
+++ b/ontos/mcp/writes.py
@@ -1,0 +1,561 @@
+"""Single-file MCP write tools for Ontos v4.1 Track B (Dev 2).
+
+This module implements the three MCP write tools whose mutation surface is
+a single markdown file:
+
+* ``scaffold_document`` — create a new ``.md`` in the target workspace.
+* ``log_session`` — create ``{logs_dir}/{date}_{slug}.md``.
+* ``promote_document`` — mutate document frontmatter only (no rename,
+  no move).
+
+Cross-cutting behavior (addendum v1.2):
+
+* **A1 single-lock discipline.** All three tools wrap the entire mutation
+  (``buffer_write`` + ``commit`` + ``rebuild_workspace``) inside
+  ``workspace_lock()``. The inner ``SessionContext`` is constructed with
+  ``owns_lock=False`` so it does not re-acquire the flock.
+* **A2 slugifier binding.** Workspace identity slugs use
+  ``ontos.mcp.scanner.slugify``; titles that become filename components
+  use ``ontos.commands.log._slugify``. No third slugifier is introduced.
+* **A3 post-commit-failure rebuild.** If ``ctx.commit()`` raises, the DB
+  may be out of sync with the filesystem. The exception path re-invokes
+  ``rebuild_workspace(slug, root)`` on a best-effort basis. Rebuild
+  errors are recorded but never mask the original exception.
+* **read_only enforcement.** Every write tool checks the server-level
+  ``read_only`` flag and returns a structured
+  ``WriteToolErrorEnvelope`` when mutations are disallowed. This closes
+  m-2 (``_ = read_only``).
+* **workspace_id validation.** Routed through
+  ``ontos.mcp._validation.validate_workspace_id`` (closes m-8 / m-14).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+import sys
+import traceback
+from typing import Any, Callable, Dict, List, Optional
+
+from mcp.types import CallToolResult, TextContent
+
+from ontos.commands.log import _slugify as slugify_title
+from ontos.core.context import SessionContext
+from ontos.core.curation import create_scaffold
+from ontos.core.errors import OntosInternalError, OntosUserError
+from ontos.core.schema import serialize_frontmatter
+from ontos.io.yaml import parse_frontmatter_content
+from ontos.mcp._validation import validate_workspace_id
+from ontos.mcp.cache import SnapshotCache
+from ontos.mcp.locking import workspace_lock
+from ontos.mcp.scanner import slugify as slugify_workspace_identity
+from ontos.mcp.schemas import (
+    ToolErrorTextItem,
+    WriteToolError,
+    WriteToolErrorEnvelope,
+    validate_success_payload,
+)
+
+
+# ---------------------------------------------------------------------------
+# Envelope + result helpers.
+# ---------------------------------------------------------------------------
+
+
+def _success_result(tool_name: str, payload: Dict[str, Any]) -> CallToolResult:
+    """Validate ``payload`` against the tool schema and wrap it for MCP."""
+    import json
+
+    validated = validate_success_payload(tool_name, payload)
+    return CallToolResult(
+        isError=False,
+        structuredContent=validated,
+        content=[
+            TextContent(
+                type="text",
+                text=json.dumps(validated, ensure_ascii=True),
+            )
+        ],
+    )
+
+
+def _write_error_result(
+    *,
+    error_code: str,
+    what: str,
+    why: str,
+    fix: str,
+) -> CallToolResult:
+    """Produce a ``WriteToolErrorEnvelope`` shaped ``CallToolResult``."""
+    envelope = WriteToolErrorEnvelope(
+        isError=True,
+        error=WriteToolError(
+            error_code=error_code,
+            what=what,
+            why=why,
+            fix=fix,
+        ),
+        content=[ToolErrorTextItem(type="text", text=what)],
+    ).model_dump(mode="json", by_alias=True)
+    return CallToolResult(
+        isError=True,
+        structuredContent=envelope,
+        content=[TextContent(type="text", text=what)],
+    )
+
+
+def _user_error_result(exc: OntosUserError) -> CallToolResult:
+    """Convert an ``OntosUserError`` into a ``WriteToolErrorEnvelope``."""
+    return _write_error_result(
+        error_code=getattr(exc, "code", "E_USER_ERROR") or "E_USER_ERROR",
+        what=str(exc),
+        why=str(exc),
+        fix="See error message for remediation guidance.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shared preflight.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Preflight:
+    slug: str
+    workspace_root: Path
+
+
+def _preflight(
+    cache: SnapshotCache,
+    portfolio_index: Any,
+    workspace_id: Optional[str],
+    read_only: bool,
+) -> _Preflight:
+    """Run read_only + workspace_id checks and resolve the target workspace."""
+    if read_only:
+        raise OntosUserError(
+            "Write tools are disabled because the MCP server is running in "
+            "read-only mode. Restart without --read-only to enable writes.",
+            code="E_READ_ONLY",
+        )
+
+    validate_workspace_id(portfolio_index, workspace_id)
+
+    workspace_root = cache.workspace_root
+    slug = slugify_workspace_identity(workspace_root.name)
+    if workspace_id is not None and workspace_id != slug:
+        # Write tools mutate the workspace served by this MCP process.
+        # Cross-workspace writes are not supported — addendum keeps the
+        # behavior symmetric with the read-tool guard at server.py.
+        raise OntosUserError(
+            "Cross-workspace writes are not supported. "
+            "Start a separate `ontos serve` in the target workspace.",
+            code="E_CROSS_WORKSPACE_NOT_SUPPORTED",
+        )
+
+    return _Preflight(slug=slug, workspace_root=workspace_root)
+
+
+def _rebuild_safely(
+    portfolio_index: Any,
+    slug: str,
+    workspace_root: Path,
+) -> None:
+    """Best-effort rebuild. Logs and swallows failures."""
+    if portfolio_index is None:
+        return
+    try:
+        portfolio_index.rebuild_workspace(slug, workspace_root)
+    except Exception:
+        traceback.print_exc(file=sys.stderr)
+
+
+def _commit_with_a3_recovery(
+    ctx: SessionContext,
+    portfolio_index: Any,
+    slug: str,
+    workspace_root: Path,
+) -> List[Path]:
+    """Commit the session. On failure, run the A3 rebuild-on-error path.
+
+    The A3 rebuild is swallowed so it cannot mask the original commit
+    exception. See addendum v1.2 §A3.
+    """
+    try:
+        return ctx.commit()
+    except Exception:
+        _rebuild_safely(portfolio_index, slug, workspace_root)
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Tool entry points.
+# ---------------------------------------------------------------------------
+
+
+def scaffold_document(
+    cache: SnapshotCache,
+    *,
+    portfolio_index: Any = None,
+    read_only: bool = False,
+    path: str,
+    content: str = "",
+    workspace_id: Optional[str] = None,
+) -> CallToolResult:
+    """Create a new ``.md`` file with a Level-0 scaffold frontmatter."""
+    return _dispatch(
+        "scaffold_document",
+        _scaffold_document_impl,
+        cache=cache,
+        portfolio_index=portfolio_index,
+        read_only=read_only,
+        workspace_id=workspace_id,
+        path=path,
+        content=content,
+    )
+
+
+def log_session(
+    cache: SnapshotCache,
+    *,
+    portfolio_index: Any = None,
+    read_only: bool = False,
+    title: str,
+    event_type: str = "chore",
+    source: str = "mcp",
+    branch: str = "unknown",
+    body: str = "",
+    workspace_id: Optional[str] = None,
+) -> CallToolResult:
+    """Create a session log at ``{logs_dir}/{date}_{slug}.md``."""
+    return _dispatch(
+        "log_session",
+        _log_session_impl,
+        cache=cache,
+        portfolio_index=portfolio_index,
+        read_only=read_only,
+        workspace_id=workspace_id,
+        title=title,
+        event_type=event_type,
+        source=source,
+        branch=branch,
+        body=body,
+    )
+
+
+def promote_document(
+    cache: SnapshotCache,
+    *,
+    portfolio_index: Any = None,
+    read_only: bool = False,
+    document_id: str,
+    new_level: int,
+    workspace_id: Optional[str] = None,
+) -> CallToolResult:
+    """Mutate frontmatter to change ``curation_level`` (no rename/move)."""
+    return _dispatch(
+        "promote_document",
+        _promote_document_impl,
+        cache=cache,
+        portfolio_index=portfolio_index,
+        read_only=read_only,
+        workspace_id=workspace_id,
+        document_id=document_id,
+        new_level=new_level,
+    )
+
+
+def _dispatch(
+    tool_name: str,
+    impl: Callable[..., Dict[str, Any]],
+    *,
+    cache: SnapshotCache,
+    portfolio_index: Any,
+    read_only: bool,
+    workspace_id: Optional[str],
+    **kwargs: Any,
+) -> CallToolResult:
+    # Preflight runs outside the workspace lock — no file state is
+    # mutated yet, and read_only / workspace_id errors should not pay
+    # the lock acquisition cost.
+    try:
+        plan = _preflight(cache, portfolio_index, workspace_id, read_only)
+    except OntosUserError as exc:
+        return _user_error_result(exc)
+
+    # NOTE on exception flow:
+    # OntosUserError / OntosInternalError are frozen dataclasses, which on
+    # Python 3.14+ can't have ``__traceback__`` reassigned by the stdlib
+    # contextlib machinery. Catching them INSIDE the lock prevents
+    # ``workspace_lock()`` from re-raising and tripping that assignment.
+    # See https://github.com/python/cpython (contextmanager __exit__).
+    result: Optional[CallToolResult] = None
+    try:
+        with workspace_lock(plan.workspace_root):
+            try:
+                payload = impl(
+                    cache=cache,
+                    portfolio_index=portfolio_index,
+                    plan=plan,
+                    **kwargs,
+                )
+                result = _success_result(tool_name, payload)
+            except OntosUserError as exc:
+                result = _user_error_result(exc)
+            except OntosInternalError as exc:
+                print(f"[ontos-mcp] {exc.code}: {exc}", file=sys.stderr)
+                if exc.details:
+                    print(exc.details, file=sys.stderr)
+                result = _write_error_result(
+                    error_code=exc.code or "E_INTERNAL",
+                    what=f"Internal error: {exc}",
+                    why="The server encountered an unexpected error.",
+                    fix="Check server logs and retry.",
+                )
+            except Exception as exc:
+                traceback.print_exc(file=sys.stderr)
+                result = _write_error_result(
+                    error_code="E_INTERNAL",
+                    what=f"Internal error in {tool_name}: {exc}",
+                    why="Unexpected exception while executing the write tool.",
+                    fix="Check server logs and retry.",
+                )
+    except OntosUserError as exc:
+        # Raised by workspace_lock itself (E_WORKSPACE_BUSY) when the
+        # flock timeout is exceeded.
+        return _user_error_result(exc)
+
+    assert result is not None  # for type-checkers
+    return result
+
+
+# ---------------------------------------------------------------------------
+# scaffold_document implementation.
+# ---------------------------------------------------------------------------
+
+
+def _scaffold_document_impl(
+    *,
+    cache: SnapshotCache,
+    portfolio_index: Any,
+    plan: _Preflight,
+    path: str,
+    content: str,
+) -> Dict[str, Any]:
+    if not path or not str(path).strip():
+        raise OntosUserError(
+            "path must be non-empty.",
+            code="E_INVALID_PATH",
+        )
+
+    resolved = _resolve_inside_workspace(plan.workspace_root, path)
+    if resolved.suffix != ".md":
+        raise OntosUserError(
+            "scaffold_document only accepts .md targets.",
+            code="E_INVALID_PATH",
+        )
+    if resolved.exists():
+        raise OntosUserError(
+            f"File already exists: {resolved.relative_to(plan.workspace_root).as_posix()}",
+            code="E_FILE_EXISTS",
+        )
+
+    # Assemble scaffold frontmatter. ``create_scaffold`` handles ID/type
+    # inference from path + body content.
+    frontmatter = create_scaffold(resolved, content=content)
+    body = content if content else f"# {frontmatter['id']}\n\nTODO: expand this scaffold.\n"
+    document = f"---\n{serialize_frontmatter(frontmatter)}\n---\n\n{body}"
+    if not document.endswith("\n"):
+        document += "\n"
+
+    ctx = SessionContext(
+        repo_root=plan.workspace_root,
+        config={},
+        owns_lock=False,
+    )
+    ctx.buffer_write(resolved, document)
+    _commit_with_a3_recovery(
+        ctx, portfolio_index, plan.slug, plan.workspace_root
+    )
+    _rebuild_safely(portfolio_index, plan.slug, plan.workspace_root)
+
+    return {
+        "success": True,
+        "path": resolved.relative_to(plan.workspace_root).as_posix(),
+        "id": str(frontmatter["id"]),
+        "type": str(frontmatter["type"]),
+        "status": str(frontmatter["status"]),
+        "curation_level": f"L{int(frontmatter['curation_level'])}",
+    }
+
+
+# ---------------------------------------------------------------------------
+# log_session implementation.
+# ---------------------------------------------------------------------------
+
+
+def _log_session_impl(
+    *,
+    cache: SnapshotCache,
+    portfolio_index: Any,
+    plan: _Preflight,
+    title: str,
+    event_type: str,
+    source: str,
+    branch: str,
+    body: str,
+) -> Dict[str, Any]:
+    if not title or not str(title).strip():
+        raise OntosUserError(
+            "title must be non-empty.",
+            code="E_INVALID_TITLE",
+        )
+
+    title_slug = slugify_title(str(title))  # addendum A2 — title slugifier
+    date_str = datetime.now().strftime("%Y-%m-%d")
+    logs_dir_raw = cache.config.paths.logs_dir or "docs/logs"
+    logs_dir = Path(logs_dir_raw)
+    if not logs_dir.is_absolute():
+        logs_dir = plan.workspace_root / logs_dir
+
+    filename = f"{date_str}_{title_slug}.md"
+    target = (logs_dir / filename).resolve(strict=False)
+    if not target.is_relative_to(plan.workspace_root.resolve()):
+        raise OntosUserError(
+            "Resolved log path escapes the workspace root.",
+            code="E_PATH_OUTSIDE_WORKSPACE",
+        )
+    if target.exists():
+        raise OntosUserError(
+            f"Log already exists: {target.relative_to(plan.workspace_root).as_posix()}",
+            code="E_FILE_EXISTS",
+        )
+
+    log_id = f"log_{date_str.replace('-', '')}_{title_slug}"
+    frontmatter = {
+        "id": log_id,
+        "type": "log",
+        "status": "active",
+        "event_type": event_type,
+        "source": source,
+        "branch": branch,
+        "created": date_str,
+    }
+    heading = str(title).strip()
+    document = (
+        f"---\n{serialize_frontmatter(frontmatter)}\n---\n\n"
+        f"# {heading}\n\n"
+    )
+    if body.strip():
+        document += f"{body.rstrip()}\n"
+
+    ctx = SessionContext(
+        repo_root=plan.workspace_root,
+        config={},
+        owns_lock=False,
+    )
+    ctx.buffer_write(target, document)
+    _commit_with_a3_recovery(
+        ctx, portfolio_index, plan.slug, plan.workspace_root
+    )
+    _rebuild_safely(portfolio_index, plan.slug, plan.workspace_root)
+
+    return {
+        "success": True,
+        "path": target.relative_to(plan.workspace_root).as_posix(),
+        "id": log_id,
+        "date": date_str,
+    }
+
+
+# ---------------------------------------------------------------------------
+# promote_document implementation.
+# ---------------------------------------------------------------------------
+
+
+def _promote_document_impl(
+    *,
+    cache: SnapshotCache,
+    portfolio_index: Any,
+    plan: _Preflight,
+    document_id: str,
+    new_level: int,
+) -> Dict[str, Any]:
+    if not document_id or not str(document_id).strip():
+        raise OntosUserError(
+            "document_id must be non-empty.",
+            code="E_INVALID_DOCUMENT_ID",
+        )
+    if new_level not in (0, 1, 2):
+        raise OntosUserError(
+            "new_level must be 0, 1, or 2.",
+            code="E_INVALID_LEVEL",
+        )
+
+    snapshot = cache.get_fresh_snapshot()
+    doc = snapshot.documents.get(document_id)
+    if doc is None:
+        raise OntosUserError(
+            f"Document not found: {document_id}",
+            code="E_DOCUMENT_NOT_FOUND",
+        )
+
+    target = Path(doc.filepath)
+    original = target.read_text(encoding="utf-8")
+    frontmatter, body = parse_frontmatter_content(original)
+    if not frontmatter:
+        raise OntosUserError(
+            f"Document {document_id} has no frontmatter to mutate.",
+            code="E_MISSING_FRONTMATTER",
+        )
+
+    old_level_raw = frontmatter.get("curation_level", 0)
+    try:
+        old_level = int(old_level_raw)
+    except (TypeError, ValueError):
+        old_level = 0
+
+    frontmatter["curation_level"] = int(new_level)
+    document = f"---\n{serialize_frontmatter(frontmatter)}\n---\n\n{body}"
+    if not document.endswith("\n"):
+        document += "\n"
+
+    ctx = SessionContext(
+        repo_root=plan.workspace_root,
+        config={},
+        owns_lock=False,
+    )
+    ctx.buffer_write(target, document)
+    _commit_with_a3_recovery(
+        ctx, portfolio_index, plan.slug, plan.workspace_root
+    )
+    _rebuild_safely(portfolio_index, plan.slug, plan.workspace_root)
+
+    return {
+        "success": True,
+        "document_id": document_id,
+        "old_level": f"L{old_level}",
+        "new_level": f"L{int(new_level)}",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Utilities.
+# ---------------------------------------------------------------------------
+
+
+def _resolve_inside_workspace(workspace_root: Path, raw_path: str) -> Path:
+    candidate = Path(raw_path)
+    if str(raw_path).startswith("~"):
+        candidate = candidate.expanduser()
+    if not candidate.is_absolute():
+        candidate = workspace_root / candidate
+    resolved = candidate.resolve(strict=False)
+    ws_resolved = workspace_root.resolve()
+    if not resolved.is_relative_to(ws_resolved):
+        raise OntosUserError(
+            "Path must resolve inside the workspace root.",
+            code="E_PATH_OUTSIDE_WORKSPACE",
+        )
+    return resolved

--- a/tests/commands/test_rename.py
+++ b/tests/commands/test_rename.py
@@ -521,3 +521,95 @@ def test_rename_quiet_mode_suppresses_per_file_details(tmp_path: Path):
     assert result.returncode == 0
     assert "Summary" in result.stdout
     assert "File:" not in result.stdout
+
+
+def test_build_rename_plan_equivalence_cli_vs_injected_docs(tmp_path: Path):
+    """Regression guard: the CLI path (``_prepare_plan``) and a direct call
+    to ``build_rename_plan`` with the SAME docs dict must produce identical
+    ``RenamePlan`` output.
+
+    This locks in the shared-orchestrator contract — if a future change
+    CWD-drifts one path but not the other, this test fails before the
+    CB-6-style divergence ships.
+    """
+    import os
+
+    from ontos.commands.rename import (
+        RenameOptions,
+        _prepare_plan,
+        build_rename_plan,
+    )
+
+    # Build a small workspace with three docs and one body reference.
+    _init_repo(tmp_path)
+    _write_doc(tmp_path / "docs" / "target.md", "old_id", doc_type="strategy")
+    _write_doc(
+        tmp_path / "docs" / "source.md",
+        "source_doc",
+        doc_type="atom",
+        depends_on="[old_id]",
+        body="See old_id inline.",
+    )
+    _write_doc(
+        tmp_path / "docs" / "other.md",
+        "unrelated_doc",
+        doc_type="atom",
+        body="Plain body.",
+    )
+
+    # Run the CLI path — _prepare_plan walks find_project_root, so we have
+    # to chdir into the workspace.
+    prev_cwd = Path.cwd()
+    os.chdir(tmp_path)
+    try:
+        prepared, error = _prepare_plan(
+            RenameOptions(old_id="old_id", new_id="new_id"),
+            mode="dry_run",
+        )
+    finally:
+        os.chdir(prev_cwd)
+
+    assert error is None
+    assert prepared is not None
+    cli_plan = prepared.plan
+
+    # Call build_rename_plan directly with the same docs the CLI loaded.
+    scope_data = prepared.scope_data
+    injected_plan, injected_error = build_rename_plan(
+        repo_root=scope_data.repo_root,
+        config=__import__(
+            "ontos.io.config", fromlist=["load_project_config"]
+        ).load_project_config(repo_root=scope_data.repo_root),
+        scope=scope_data.scope,
+        docs=scope_data.docs,
+        load_issues=scope_data.load_result.issues,
+        old_id="old_id",
+        new_id="new_id",
+        mode="dry_run",
+    )
+    assert injected_error is None
+    assert injected_plan is not None
+
+    # Same file plans, sorted by path.
+    cli_paths = [str(fp.path) for fp in cli_plan.files]
+    inj_paths = [str(fp.path) for fp in injected_plan.files]
+    assert cli_paths == inj_paths
+
+    # Edit-level equality — frontmatter + body rewrites must match exactly.
+    for cli_fp, inj_fp in zip(cli_plan.files, injected_plan.files):
+        assert cli_fp.new_content == inj_fp.new_content
+        assert cli_fp.frontmatter_edits == inj_fp.frontmatter_edits
+        assert cli_fp.body_edits == inj_fp.body_edits
+
+    # Summary counts (ignoring files_scanned — the CLI wrapper refreshes
+    # that with the pre-scan count, a deliberate divergence because the
+    # orchestrator can't know the scan count).
+    assert cli_plan.summary.documents_loaded == injected_plan.summary.documents_loaded
+    assert cli_plan.summary.planned_files == injected_plan.summary.planned_files
+    assert cli_plan.summary.frontmatter_edits == injected_plan.summary.frontmatter_edits
+    assert cli_plan.summary.body_edits == injected_plan.summary.body_edits
+    assert cli_plan.summary.skipped_zone_sightings == injected_plan.summary.skipped_zone_sightings
+    assert cli_plan.summary.warnings == injected_plan.summary.warnings
+
+    # Warnings list parity.
+    assert list(cli_plan.warnings) == list(injected_plan.warnings)

--- a/tests/mcp/test_refresh.py
+++ b/tests/mcp/test_refresh.py
@@ -25,10 +25,11 @@ def test_server_lists_tools_and_instructions(tmp_path):
     server = build_server(cache.workspace_root)
     tool_map = {tool.name: tool for tool in list_tools(server)}
 
-    assert len(tool_map) == 11
+    assert len(tool_map) == 12
     assert "workspace_overview" in tool_map
     assert "scaffold_document" in tool_map
     assert "log_session" in tool_map
     assert "promote_document" in tool_map
+    assert "rename_document" in tool_map
     assert "workspace_overview" in server.instructions
     assert "workspace" in tool_map["workspace_overview"].description

--- a/tests/mcp/test_refresh.py
+++ b/tests/mcp/test_refresh.py
@@ -25,7 +25,10 @@ def test_server_lists_tools_and_instructions(tmp_path):
     server = build_server(cache.workspace_root)
     tool_map = {tool.name: tool for tool in list_tools(server)}
 
-    assert len(tool_map) == 8
+    assert len(tool_map) == 11
     assert "workspace_overview" in tool_map
+    assert "scaffold_document" in tool_map
+    assert "log_session" in tool_map
+    assert "promote_document" in tool_map
     assert "workspace_overview" in server.instructions
     assert "workspace" in tool_map["workspace_overview"].description

--- a/tests/mcp/test_rename_document.py
+++ b/tests/mcp/test_rename_document.py
@@ -1,0 +1,618 @@
+"""Tests for v4.1 Track B multi-file MCP write tool ``rename_document`` (Dev 3).
+
+Covers (per Dev 3 scope in ``v4.1_TrackB_Implementation_Spec.md``):
+
+* Happy path — N-file reference rewrite with planned-vs-committed parity.
+* Git-dirty precondition refusal (addendum v1.2 §A6 matching v1.1 §4.8.2
+  Step 4) — unstaged or untracked file in the workspace blocks the rename.
+* ``read_only`` refusal (closes m-2 consumer).
+* Cross-workspace refusal via shared ``validate_workspace_id`` helper
+  (closes m-8 consumer).
+* ``workspace_lock`` contention returns structured ``E_WORKSPACE_BUSY``.
+* A3 post-commit rollback path — commit raises, working tree is reverted
+  via ``git checkout -- .``, and ``rebuild_workspace`` re-converges the
+  portfolio DB.
+* m-13 FTS5 parity recoverable rebuild — a first rebuild that raises the
+  parity-mismatch ``RuntimeError`` is retried once; if the retry succeeds
+  the tool succeeds overall.
+* A6 binding — ``buffer_write`` is the only mutation surface (no
+  ``os.rename``, no ``buffer_move``).
+
+References: v1.1 §4.8.2, addendum §A1/§A2/§A3/§A6, TrackB-Design §9.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+import time
+from multiprocessing import Event, Process, Queue
+from pathlib import Path
+from typing import Any, List
+
+import pytest
+from mcp.types import CallToolResult
+
+from tests.mcp import build_cache, build_server, create_workspace
+
+
+# ---------------------------------------------------------------------------
+# Helpers — recording portfolio index + git-init helper.
+# ---------------------------------------------------------------------------
+
+
+class RecordingPortfolioIndex:
+    def __init__(self) -> None:
+        self.rebuild_calls: List[tuple] = []
+        self.raise_on_rebuild = False
+        # When set, the first N calls raise; subsequent calls succeed.
+        self.raise_parity_times = 0
+
+    def get_projects(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "slug": "workspace",
+                "path": "/tmp/workspace",
+                "status": "documented",
+                "doc_count": 0,
+                "last_scanned": "2026-04-11T00:00:00Z",
+                "tags": [],
+                "has_ontos": 1,
+            }
+        ]
+
+    def rebuild_workspace(self, slug: str, root: Path) -> None:
+        self.rebuild_calls.append((slug, str(root)))
+        if self.raise_parity_times > 0:
+            self.raise_parity_times -= 1
+            raise RuntimeError(
+                f"FTS parity mismatch for {slug}: documents=3, fts=2"
+            )
+        if self.raise_on_rebuild:
+            raise RuntimeError("induced rebuild failure")
+
+
+def _git_init_clean(root: Path) -> None:
+    """Initialise a git repo, commit current state, return a clean tree.
+
+    Seeds ``.gitignore`` with ``.ontos.lock`` first — addendum §A5 says
+    the repo template already ignores ``.ontos.lock``, so the test
+    workspace must mirror that contract or every write tool that takes
+    the workspace lock would trip the dirty-workspace precondition.
+    """
+    (root / ".gitignore").write_text(".ontos.lock\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "init", "--initial-branch=main"],
+        cwd=str(root),
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=str(root), capture_output=True, check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=str(root), capture_output=True, check=True,
+    )
+    subprocess.run(
+        ["git", "config", "commit.gpgsign", "false"],
+        cwd=str(root), capture_output=True, check=True,
+    )
+    subprocess.run(
+        ["git", "add", "-A"], cwd=str(root), capture_output=True, check=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "init"],
+        cwd=str(root),
+        capture_output=True,
+        check=True,
+    )
+
+
+def _call(server, name: str, args: dict[str, Any]) -> CallToolResult:
+    return asyncio.run(server.call_tool(name, args))
+
+
+# ---------------------------------------------------------------------------
+# A6 verification — buffer_write is the only mutation channel.
+# ---------------------------------------------------------------------------
+
+
+def test_a6_rename_uses_buffer_write_not_filesystem_rename():
+    """Locks the A6 semantic in place: the MCP tool must mirror
+    ``rename.py:221`` and never call ``os.rename``/``buffer_move``.
+
+    This is a static guard on the module's AST — if a future refactor
+    introduces filesystem moves as real calls (not just doc-references),
+    this test fails and the author is forced to re-read §A6.
+    """
+    import ast
+    import inspect
+
+    from ontos.mcp import rename_tool
+
+    tree = ast.parse(inspect.getsource(rename_tool))
+    call_attrs = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            call_attrs.append(node.func.attr)
+
+    # buffer_write is used for every mutation.
+    assert "buffer_write" in call_attrs
+    # buffer_move is NOT called from the rename_document flow.
+    assert "buffer_move" not in call_attrs
+    # No filesystem rename calls (Path.rename, os.rename).
+    assert "rename" not in call_attrs
+
+
+# ---------------------------------------------------------------------------
+# Happy path.
+# ---------------------------------------------------------------------------
+
+
+def test_rename_document_happy_path_rewrites_frontmatter_and_body(tmp_path):
+    root = create_workspace(tmp_path)
+    _git_init_clean(root)
+    # Add a body reference to strategy_doc so we get a body-edit too.
+    extra = root / "docs" / "bridge.md"
+    extra.write_text(
+        "---\n"
+        "id: bridge_doc\n"
+        "type: atom\n"
+        "status: active\n"
+        "depends_on: [strategy_doc]\n"
+        "---\n\n"
+        "Bridge body references [strategy_doc](strategy_doc) inline.\n",
+        encoding="utf-8",
+    )
+    subprocess.run(
+        ["git", "add", "-A"], cwd=str(root), capture_output=True, check=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "bridge"],
+        cwd=str(root), capture_output=True, check=True,
+    )
+
+    server = build_server(root)
+    result = _call(
+        server,
+        "rename_document",
+        {"document_id": "strategy_doc", "new_id": "renamed_strategy"},
+    )
+
+    assert result.isError is False, result.content[0].text
+    payload = result.structuredContent
+    assert payload["success"] is True
+    assert payload["old_id"] == "strategy_doc"
+    assert payload["new_id"] == "renamed_strategy"
+    # strategy.md (id + depends_on-ers) + product.md (depends_on) +
+    # bridge.md (depends_on + body) all touched.
+    assert set(payload["updated_files"]) == {
+        "docs/strategy.md",
+        "docs/product.md",
+        "docs/bridge.md",
+    }
+    assert payload["references_updated"] >= 4
+
+    # Strategy file's own id was rewritten.
+    text = (root / "docs" / "strategy.md").read_text(encoding="utf-8")
+    assert "id: renamed_strategy" in text
+    # Dependents were rewritten.
+    product_text = (root / "docs" / "product.md").read_text(encoding="utf-8")
+    assert "renamed_strategy" in product_text
+    bridge_text = (root / "docs" / "bridge.md").read_text(encoding="utf-8")
+    assert "renamed_strategy" in bridge_text
+    # No stale occurrences survived.
+    assert "strategy_doc" not in product_text
+    assert "strategy_doc" not in text
+
+
+def test_rename_document_noop_same_id(tmp_path):
+    root = create_workspace(tmp_path)
+    _git_init_clean(root)
+
+    server = build_server(root)
+    result = _call(
+        server,
+        "rename_document",
+        {"document_id": "kernel_doc", "new_id": "kernel_doc"},
+    )
+
+    assert result.isError is False, result.content[0].text
+    payload = result.structuredContent
+    assert payload["references_updated"] == 0
+    assert payload["updated_files"] == []
+
+
+# ---------------------------------------------------------------------------
+# Validation.
+# ---------------------------------------------------------------------------
+
+
+def test_rename_document_rejects_missing_old_id(tmp_path):
+    root = create_workspace(tmp_path)
+    _git_init_clean(root)
+    server = build_server(root)
+
+    result = _call(
+        server,
+        "rename_document",
+        {"document_id": "no_such_doc", "new_id": "brand_new"},
+    )
+
+    assert result.isError is True
+    assert result.structuredContent["error"]["error_code"] == "E_DOCUMENT_NOT_FOUND"
+
+
+def test_rename_document_rejects_duplicate_new_id(tmp_path):
+    root = create_workspace(tmp_path)
+    _git_init_clean(root)
+    server = build_server(root)
+
+    result = _call(
+        server,
+        "rename_document",
+        {"document_id": "kernel_doc", "new_id": "strategy_doc"},
+    )
+
+    assert result.isError is True
+    assert result.structuredContent["error"]["error_code"] == "E_DUPLICATE_ID"
+
+
+def test_rename_document_rejects_invalid_new_id_format(tmp_path):
+    root = create_workspace(tmp_path)
+    _git_init_clean(root)
+    server = build_server(root)
+
+    # Contains illegal characters.
+    result = _call(
+        server,
+        "rename_document",
+        {"document_id": "kernel_doc", "new_id": "has spaces"},
+    )
+
+    assert result.isError is True
+    assert result.structuredContent["error"]["error_code"] == "E_INVALID_ID"
+
+
+def test_rename_document_rejects_empty_old_id(tmp_path):
+    root = create_workspace(tmp_path)
+    _git_init_clean(root)
+    server = build_server(root)
+
+    result = _call(
+        server,
+        "rename_document",
+        {"document_id": "   ", "new_id": "renamed"},
+    )
+
+    assert result.isError is True
+    assert result.structuredContent["error"]["error_code"] == "E_INVALID_DOCUMENT_ID"
+
+
+# ---------------------------------------------------------------------------
+# Git clean-state precondition (v1.1 §4.8.2 Step 4).
+# ---------------------------------------------------------------------------
+
+
+def test_rename_document_refuses_dirty_workspace(tmp_path):
+    root = create_workspace(tmp_path)
+    _git_init_clean(root)
+
+    # Dirty the tree with a modification.
+    (root / "docs" / "kernel.md").write_text(
+        (root / "docs" / "kernel.md").read_text(encoding="utf-8")
+        + "Extra appended line.\n",
+        encoding="utf-8",
+    )
+
+    server = build_server(root)
+    result = _call(
+        server,
+        "rename_document",
+        {"document_id": "strategy_doc", "new_id": "renamed_strategy"},
+    )
+
+    assert result.isError is True
+    assert result.structuredContent["error"]["error_code"] == "E_DIRTY_WORKSPACE"
+    # Nothing got mutated.
+    strategy_text = (root / "docs" / "strategy.md").read_text(encoding="utf-8")
+    assert "id: strategy_doc" in strategy_text
+
+
+def test_rename_document_refuses_untracked_files(tmp_path):
+    root = create_workspace(tmp_path)
+    _git_init_clean(root)
+    (root / "scratch.txt").write_text("untracked\n", encoding="utf-8")
+
+    server = build_server(root)
+    result = _call(
+        server,
+        "rename_document",
+        {"document_id": "strategy_doc", "new_id": "renamed_strategy"},
+    )
+
+    assert result.isError is True
+    assert result.structuredContent["error"]["error_code"] == "E_DIRTY_WORKSPACE"
+
+
+# ---------------------------------------------------------------------------
+# read_only enforcement (m-2 consumer).
+# ---------------------------------------------------------------------------
+
+
+def test_rename_document_refuses_when_read_only(tmp_path):
+    root = create_workspace(tmp_path)
+    _git_init_clean(root)
+    server = build_server(root, read_only=True)
+
+    result = _call(
+        server,
+        "rename_document",
+        {"document_id": "strategy_doc", "new_id": "renamed_strategy"},
+    )
+
+    assert result.isError is True
+    assert result.structuredContent["error"]["error_code"] == "E_READ_ONLY"
+    # Unchanged on disk.
+    text = (root / "docs" / "strategy.md").read_text(encoding="utf-8")
+    assert "id: strategy_doc" in text
+
+
+# ---------------------------------------------------------------------------
+# Shared workspace_id helper (m-8 consumer).
+# ---------------------------------------------------------------------------
+
+
+def test_rename_document_reuses_shared_workspace_id_helper():
+    """Verify the import/binding chain — the tool calls the shared helper.
+
+    Mirrors ``test_write_tools.py::test_shared_validate_workspace_id_helper_exists_and_is_reused``.
+    """
+    from ontos.mcp import _validation
+    from ontos.mcp import rename_tool
+
+    assert _validation.validate_workspace_id is rename_tool.validate_workspace_id
+
+
+def test_rename_document_rejects_cross_workspace_id(tmp_path):
+    root = create_workspace(tmp_path)
+    _git_init_clean(root)
+    server = build_server(root)
+
+    result = _call(
+        server,
+        "rename_document",
+        {
+            "document_id": "strategy_doc",
+            "new_id": "renamed_strategy",
+            "workspace_id": "someone-elses-workspace",
+        },
+    )
+
+    assert result.isError is True
+    # Same shape as writes.py — portfolio-required in non-portfolio mode.
+    assert result.structuredContent["error"]["error_code"] == "E_PORTFOLIO_REQUIRED"
+
+
+# ---------------------------------------------------------------------------
+# A1 — workspace_lock contention inside the write tool.
+# ---------------------------------------------------------------------------
+
+
+def _hold_workspace_lock(workspace: str, ready, release, result: Queue) -> None:
+    from ontos.mcp.locking import workspace_lock
+
+    try:
+        with workspace_lock(Path(workspace), timeout=5.0):
+            ready.set()
+            release.wait(timeout=30.0)
+        result.put(("ok", None))
+    except BaseException as exc:  # pragma: no cover — relay via queue
+        result.put(("error", repr(exc)))
+
+
+def test_rename_document_under_contention_returns_structured_error(tmp_path):
+    root = create_workspace(tmp_path)
+    _git_init_clean(root)
+    server = build_server(root)
+
+    ready = Event()
+    release = Event()
+    q: Queue = Queue()
+    holder = Process(
+        target=_hold_workspace_lock,
+        args=(str(root), ready, release, q),
+    )
+    holder.start()
+    try:
+        assert ready.wait(timeout=5.0), "holder never signalled ready"
+
+        start = time.monotonic()
+        result = _call(
+            server,
+            "rename_document",
+            {"document_id": "strategy_doc", "new_id": "renamed_strategy"},
+        )
+        elapsed = time.monotonic() - start
+
+        assert result.isError is True, result.content[0].text
+        assert result.structuredContent["error"]["error_code"] == "E_WORKSPACE_BUSY"
+        # Workspace-lock timeout is 5s; ensure we really waited for it.
+        assert 4.5 <= elapsed <= 15.0, f"unexpected elapsed={elapsed:.2f}s"
+
+        # No file got rewritten.
+        text = (root / "docs" / "strategy.md").read_text(encoding="utf-8")
+        assert "id: strategy_doc" in text
+    finally:
+        release.set()
+        holder.join(timeout=5.0)
+        if holder.is_alive():  # pragma: no cover
+            holder.terminate()
+            holder.join(timeout=2.0)
+
+
+# ---------------------------------------------------------------------------
+# A3 — post-commit rollback + rebuild path.
+# ---------------------------------------------------------------------------
+
+
+def test_a3_rollback_reverts_working_tree_on_commit_failure(monkeypatch, tmp_path):
+    """When commit raises, the tool must rollback via ``git checkout -- .``
+    and then re-invoke ``rebuild_workspace`` so the portfolio DB re-converges
+    with the reverted filesystem state.
+    """
+    from ontos.core.context import SessionContext
+    from ontos.mcp import rename_tool
+
+    root = create_workspace(tmp_path)
+    _git_init_clean(root)
+    cache = build_cache(root)
+    portfolio = RecordingPortfolioIndex()
+
+    # Capture the pre-rename content so we can assert rollback worked.
+    strategy_before = (root / "docs" / "strategy.md").read_text(encoding="utf-8")
+
+    def exploding_commit(self):
+        # Simulate a mid-commit IO failure AFTER buffer_write staging.
+        raise IOError("induced commit failure")
+
+    monkeypatch.setattr(SessionContext, "commit", exploding_commit)
+
+    result = rename_tool.rename_document(
+        cache,
+        portfolio_index=portfolio,
+        read_only=False,
+        document_id="strategy_doc",
+        new_id="renamed_strategy",
+    )
+
+    assert result.isError is True
+    # Original commit exception surfaces — rebuild must not mask it.
+    assert "induced commit failure" in result.content[0].text
+    # Working tree reverted — strategy.md is exactly as before the call.
+    strategy_after = (root / "docs" / "strategy.md").read_text(encoding="utf-8")
+    assert strategy_after == strategy_before
+    # Rebuild ran at least once as part of the recovery path.
+    assert len(portfolio.rebuild_calls) >= 1
+    slug, recorded_root = portfolio.rebuild_calls[0]
+    assert slug == "workspace"
+    assert Path(recorded_root) == root
+
+
+def test_a3_rollback_does_not_leak_staged_writes(monkeypatch, tmp_path):
+    """State-convergence check: after the rollback + rebuild, the filesystem
+    view matches the pre-commit state, so a subsequent rescan yields the
+    same document graph.
+    """
+    from ontos.core.context import SessionContext
+    from ontos.mcp import rename_tool
+
+    root = create_workspace(tmp_path)
+    _git_init_clean(root)
+    cache = build_cache(root)
+    portfolio = RecordingPortfolioIndex()
+
+    monkeypatch.setattr(
+        SessionContext, "commit",
+        lambda self: (_ for _ in ()).throw(IOError("induced")),
+    )
+
+    rename_tool.rename_document(
+        cache,
+        portfolio_index=portfolio,
+        read_only=False,
+        document_id="strategy_doc",
+        new_id="renamed_strategy",
+    )
+
+    # The original IDs still resolve — the rename left no trace.
+    snapshot = cache.get_fresh_snapshot()
+    assert "strategy_doc" in snapshot.documents
+    assert "renamed_strategy" not in snapshot.documents
+
+
+# ---------------------------------------------------------------------------
+# m-13 — FTS5 parity recoverable rebuild.
+# ---------------------------------------------------------------------------
+
+
+def test_m13_parity_mismatch_is_retried_once_and_succeeds(tmp_path):
+    """If rebuild_workspace raises the parity-mismatch RuntimeError once,
+    the tool retries once and succeeds (rebuild_workspace is idempotent).
+    """
+    from ontos.mcp import rename_tool
+
+    root = create_workspace(tmp_path)
+    _git_init_clean(root)
+    cache = build_cache(root)
+    portfolio = RecordingPortfolioIndex()
+    # First rebuild raises parity mismatch; the retry succeeds.
+    portfolio.raise_parity_times = 1
+
+    result = rename_tool.rename_document(
+        cache,
+        portfolio_index=portfolio,
+        read_only=False,
+        document_id="strategy_doc",
+        new_id="renamed_strategy",
+    )
+
+    assert result.isError is False, result.content[0].text
+    # Exactly two rebuild attempts (first raised, second succeeded).
+    assert len(portfolio.rebuild_calls) == 2
+
+
+def test_m13_non_parity_error_is_not_retried(tmp_path):
+    """Only parity-mismatch RuntimeError gets the retry. Other exceptions
+    are re-raised immediately to avoid masking real bugs.
+    """
+    from ontos.mcp import rename_tool
+
+    root = create_workspace(tmp_path)
+    _git_init_clean(root)
+    cache = build_cache(root)
+
+    class Index(RecordingPortfolioIndex):
+        def rebuild_workspace(self, slug, workspace_root):
+            self.rebuild_calls.append((slug, str(workspace_root)))
+            raise RuntimeError("not a parity error")
+
+    portfolio = Index()
+
+    # The rebuild is invoked in "safely" mode in the happy path — the tool
+    # still succeeds because rebuild failures are swallowed + logged.
+    result = rename_tool.rename_document(
+        cache,
+        portfolio_index=portfolio,
+        read_only=False,
+        document_id="strategy_doc",
+        new_id="renamed_strategy",
+    )
+
+    assert result.isError is False, result.content[0].text
+    # Exactly one call (no retry) — other exceptions do not trigger retry.
+    assert len(portfolio.rebuild_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Schema / response model wiring (m-15 partial).
+# ---------------------------------------------------------------------------
+
+
+def test_rename_document_response_model_registered():
+    from ontos.mcp.schemas import TOOL_SUCCESS_MODELS
+
+    assert "rename_document" in TOOL_SUCCESS_MODELS
+
+
+def test_rename_document_output_schema_exposed():
+    from ontos.mcp.schemas import output_schema_for
+
+    schema = output_schema_for("rename_document")
+    properties = set(schema["properties"].keys())
+    assert properties == {
+        "success", "old_id", "new_id", "path",
+        "references_updated", "updated_files",
+    }

--- a/tests/mcp/test_rename_document.py
+++ b/tests/mcp/test_rename_document.py
@@ -616,3 +616,96 @@ def test_rename_document_output_schema_exposed():
         "success", "old_id", "new_id", "path",
         "references_updated", "updated_files",
     }
+
+
+# ---------------------------------------------------------------------------
+# Shared-orchestrator cross-scope collision (gained in the Dev 3 follow-up).
+# ---------------------------------------------------------------------------
+
+
+def test_rename_rejects_cross_scope_collision_docs_scope(tmp_path):
+    """Seed a doc with ``id: strategy_doc`` inside ``.ontos-internal/`` and
+    attempt to rename the docs-scope ``strategy_doc`` → ``renamed_strategy``.
+    The shared orchestrator's docs-scope external-IDs check must refuse it.
+
+    This path was silently allowed before the shared-orchestrator refactor:
+    the MCP tool had its own ID validation + collision checks that never
+    consulted ``_load_external_ids``. Asserts a new regression line.
+    """
+    root = create_workspace(tmp_path)
+    # Seed .ontos-internal/ with a colliding id BEFORE git init so the
+    # baseline commit is clean.
+    internal_doc = root / ".ontos-internal" / "collision.md"
+    internal_doc.parent.mkdir(parents=True, exist_ok=True)
+    internal_doc.write_text(
+        "---\n"
+        "id: strategy_doc\n"
+        "type: atom\n"
+        "status: active\n"
+        "---\n\n"
+        "Internal body.\n",
+        encoding="utf-8",
+    )
+    _git_init_clean(root)
+
+    server = build_server(root)
+    result = _call(
+        server,
+        "rename_document",
+        {"document_id": "strategy_doc", "new_id": "renamed_strategy"},
+    )
+
+    assert result.isError is True
+    assert (
+        result.structuredContent["error"]["error_code"]
+        == "E_CROSS_SCOPE_COLLISION"
+    )
+
+
+def test_rename_library_scope_allows_ids_in_ontos_internal(tmp_path):
+    """Complement: when ``scanning.default_scope = "library"``, the snapshot
+    includes ``.ontos-internal/`` and the cross-scope check is skipped.
+
+    The rename must succeed — library scope treats internal docs as first
+    class participants rather than hidden siblings.
+    """
+    root = create_workspace(tmp_path)
+    # Flip the workspace into library scope — the [scanning] section
+    # already exists from create_workspace, so we append a key under it
+    # via string replacement rather than declaring the table twice.
+    ontos_toml = root / ".ontos.toml"
+    existing = ontos_toml.read_text(encoding="utf-8")
+    assert "[scanning]" in existing
+    ontos_toml.write_text(
+        existing.replace(
+            "[scanning]",
+            '[scanning]\ndefault_scope = "library"',
+            1,
+        ),
+        encoding="utf-8",
+    )
+    # Internal doc that does NOT collide — rename should proceed cleanly.
+    internal_doc = root / ".ontos-internal" / "neighbour.md"
+    internal_doc.parent.mkdir(parents=True, exist_ok=True)
+    internal_doc.write_text(
+        "---\n"
+        "id: internal_neighbour\n"
+        "type: atom\n"
+        "status: active\n"
+        "---\n\n"
+        "Internal body.\n",
+        encoding="utf-8",
+    )
+    _git_init_clean(root)
+
+    server = build_server(root)
+    result = _call(
+        server,
+        "rename_document",
+        {"document_id": "strategy_doc", "new_id": "renamed_strategy"},
+    )
+
+    assert result.isError is False, result.content[0].text
+    payload = result.structuredContent
+    assert payload["success"] is True
+    assert payload["new_id"] == "renamed_strategy"

--- a/tests/mcp/test_server_integration.py
+++ b/tests/mcp/test_server_integration.py
@@ -23,13 +23,15 @@ def test_server_lists_all_tools_with_correct_annotations(tmp_path):
         "scaffold_document",
         "log_session",
         "promote_document",
+        # v4.1 Track B (Dev 3) — multi-file write tool.
+        "rename_document",
     }
     assert set(tool_map.keys()) == expected_tools
     assert len(tool_map) == len(expected_tools)
 
     # export_graph, refresh, and the write tools are non-read-only
     for name in ("export_graph", "refresh", "scaffold_document",
-                 "log_session", "promote_document"):
+                 "log_session", "promote_document", "rename_document"):
         assert tool_map[name].annotations.readOnlyHint is False, (
             f"{name} must not be readOnly"
         )

--- a/tests/mcp/test_server_integration.py
+++ b/tests/mcp/test_server_integration.py
@@ -5,12 +5,11 @@ from pathlib import Path
 from tests.mcp import build_cache, build_server, create_workspace, list_tools, write_file
 
 
-def test_server_lists_all_eight_tools_with_correct_annotations(tmp_path):
+def test_server_lists_all_tools_with_correct_annotations(tmp_path):
     root = create_workspace(tmp_path)
     server = build_server(root)
     tool_map = {tool.name: tool for tool in list_tools(server)}
 
-    assert len(tool_map) == 8
     expected_tools = {
         "workspace_overview",
         "context_map",
@@ -20,15 +19,23 @@ def test_server_lists_all_eight_tools_with_correct_annotations(tmp_path):
         "query",
         "health",
         "refresh",
+        # v4.1 Track B (Dev 2) — single-file write tools.
+        "scaffold_document",
+        "log_session",
+        "promote_document",
     }
     assert set(tool_map.keys()) == expected_tools
+    assert len(tool_map) == len(expected_tools)
 
-    # export_graph and refresh must be non-read-only
-    assert tool_map["export_graph"].annotations.readOnlyHint is False
-    assert tool_map["refresh"].annotations.readOnlyHint is False
+    # export_graph, refresh, and the write tools are non-read-only
+    for name in ("export_graph", "refresh", "scaffold_document",
+                 "log_session", "promote_document"):
+        assert tool_map[name].annotations.readOnlyHint is False, (
+            f"{name} must not be readOnly"
+        )
     assert tool_map["refresh"].annotations.idempotentHint is False
 
-    # All other tools must be read-only
+    # Read-only tools
     for name in ("workspace_overview", "context_map", "get_document",
                  "list_documents", "query", "health"):
         assert tool_map[name].annotations.readOnlyHint is True, f"{name} should be readOnly"

--- a/tests/mcp/test_server_portfolio_mode.py
+++ b/tests/mcp/test_server_portfolio_mode.py
@@ -22,6 +22,7 @@ WRITE_TOOLS = {
     "scaffold_document",
     "log_session",
     "promote_document",
+    "rename_document",
 }
 
 
@@ -51,7 +52,7 @@ def test_create_server_includes_bundle_tool_in_single_workspace_mode(tmp_path):
     tool_map = {tool.name: tool for tool in list_tools(server)}
 
     assert set(tool_map) == CORE_TOOLS | WRITE_TOOLS | {"get_context_bundle"}
-    assert len(tool_map) == 12
+    assert len(tool_map) == 13
     assert tool_map["get_context_bundle"].annotations.readOnlyHint is True
     assert "workspace_id" in tool_map["get_context_bundle"].inputSchema["properties"]
     assert "token_budget" in tool_map["get_context_bundle"].inputSchema["properties"]
@@ -74,7 +75,7 @@ def test_create_server_registers_track_a_portfolio_matrix(tmp_path):
     )
 
     assert set(tool_map) == expected
-    assert len(tool_map) == 14
+    assert len(tool_map) == 15
     assert tool_map["project_registry"].annotations.readOnlyHint is True
     assert tool_map["search"].annotations.readOnlyHint is True
     assert tool_map["get_context_bundle"].annotations.readOnlyHint is True

--- a/tests/mcp/test_server_portfolio_mode.py
+++ b/tests/mcp/test_server_portfolio_mode.py
@@ -18,6 +18,12 @@ CORE_TOOLS = {
     "refresh",
 }
 
+WRITE_TOOLS = {
+    "scaffold_document",
+    "log_session",
+    "promote_document",
+}
+
 
 class FakePortfolioIndex:
     def get_projects(self):
@@ -44,8 +50,8 @@ def test_create_server_includes_bundle_tool_in_single_workspace_mode(tmp_path):
     server = build_server(root, include_bundle_tool=True)
     tool_map = {tool.name: tool for tool in list_tools(server)}
 
-    assert set(tool_map) == CORE_TOOLS | {"get_context_bundle"}
-    assert len(tool_map) == 9
+    assert set(tool_map) == CORE_TOOLS | WRITE_TOOLS | {"get_context_bundle"}
+    assert len(tool_map) == 12
     assert tool_map["get_context_bundle"].annotations.readOnlyHint is True
     assert "workspace_id" in tool_map["get_context_bundle"].inputSchema["properties"]
     assert "token_budget" in tool_map["get_context_bundle"].inputSchema["properties"]
@@ -61,10 +67,14 @@ def test_create_server_registers_track_a_portfolio_matrix(tmp_path):
     )
     tool_map = {tool.name: tool for tool in list_tools(server)}
 
-    expected = CORE_TOOLS | {"project_registry", "search", "get_context_bundle"}
+    expected = (
+        CORE_TOOLS
+        | WRITE_TOOLS
+        | {"project_registry", "search", "get_context_bundle"}
+    )
 
     assert set(tool_map) == expected
-    assert len(tool_map) == 11
+    assert len(tool_map) == 14
     assert tool_map["project_registry"].annotations.readOnlyHint is True
     assert tool_map["search"].annotations.readOnlyHint is True
     assert tool_map["get_context_bundle"].annotations.readOnlyHint is True

--- a/tests/mcp/test_write_tools.py
+++ b/tests/mcp/test_write_tools.py
@@ -1,0 +1,490 @@
+"""Tests for v4.1 Track B single-file MCP write tools (Dev 2).
+
+Covers:
+* scaffold_document — create a new markdown file with scaffold frontmatter.
+* log_session — create a dated session log under logs_dir.
+* promote_document — mutate frontmatter-only curation_level change.
+* read_only refusal (m-2 consumer).
+* workspace_id validation (m-14 consumer via shared helper).
+* Contention inside workspace_lock — a second writer process times out.
+* A3 post-commit-failure rebuild path (commit raises → rebuild_workspace
+  re-invoked, original exception not masked).
+
+References: addendum v1.2 §A1/§A2/§A3, C.0 findings Q1+Q3, verdict m-2/m-7/m-14/m-15.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from multiprocessing import Event, Process, Queue
+from pathlib import Path
+from typing import Any
+
+import pytest
+from mcp.types import CallToolResult
+
+from tests.mcp import build_cache, build_server, create_workspace, list_tools
+
+
+# ---------------------------------------------------------------------------
+# Fake portfolio index (records invocations so we can assert on A3 recovery).
+# ---------------------------------------------------------------------------
+
+
+class RecordingPortfolioIndex:
+    def __init__(self) -> None:
+        self.rebuild_calls: list[tuple[str, str]] = []
+        self.raise_on_rebuild = False
+
+    def get_projects(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "slug": "workspace",
+                "path": "/tmp/workspace",
+                "status": "documented",
+                "doc_count": 0,
+                "last_scanned": "2026-04-11T00:00:00Z",
+                "tags": [],
+                "has_ontos": 1,
+            }
+        ]
+
+    def rebuild_workspace(self, slug: str, root: Path) -> None:
+        self.rebuild_calls.append((slug, str(root)))
+        if self.raise_on_rebuild:
+            raise RuntimeError("induced rebuild failure")
+
+
+# ---------------------------------------------------------------------------
+# scaffold_document
+# ---------------------------------------------------------------------------
+
+
+def _call(server, name: str, args: dict[str, Any]) -> CallToolResult:
+    return asyncio.run(server.call_tool(name, args))
+
+
+def test_scaffold_document_creates_file_with_scaffold_frontmatter(tmp_path):
+    root = create_workspace(tmp_path)
+    server = build_server(root)
+
+    result = _call(
+        server,
+        "scaffold_document",
+        {"path": "docs/new_feature.md", "content": ""},
+    )
+
+    assert result.isError is False, result.content[0].text
+    payload = result.structuredContent
+    assert payload["success"] is True
+    assert payload["path"] == "docs/new_feature.md"
+    assert payload["curation_level"] == "L0"
+
+    created = root / "docs" / "new_feature.md"
+    assert created.exists()
+    text = created.read_text(encoding="utf-8")
+    assert text.startswith("---\n")
+    assert "status: scaffold" in text
+    assert "curation_level: 0" in text
+
+
+def test_scaffold_document_rejects_existing_path(tmp_path):
+    root = create_workspace(tmp_path)
+    server = build_server(root)
+
+    # docs/kernel.md is seeded by create_workspace — collision.
+    result = _call(
+        server,
+        "scaffold_document",
+        {"path": "docs/kernel.md"},
+    )
+
+    assert result.isError is True
+    assert "E_FILE_EXISTS" in result.structuredContent["error"]["error_code"]
+
+
+def test_scaffold_document_rejects_path_outside_workspace(tmp_path):
+    root = create_workspace(tmp_path)
+    server = build_server(root)
+
+    result = _call(
+        server,
+        "scaffold_document",
+        {"path": "../escape.md"},
+    )
+
+    assert result.isError is True
+    assert result.structuredContent["error"]["error_code"] == "E_PATH_OUTSIDE_WORKSPACE"
+
+
+# ---------------------------------------------------------------------------
+# log_session
+# ---------------------------------------------------------------------------
+
+
+def test_log_session_creates_dated_log_at_logs_dir(tmp_path):
+    root = create_workspace(tmp_path)
+    server = build_server(root)
+
+    result = _call(
+        server,
+        "log_session",
+        {
+            "title": "Refactor cache layer",
+            "event_type": "refactor",
+            "source": "mcp",
+            "branch": "feature/cache",
+            "body": "Replaced snapshot cache with SnapshotCacheView.",
+        },
+    )
+
+    assert result.isError is False, result.content[0].text
+    payload = result.structuredContent
+    assert payload["success"] is True
+    # logs_dir defaults to docs/logs per workspace config.
+    assert payload["path"].startswith("docs/logs/")
+    assert payload["path"].endswith("_refactor-cache-layer.md")
+    assert payload["id"].startswith("log_")
+
+    log_file = root / payload["path"]
+    assert log_file.exists()
+    content = log_file.read_text(encoding="utf-8")
+    assert "event_type: refactor" in content
+    assert "# Refactor cache layer" in content
+
+
+def test_log_session_rejects_empty_title(tmp_path):
+    root = create_workspace(tmp_path)
+    server = build_server(root)
+
+    result = _call(server, "log_session", {"title": "   "})
+
+    assert result.isError is True
+    assert result.structuredContent["error"]["error_code"] == "E_INVALID_TITLE"
+
+
+# ---------------------------------------------------------------------------
+# promote_document
+# ---------------------------------------------------------------------------
+
+
+def test_promote_document_mutates_curation_level_only(tmp_path):
+    root = create_workspace(tmp_path)
+    server = build_server(root)
+
+    # kernel_doc exists in the seeded workspace. Give it curation_level=0.
+    kernel_path = root / "docs" / "kernel.md"
+    original_body = "Kernel body.\n"
+    kernel_path.write_text(
+        "---\n"
+        "id: kernel_doc\n"
+        "type: kernel\n"
+        "status: active\n"
+        "curation_level: 0\n"
+        "---\n\n"
+        f"{original_body}",
+        encoding="utf-8",
+    )
+    # Rebuild cache so snapshot sees the new file.
+    server = build_server(root)
+
+    result = _call(
+        server,
+        "promote_document",
+        {"document_id": "kernel_doc", "new_level": 2},
+    )
+
+    assert result.isError is False, result.content[0].text
+    payload = result.structuredContent
+    assert payload["success"] is True
+    assert payload["document_id"] == "kernel_doc"
+    assert payload["old_level"] == "L0"
+    assert payload["new_level"] == "L2"
+
+    text = kernel_path.read_text(encoding="utf-8")
+    assert "curation_level: 2" in text
+    # Body preserved, frontmatter-only mutation.
+    assert original_body.strip() in text
+
+
+def test_promote_document_rejects_unknown_id(tmp_path):
+    root = create_workspace(tmp_path)
+    server = build_server(root)
+
+    result = _call(
+        server,
+        "promote_document",
+        {"document_id": "nonexistent_doc", "new_level": 1},
+    )
+
+    assert result.isError is True
+    assert result.structuredContent["error"]["error_code"] == "E_DOCUMENT_NOT_FOUND"
+
+
+def test_promote_document_rejects_invalid_level(tmp_path):
+    root = create_workspace(tmp_path)
+    server = build_server(root)
+
+    result = _call(
+        server,
+        "promote_document",
+        {"document_id": "kernel_doc", "new_level": 5},
+    )
+
+    assert result.isError is True
+    assert result.structuredContent["error"]["error_code"] == "E_INVALID_LEVEL"
+
+
+# ---------------------------------------------------------------------------
+# read_only enforcement (closes m-2)
+# ---------------------------------------------------------------------------
+
+
+def test_read_only_refuses_scaffold_document(tmp_path):
+    root = create_workspace(tmp_path)
+    server = build_server(root, read_only=True)
+
+    result = _call(
+        server,
+        "scaffold_document",
+        {"path": "docs/should_not_exist.md"},
+    )
+
+    assert result.isError is True
+    assert result.structuredContent["error"]["error_code"] == "E_READ_ONLY"
+    assert not (root / "docs" / "should_not_exist.md").exists()
+
+
+def test_read_only_refuses_log_session(tmp_path):
+    root = create_workspace(tmp_path)
+    server = build_server(root, read_only=True)
+
+    result = _call(server, "log_session", {"title": "banned write"})
+
+    assert result.isError is True
+    assert result.structuredContent["error"]["error_code"] == "E_READ_ONLY"
+
+
+def test_read_only_refuses_promote_document(tmp_path):
+    root = create_workspace(tmp_path)
+    server = build_server(root, read_only=True)
+
+    result = _call(
+        server,
+        "promote_document",
+        {"document_id": "kernel_doc", "new_level": 2},
+    )
+
+    assert result.isError is True
+    assert result.structuredContent["error"]["error_code"] == "E_READ_ONLY"
+
+
+# ---------------------------------------------------------------------------
+# workspace_id cross-workspace refusal (m-14 consumer via shared helper)
+# ---------------------------------------------------------------------------
+
+
+def test_write_tool_rejects_cross_workspace_id(tmp_path):
+    root = create_workspace(tmp_path)
+    server = build_server(root)
+
+    result = _call(
+        server,
+        "scaffold_document",
+        {
+            "path": "docs/nope.md",
+            "workspace_id": "some-other-workspace",
+        },
+    )
+
+    assert result.isError is True
+    # In non-portfolio mode the shared helper raises E_PORTFOLIO_REQUIRED.
+    assert result.structuredContent["error"]["error_code"] == "E_PORTFOLIO_REQUIRED"
+
+
+# ---------------------------------------------------------------------------
+# A1 — workspace_lock contention inside the write tool.
+# ---------------------------------------------------------------------------
+
+
+def _hold_workspace_lock(workspace: str, ready, release, result: Queue) -> None:
+    """Hold workspace_lock() from another process until told to release."""
+    from ontos.mcp.locking import workspace_lock
+
+    try:
+        with workspace_lock(Path(workspace), timeout=5.0):
+            ready.set()
+            release.wait(timeout=30.0)
+        result.put(("ok", None))
+    except BaseException as exc:  # pragma: no cover — surfaced via Queue
+        result.put(("error", repr(exc)))
+
+
+def test_write_tool_under_contention_returns_structured_error(tmp_path):
+    """An outer process holds workspace_lock → write tool must fail cleanly.
+
+    The internal ``workspace_lock`` timeout is 5s; the tool surfaces a
+    structured ``E_WORKSPACE_BUSY`` error envelope rather than raising.
+    """
+    root = create_workspace(tmp_path)
+    server = build_server(root)
+
+    ready = Event()
+    release = Event()
+    q: Queue = Queue()
+    holder = Process(
+        target=_hold_workspace_lock,
+        args=(str(root), ready, release, q),
+    )
+    holder.start()
+    try:
+        assert ready.wait(timeout=5.0), "holder never signalled ready"
+
+        start = time.monotonic()
+        result = _call(
+            server,
+            "scaffold_document",
+            {"path": "docs/contended.md"},
+        )
+        elapsed = time.monotonic() - start
+
+        assert result.isError is True, result.content[0].text
+        # workspace_lock raises OntosUserError(code=E_WORKSPACE_BUSY).
+        assert result.structuredContent["error"]["error_code"] == "E_WORKSPACE_BUSY"
+        # Confirm the retry window is observed (addendum A1 timeout = 5s).
+        assert 4.5 <= elapsed <= 15.0, f"unexpected elapsed={elapsed:.2f}s"
+
+        assert not (root / "docs" / "contended.md").exists()
+    finally:
+        release.set()
+        holder.join(timeout=5.0)
+        if holder.is_alive():  # pragma: no cover
+            holder.terminate()
+            holder.join(timeout=2.0)
+
+
+# ---------------------------------------------------------------------------
+# A3 — post-commit-failure rebuild path.
+# ---------------------------------------------------------------------------
+
+
+def test_a3_rebuild_invoked_when_commit_raises(monkeypatch, tmp_path):
+    """If commit() raises, the exception path re-invokes rebuild_workspace.
+
+    The rebuild call is best-effort: its failure must NOT mask the
+    original commit exception. See addendum v1.2 §A3.
+    """
+    from ontos.core.context import SessionContext
+    from ontos.mcp import writes as write_impl
+
+    root = create_workspace(tmp_path)
+    cache = build_cache(root)
+
+    portfolio = RecordingPortfolioIndex()
+
+    real_commit = SessionContext.commit
+
+    def exploding_commit(self):
+        # Simulate a mid-commit rename failure AFTER tmp staging.
+        raise IOError("induced commit failure")
+
+    monkeypatch.setattr(SessionContext, "commit", exploding_commit)
+
+    result = write_impl.scaffold_document(
+        cache,
+        portfolio_index=portfolio,
+        read_only=False,
+        path="docs/should_rebuild.md",
+        content="",
+    )
+
+    # Restore (not strictly needed under monkeypatch).
+    SessionContext.commit = real_commit  # type: ignore[method-assign]
+
+    assert result.isError is True
+    # Original commit exception is surfaced — not masked by rebuild.
+    assert "induced commit failure" in result.content[0].text
+    # A3 recovery ran exactly once (rebuild-on-error path).
+    assert len(portfolio.rebuild_calls) == 1
+    slug, recorded_root = portfolio.rebuild_calls[0]
+    assert slug == "workspace"
+    assert Path(recorded_root) == root
+
+
+def test_a3_rebuild_failure_does_not_mask_original_exception(monkeypatch, tmp_path):
+    """A rebuild failure in the exception path is swallowed, not re-raised.
+
+    Mirrors the guard at ``core/context.py:189-199`` — the commit failure
+    must propagate as the user-visible error.
+    """
+    from ontos.core.context import SessionContext
+    from ontos.mcp import writes as write_impl
+
+    root = create_workspace(tmp_path)
+    cache = build_cache(root)
+
+    portfolio = RecordingPortfolioIndex()
+    portfolio.raise_on_rebuild = True
+
+    def exploding_commit(self):
+        raise IOError("induced commit failure")
+
+    monkeypatch.setattr(SessionContext, "commit", exploding_commit)
+
+    result = write_impl.scaffold_document(
+        cache,
+        portfolio_index=portfolio,
+        read_only=False,
+        path="docs/should_rebuild_fail.md",
+        content="",
+    )
+
+    assert result.isError is True
+    assert "induced commit failure" in result.content[0].text
+    assert len(portfolio.rebuild_calls) == 1
+
+
+def test_rebuild_is_called_in_happy_path(tmp_path):
+    """Happy path also rebuilds the workspace index after commit."""
+    from ontos.mcp import writes as write_impl
+
+    root = create_workspace(tmp_path)
+    cache = build_cache(root)
+    portfolio = RecordingPortfolioIndex()
+
+    result = write_impl.scaffold_document(
+        cache,
+        portfolio_index=portfolio,
+        read_only=False,
+        path="docs/new_doc.md",
+        content="",
+    )
+
+    assert result.isError is False, result.content[0].text
+    # Exactly one rebuild in the happy path (from _rebuild_safely).
+    assert len(portfolio.rebuild_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Shared workspace_id validator lookup (m-8 consolidation).
+# ---------------------------------------------------------------------------
+
+
+def test_shared_validate_workspace_id_helper_exists_and_is_reused():
+    """Dev 2 adds ontos.mcp._validation — Dev 3's rename_document must reuse it."""
+    import inspect
+
+    from ontos.mcp import _validation
+    from ontos.mcp import tools as read_tools
+    from ontos.mcp import writes as write_tools
+
+    assert hasattr(_validation, "validate_workspace_id")
+
+    # The legacy tools._validate_workspace_id now delegates to the shared
+    # helper so we don't have two implementations to diverge.
+    src = inspect.getsource(read_tools._validate_workspace_id)
+    assert "_validation" in src or "validate_workspace_id" in src
+
+    # The write tools import the shared helper directly.
+    assert _validation.validate_workspace_id is write_tools.validate_workspace_id

--- a/tests/test_context_contention.py
+++ b/tests/test_context_contention.py
@@ -1,0 +1,352 @@
+"""Write-contention tests for SessionContext + workspace_lock.
+
+Covers v4.1 Track B Dev 1 scope:
+
+* A1 regression — ``SessionContext(owns_lock=False)`` works inside a
+  ``workspace_lock()`` and the same call would deadlock/timeout with the
+  default ``owns_lock=True``. See
+  ``.project-internal/reviews/ontos-v4.1-spec-addendum-v1.2.md`` A1.
+* Two concurrent writers on the same workspace — the second times out
+  with ``RuntimeError("Could not acquire write lock...")``.
+* A writer holding the workspace lock does not stall a reader that does
+  not flock (portfolio-read path per C.0 findings Q2).
+* SF-8 — a pre-v4.1 PID-style ``.ontos.lock`` file (arbitrary text
+  content, no flock held) is acquired by the new flock-based path.
+* m-12 — a handle leak between ``open()`` and a successful flock in
+  ``_acquire_lock`` is prevented when an unexpected exception is raised.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import time
+from multiprocessing import Event, Process, Queue
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+from ontos.core.context import SessionContext
+from ontos.mcp.locking import workspace_lock
+
+
+# ---------------------------------------------------------------------------
+# multiprocessing helpers (top-level so they are picklable on macOS spawn).
+# ---------------------------------------------------------------------------
+
+
+def _writer_child(workspace: str, ready, release, result: Queue) -> None:
+    """Hold an exclusive flock on ``<workspace>/.ontos.lock`` until released.
+
+    Signals ``ready`` once the lock is held; waits for ``release`` before
+    dropping it. Reports success/failure through ``result``.
+    """
+    try:
+        ctx = SessionContext(repo_root=Path(workspace), config={})
+        lock_path = Path(workspace) / ".ontos.lock"
+        acquired = ctx._acquire_lock(lock_path, timeout=5.0)
+        if not acquired:
+            result.put(("fail", "first writer could not acquire"))
+            return
+        ready.set()
+        release.wait(timeout=10.0)
+        ctx._release_lock(lock_path)
+        result.put(("ok", None))
+    except BaseException as exc:  # pragma: no cover — surfaced via Queue
+        result.put(("error", repr(exc)))
+
+
+def _second_writer_child(workspace: str, result: Queue) -> None:
+    """Attempt a committed write; should raise RuntimeError under contention."""
+    try:
+        ctx = SessionContext(repo_root=Path(workspace), config={})
+        ctx.buffer_write(Path(workspace) / "doc.md", "hello")
+        ctx.commit()
+        result.put(("ok", None))
+    except RuntimeError as exc:
+        result.put(("runtime", str(exc)))
+    except BaseException as exc:  # pragma: no cover
+        result.put(("error", repr(exc)))
+
+
+def _outer_lock_child(workspace: str, ready, release, result: Queue) -> None:
+    """Hold ``workspace_lock()`` on ``workspace`` until released.
+
+    Used to simulate an outer flock held by a different process while the
+    parent process runs a reader-that-does-not-flock.
+    """
+    try:
+        with workspace_lock(Path(workspace), timeout=5.0):
+            ready.set()
+            release.wait(timeout=10.0)
+        result.put(("ok", None))
+    except BaseException as exc:  # pragma: no cover
+        result.put(("error", repr(exc)))
+
+
+# ---------------------------------------------------------------------------
+# Tests.
+# ---------------------------------------------------------------------------
+
+
+class TestA1OwnsLockRegression:
+    """A1 — `SessionContext(owns_lock=False)` inside `workspace_lock`.
+
+    The default `owns_lock=True` path would deadlock against an outer
+    flock held by `workspace_lock()` (same process, different fd, same
+    file — `flock(2)` treats them independently); `owns_lock=False` is
+    the contract introduced by addendum v1.2 A1.
+    """
+
+    def test_owns_lock_false_allows_commit_under_workspace_lock(self, tmp_path):
+        target = tmp_path / "note.md"
+        with workspace_lock(tmp_path, timeout=5.0):
+            ctx = SessionContext(
+                repo_root=tmp_path, config={}, owns_lock=False
+            )
+            ctx.buffer_write(target, "hello A1")
+            modified = ctx.commit()
+        assert modified == [target]
+        assert target.read_text() == "hello A1"
+
+    def test_default_owns_lock_true_deadlocks_under_workspace_lock(self, tmp_path):
+        """Same setup with the default owns_lock=True must fail fast.
+
+        The inner acquire uses a small timeout so the test does not pay
+        the full 5s; the point is that the lock WOULD be acquired if
+        `owns_lock=False` were the default, and is NOT acquired when the
+        outer workspace_lock is held.
+        """
+        ctx = SessionContext(repo_root=tmp_path, config={})  # owns_lock=True
+
+        with workspace_lock(tmp_path, timeout=5.0):
+            lock_path = tmp_path / ".ontos.lock"
+            # Directly exercise _acquire_lock with a short timeout to
+            # keep the test fast — the production path (commit()) uses
+            # the full 5s window and raises RuntimeError on False.
+            acquired = ctx._acquire_lock(lock_path, timeout=0.2)
+            assert acquired is False, (
+                "default owns_lock=True must fail to acquire while the "
+                "outer workspace_lock is held — this is the A1 deadlock "
+                "the owns_lock=False contract prevents"
+            )
+            assert ctx._lock_handle is None
+
+    def test_owns_lock_false_acquire_release_are_noops(self, tmp_path):
+        ctx = SessionContext(
+            repo_root=tmp_path, config={}, owns_lock=False
+        )
+        lock_path = tmp_path / ".ontos.lock"
+        # No outer flock held — the contract is still "do nothing".
+        assert ctx._acquire_lock(lock_path, timeout=0.1) is True
+        assert ctx._lock_handle is None
+        ctx._release_lock(lock_path)  # Must not raise.
+        assert ctx._lock_handle is None
+
+
+class TestTwoWriterContention:
+    """Two writers on the same workspace — second must time out."""
+
+    def test_second_writer_times_out_with_runtime_error(self, tmp_path):
+        ready = Event()
+        release = Event()
+        first_q: Queue = Queue()
+        second_q: Queue = Queue()
+
+        first = Process(
+            target=_writer_child,
+            args=(str(tmp_path), ready, release, first_q),
+        )
+        first.start()
+        try:
+            assert ready.wait(timeout=5.0), "first writer never signalled ready"
+
+            second = Process(
+                target=_second_writer_child,
+                args=(str(tmp_path), second_q),
+            )
+            start = time.monotonic()
+            second.start()
+            second.join(timeout=20.0)
+            elapsed = time.monotonic() - start
+
+            assert not second.is_alive(), "second writer did not exit"
+            assert second.exitcode == 0, (
+                f"second writer crashed: exitcode={second.exitcode}"
+            )
+
+            status, payload = second_q.get(timeout=2.0)
+            assert status == "runtime", (
+                f"second writer should have raised RuntimeError; "
+                f"got {status!r} with payload {payload!r}"
+            )
+            assert "Could not acquire write lock" in payload
+            # The retry loop in _acquire_lock is 5s; the second writer
+            # should fail somewhere around that mark.
+            assert 4.5 <= elapsed <= 15.0, (
+                f"second writer elapsed={elapsed:.2f}s — expected ~5s retry window"
+            )
+        finally:
+            release.set()
+            first.join(timeout=5.0)
+            if first.is_alive():  # pragma: no cover
+                first.terminate()
+                first.join(timeout=2.0)
+
+
+class TestWriterVsNonFlockingReader:
+    """A reader that does not flock must not block behind a writer.
+
+    Per C.0 findings Q2 (sub-questions table), portfolio-level read
+    tools (``project_registry``, ``search_portfolio``, ``verify
+    --portfolio``) operate on ``portfolio.db`` and do NOT acquire the
+    workspace flock. This test asserts that invariant at the substrate
+    layer: an outer ``workspace_lock()`` in one process does not impede
+    a bare filesystem read in another process (no flock acquisition).
+    """
+
+    def test_non_flocking_reader_unblocked_by_writer(self, tmp_path):
+        # Place a file the "reader" will read.
+        sentinel = tmp_path / "doc.md"
+        sentinel.write_text("data")
+
+        ready = Event()
+        release = Event()
+        holder_q: Queue = Queue()
+        holder = Process(
+            target=_outer_lock_child,
+            args=(str(tmp_path), ready, release, holder_q),
+        )
+        holder.start()
+        try:
+            assert ready.wait(timeout=5.0), "holder never signalled ready"
+
+            # The reader-like path: just read the file. No flock.
+            start = time.monotonic()
+            content = sentinel.read_text()
+            # Also stat the lockfile path, simulating a tool that may
+            # inspect the lockfile's metadata without acquiring it.
+            lockfile = tmp_path / ".ontos.lock"
+            assert lockfile.exists()
+            _ = lockfile.stat()
+            elapsed = time.monotonic() - start
+
+            assert content == "data"
+            assert elapsed < 1.0, (
+                f"non-flocking reader blocked for {elapsed:.2f}s while "
+                f"writer held workspace_lock — must not stall"
+            )
+        finally:
+            release.set()
+            holder.join(timeout=5.0)
+            if holder.is_alive():  # pragma: no cover
+                holder.terminate()
+                holder.join(timeout=2.0)
+
+
+class TestSF8StaleLegacyLockfile:
+    """SF-8 — a pre-v4.1 PID-style ``.ontos.lock`` must not break acquire.
+
+    Earlier Ontos versions wrote PID/text content into ``.ontos.lock``.
+    The v4.1 flock-based path opens the file in ``"a+"`` and flocks the
+    fd; it does not read or parse the file's content. This test proves
+    it.
+    """
+
+    def test_stale_pid_style_lockfile_is_acquired(self, tmp_path):
+        lock_path = tmp_path / ".ontos.lock"
+        lock_path.write_text("12345\nworkspace=/some/old/path\n")
+
+        ctx = SessionContext(repo_root=tmp_path, config={})
+        acquired = ctx._acquire_lock(lock_path, timeout=1.0)
+        try:
+            assert acquired is True
+            assert ctx._lock_handle is not None
+            # The file's prior contents remain — open in append mode
+            # does not truncate. This is intentional and harmless; flock
+            # is purely fd-based.
+            assert lock_path.read_text().startswith("12345")
+        finally:
+            ctx._release_lock(lock_path)
+
+    def test_no_codepath_parses_lockfile_content(self):
+        """Assert the regression surface never existed.
+
+        The acquire path must not ``read()`` the lockfile expecting a
+        PID-style format. Narrow source inspection of the two lock
+        primitives guards against anyone reintroducing PID parsing.
+        """
+        import inspect as _inspect
+
+        import ontos.core.context as context_module
+        import ontos.mcp.locking as locking_module
+
+        acquire_src = _inspect.getsource(SessionContext._acquire_lock)
+        release_src = _inspect.getsource(SessionContext._release_lock)
+        locking_src = _inspect.getsource(locking_module.workspace_lock)
+
+        for src, name in (
+            (acquire_src, "SessionContext._acquire_lock"),
+            (release_src, "SessionContext._release_lock"),
+            (locking_src, "workspace_lock"),
+        ):
+            assert ".readline" not in src, (
+                f"{name} must not readline() the lockfile"
+            )
+            assert ".readlines" not in src, (
+                f"{name} must not readlines() the lockfile"
+            )
+            assert "read_text" not in src, (
+                f"{name} must not read_text() the lockfile"
+            )
+            # Bare `handle.read(` on the lock handle would also be a
+            # regression. `fileno().read` is not a real API but guard
+            # broadly against `<anything>.read(` that isn't part of
+            # ``read_text`` (handled above).
+            assert ".read(" not in src, (
+                f"{name} must not read() the lockfile's contents"
+            )
+
+        # Reference ``context_module`` to keep the import alive for
+        # future assertions — this also ensures the module still exposes
+        # SessionContext at the expected path.
+        assert context_module.SessionContext is SessionContext
+
+
+class TestM12HandleLeakFix:
+    """m-12 — close the handle on any non-BlockingIOError between open/flock."""
+
+    def test_unexpected_exception_does_not_leak_handle(self, tmp_path, monkeypatch):
+        """Force an OSError out of ``fcntl.flock`` and confirm cleanup.
+
+        Pre-m-12 the loop would drop the opened handle on the floor. Now
+        the handle must be closed and the exception re-raised.
+        """
+        ctx = SessionContext(repo_root=tmp_path, config={})
+        lock_path = tmp_path / ".ontos.lock"
+
+        opened_handles: list = []
+        real_open = Path.open
+
+        def tracking_open(self: Path, *args, **kwargs):
+            handle = real_open(self, *args, **kwargs)
+            if self == lock_path:
+                opened_handles.append(handle)
+            return handle
+
+        def exploding_flock(fd, op):  # noqa: ANN001
+            raise OSError("induced flock failure")
+
+        monkeypatch.setattr(Path, "open", tracking_open)
+        monkeypatch.setattr(fcntl, "flock", exploding_flock)
+
+        with pytest.raises(OSError, match="induced flock failure"):
+            ctx._acquire_lock(lock_path, timeout=1.0)
+
+        assert len(opened_handles) == 1, "lock path was not opened exactly once"
+        handle = opened_handles[0]
+        assert handle.closed, (
+            "m-12 regression: unexpected exception between open() and "
+            "successful flock leaked the file handle"
+        )
+        assert ctx._lock_handle is None


### PR DESCRIPTION
## Scope

Implements the `rename_document` MCP tool (v4.1 Track B Dev 3). ID-only rename across N referencing files in a workspace. Matches CLI `ontos/commands/rename.py:221` semantics: every mutation flows through `ctx.buffer_write`; no filesystem rename, no `buffer_move`.

Ships as a new module `ontos/mcp/rename_tool.py` to keep Dev 2's `writes.py` untouched while reusing the same preflight / envelope / lock pattern.

## Items closed

- **m-8 (consumer)** — reuses `ontos/mcp/_validation.validate_workspace_id` (Dev 2's shared helper); no fourth guard added.
- **m-13** — see decision below.
- **m-15 (partial)** — `rename_document` registered in `TOOL_SUCCESS_MODELS` with the `RenameDocumentResponse` model.

## A6 confirmation

`ontos/commands/rename.py:221` rename-in-place semantics verified; the MCP tool uses `ctx.buffer_write` and performs **no** filesystem rename. A static AST test (`test_a6_rename_uses_buffer_write_not_filesystem_rename`) locks this in: the module has zero `buffer_move` / `os.rename` / `Path.rename` call sites.

## m-13 decision: (b) parity-failure path made recoverable

Rationale: `PortfolioIndex.rebuild_workspace` starts with `DELETE FROM documents WHERE workspace = ?` (`portfolio.py:300`) before re-inserting. It is fully idempotent, so a second invocation converges on success. The parity check at `portfolio.py:410-422` raises `RuntimeError("FTS parity mismatch ...")` after `conn.commit()` has already mutated the DB, making pre-commit abortion impossible without invasive surgery across shared substrate.

`rename_tool._rebuild_with_m13_retry` catches only the parity-mismatch `RuntimeError` and retries `rebuild_workspace` exactly once. Non-parity exceptions are re-raised immediately so real bugs are not silently retried.

Alternative (a) — moving the parity check pre-commit — was rejected because it would require modifying `portfolio.py` (shared substrate touched by Dev 4) and the retry path fully resolves the consistency window.

## Key mechanics

- **Precondition before lock.** `is_workspace_clean(root)` runs inside `_preflight()` **before** entering `workspace_lock()`. The lock context materialises `.ontos.lock`; checking dirty-state afterwards would false-positive for any workspace that hasn't gitignored it. A5 requires `.ontos.lock` in `.gitignore`; this tool degrades gracefully if it isn't.
- **Single lock discipline (A1).** `SessionContext(owns_lock=False)` inside `workspace_lock(root)`.
- **A3 rollback + rebuild.** On commit failure: `git checkout -- .` reverts the working tree; `rebuild_workspace(slug, root)` re-converges the portfolio DB. Rebuild errors are captured via `ctx.error(...)` and never mask the original commit exception.
- **Partial-commit guard.** If `ctx.commit()` returns a file set that differs from the planned set, the tool rolls back via `git checkout -- .`, triggers a rebuild, and raises `OntosInternalError(code=E_PARTIAL_COMMIT_MISMATCH)`.
- **Python 3.14 frozen-dataclass gotcha.** `OntosUserError`/`OntosInternalError` are caught *inside* the `workspace_lock` context, mirroring Dev 2's workaround. Only `workspace_lock`'s own `E_WORKSPACE_BUSY` escapes the lock.

## Files

- `ontos/core/git.py` — new `is_workspace_clean(root)` helper; shells out to `git status --porcelain`, treats untracked as dirty.
- `ontos/mcp/rename_tool.py` — the tool.
- `ontos/mcp/schemas.py` — registered `rename_document` in `TOOL_SUCCESS_MODELS`.
- `ontos/mcp/server.py` — wired `handle_rename_document` and `register_fn(name="rename_document", ...)`.
- `tests/mcp/test_rename_document.py` — 19 new tests (happy path, git preconditions, read_only, cross-workspace, contention, A3 rollback, m-13 retry, schema wiring).
- `tests/mcp/test_refresh.py` / `test_server_integration.py` / `test_server_portfolio_mode.py` — tool-count assertions bumped from 11→12 / added `rename_document` to expected set.

## Test plan

- [x] Happy path: frontmatter `id`, `depends_on`, and markdown-link body references all rewritten; `updated_files` matches planned set.
- [x] Git-dirty precondition refusal — modified tracked file blocks rename with `E_DIRTY_WORKSPACE`.
- [x] Untracked-file refusal — unrelated untracked file also blocks rename.
- [x] `read_only` refusal → `E_READ_ONLY` before any mutation.
- [x] Cross-workspace `workspace_id` refusal via shared helper.
- [x] Contention inside `workspace_lock` → `E_WORKSPACE_BUSY` after ~5s timeout.
- [x] A3: commit raises → `git checkout -- .` reverts working tree → `rebuild_workspace` runs → state converges (snapshot has old IDs, not new).
- [x] A3: rebuild failure does not mask original commit exception.
- [x] m-13: parity-mismatch first call retries once and succeeds.
- [x] m-13: non-parity RuntimeError is NOT retried.
- [x] Schema: response model registered, output schema exposes exactly `success/old_id/new_id/path/references_updated/updated_files`.
- [x] A6 AST guard: no `buffer_move`, no `rename` attribute calls.

**Test result:** 1081 → 1100 passed, 2 skipped (Python 3.14).

## References

- v1.1 §4.8.2 — base spec for `rename_document`
- Addendum v1.2 §A1 (lock discipline), §A2 (slugifier binding), §A3 (post-rollback rebuild), §A6 (rename-in-place semantics verified)
- TrackB-Design.md §9 — A6 verification pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up refactor: extract `build_rename_plan`

Adds one commit that unifies the rename plan-building orchestration.
Previously the MCP tool had its own ID validation + collision checks +
file-plan iteration loop in parallel with CLI `_prepare_plan`; both now
delegate to a new shared orchestrator `build_rename_plan`. MCP
additionally gains the external-IDs cross-scope collision check it was
previously missing (new error code `E_CROSS_SCOPE_COLLISION`).

- `_prepare_plan` public signature unchanged.
- MCP preserves pre-lock git-clean via `check_git=False`.
- MCP's effective scope now uses `resolve_scan_scope(None, config.scanning.default_scope)` so it matches the snapshot-cache scope exactly (the shared orchestrator only runs the docs-scope external-IDs check when the effective scope is `docs`).
- Removed from `ontos/mcp/rename_tool.py`: local `_ID_PATTERN`, `_RESERVED_YAML_WORDS`, the manual old/new existence checks, and the sorted `_build_file_plan` loop.
- Added helper `_rename_error_to_user_exc` maps shared `RenameError` codes to MCP envelope codes.
- New equivalence test `test_build_rename_plan_equivalence_cli_vs_injected_docs` in `tests/commands/test_rename.py` asserts CLI vs direct-injection parity (file list, edit content, summary counts, warnings).
- New MCP tests `test_rename_rejects_cross_scope_collision_docs_scope` and `test_rename_library_scope_allows_ids_in_ontos_internal` cover the gained safety check and its library-scope complement.

Total test count: 1103 (Dev 3 baseline 1100 + 3 new).

Closes the CB-6-style parallelism risk before Track B integration.
