### PR TITLE
docs(v4.1.0): update customer-facing docs for PyPI publish

### DIFF
--- a/Ontos_CHANGELOG.md
+++ b/Ontos_CHANGELOG.md
@@ -21,6 +21,106 @@ All notable changes to **Project Ontos itself** (the protocol and tooling) will 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.0] - 2026-04-12
+
+### Theme: "Portfolio Authority"
+
+Major release shipping portfolio-scoped MCP with read AND write tools, a portfolio index with FTS5 search, advisory flock locking, wired bundle configuration, and a shared rename orchestrator.
+
+### Added
+
+- **4 MCP write tools** — `scaffold_document`, `log_session`, `promote_document`, `rename_document`. All respect `read_only` at registration time and wrap mutations in `workspace_lock()`.
+- **3 MCP portfolio tools** — `project_registry`, `search_portfolio`, `get_context_bundle` over a per-session SQLite portfolio index with FTS5 full-text search.
+- **`ontos verify --portfolio`** — Audits portfolio consistency (slug collisions, malformed TOML).
+- **Bundle config** — `bundle_token_budget`, `bundle_max_logs`, `bundle_log_window_days` in `~/.config/ontos/portfolio.toml` now reach `build_context_bundle()`.
+- **Shared rename orchestrator** — `build_rename_plan` used by both CLI and MCP.
+- **Advisory flock locking** — `workspace_lock()` on `<workspace>/.ontos.lock` for cross-process mutual exclusion.
+- **Rollback-then-rebuild recovery** — Write tools revert partial file state on commit failure before rebuilding portfolio index.
+
+### Changed
+
+- MCP tool count: 8 → 15 (8 core + 3 portfolio + 4 write).
+- `read_only=True` now omits write tools from `list_tools()` entirely (previously returned `E_READ_ONLY` on invocation).
+
+### Metrics
+
+- ~40 commits (Track A + Track B + fix cycles), 5 PRs merged, 1133 tests passed.
+
+---
+
+## [4.0.0] - 2026-04-05
+
+### Theme: "MCP Server Mode"
+
+Major release adding an MCP (Model Context Protocol) server for native AI IDE integration.
+
+### Added
+
+- **`ontos serve` command** — Starts a stdio MCP server exposing the knowledge graph to AI agents.
+- **8 MCP tools** — `workspace_overview`, `context_map`, `get_document`, `list_documents`, `export_graph`, `query`, `health`, `refresh`.
+- **File-mtime cache invalidation** — Automatic snapshot rebuild when documents change.
+- **`[mcp]` config section** — Optional usage logging in `.ontos.toml`.
+- **`ontos[mcp]` optional dependency** — `mcp>=1.27.0` and `pydantic>=2.0` (Python 3.10+).
+
+### Changed
+
+- Version bumped to `4.0.0` in `pyproject.toml` and `ontos/__init__.py`.
+- CI matrix updated: Python 3.10+ installs `[mcp]` extra; Python 3.9 stays on base package.
+
+### Metrics
+
+- 8 MCP tools, stdio transport, Python 3.9+ base compatibility preserved.
+
+---
+
+## [3.4.0] - 2026-04-04
+
+### Theme: "Tiered Context"
+
+Minor release shipping `--compact tiered` context maps for token-constrained agents.
+
+### Added
+
+- **`--compact tiered` mode** — Three-section output: prose project summary (Tier 1), type-ranked compact listing (Tier 2), and full ID index (Tier 3).
+
+### Fixed
+
+- Consistent Tier 1 log ordering by date descending.
+- `project_root` normalization before compact dispatch (crash fix on relative paths).
+- Shared `_sort_key` across all compact modes for deterministic output.
+
+### Metrics
+
+- 7 commits, 1 PR (#79), compact modes: 2 → 3 (`plain`, `rich`, `tiered`).
+
+---
+
+## [3.3.1] - 2026-02-28
+
+### Theme: "Review Remediation"
+
+Patch release shipping link-check false positive reduction and a new `promote_check` maintenance task.
+
+### Added
+
+- **`promote_check` maintenance task** — 9th task in `ontos maintain`; reports documents ready for promotion.
+
+### Fixed
+
+- **link-check FP reduction: 408 → 45** — Two rounds of pre-classification filters eliminate 89% of false positives.
+
+### Changed
+
+- `SECURITY.md` rewritten for v3.3.x surface.
+- `pyproject.toml` classifier bumped: `Alpha` → `Beta`.
+- README roadmap and Manual updated to v3.3.
+
+### Metrics
+
+- 11 commits, 3 PRs (#76, #77, #78), 920+ tests passed.
+
+---
+
 ## [3.3.0] - 2026-02-11
 
 ### Theme: "Full Spectrum Hardening"

--- a/Ontos_CHANGELOG.md
+++ b/Ontos_CHANGELOG.md
@@ -30,7 +30,7 @@ Major release shipping portfolio-scoped MCP with read AND write tools, a portfol
 ### Added
 
 - **4 MCP write tools** — `scaffold_document`, `log_session`, `promote_document`, `rename_document`. All respect `read_only` at registration time and wrap mutations in `workspace_lock()`.
-- **3 MCP portfolio tools** — `project_registry`, `search_portfolio`, `get_context_bundle` over a per-session SQLite portfolio index with FTS5 full-text search.
+- **3 MCP portfolio tools** — `project_registry`, `search`, `get_context_bundle` over a per-session SQLite portfolio index with FTS5 full-text search. `project_registry` and `search` require `--portfolio`; `get_context_bundle` is always available.
 - **`ontos verify --portfolio`** — Audits portfolio consistency (slug collisions, malformed TOML).
 - **Bundle config** — `bundle_token_budget`, `bundle_max_logs`, `bundle_log_window_days` in `~/.config/ontos/portfolio.toml` now reach `build_context_bundle()`.
 - **Shared rename orchestrator** — `build_rename_plan` used by both CLI and MCP.
@@ -39,7 +39,7 @@ Major release shipping portfolio-scoped MCP with read AND write tools, a portfol
 
 ### Changed
 
-- MCP tool count: 8 → 15 (8 core + 3 portfolio + 4 write).
+- MCP tool count: 8 → up to 15 (9 core + 2 portfolio + 4 write).
 - `read_only=True` now omits write tools from `list_tools()` entirely (previously returned `E_READ_ONLY` on invocation).
 
 ### Metrics

--- a/README.md
+++ b/README.md
@@ -292,9 +292,9 @@ The server runs over stdio — your IDE manages the process lifecycle.
 
 ### 4. Available Tools
 
-The MCP server exposes 15 tools across three categories:
+The MCP server exposes up to 15 tools depending on server flags:
 
-**Core (8 tools — always available):**
+**Core (9 tools — always available):**
 
 | Tool | Purpose | Read-only |
 |------|---------|:---------:|
@@ -306,14 +306,14 @@ The MCP server exposes 15 tools across three categories:
 | `query` | Dependency details for a single document | ✅ |
 | `health` | Server uptime, document count, version | ✅ |
 | `refresh` | Force cache rebuild after bulk changes | ⚠️ |
+| `get_context_bundle` | Token-budgeted context bundle for a workspace | ✅ |
 
-**Portfolio (3 tools — v4.1, always available):**
+**Portfolio (2 tools — v4.1, requires `--portfolio` flag):**
 
 | Tool | Purpose |
 |------|---------|
 | `project_registry` | Inventory of all known workspaces |
-| `search_portfolio` | FTS5 full-text search across workspaces |
-| `get_context_bundle` | Token-budgeted context bundle for a workspace |
+| `search` | FTS5 full-text search across workspaces |
 
 **Write (4 tools — v4.1, mutable mode only):**
 

--- a/README.md
+++ b/README.md
@@ -292,7 +292,9 @@ The server runs over stdio — your IDE manages the process lifecycle.
 
 ### 4. Available Tools
 
-The MCP server exposes 8 tools (6 read-only, 2 write-capable):
+The MCP server exposes 15 tools across three categories:
+
+**Core (8 tools — always available):**
 
 | Tool | Purpose | Read-only |
 |------|---------|:---------:|
@@ -305,12 +307,29 @@ The MCP server exposes 8 tools (6 read-only, 2 write-capable):
 | `health` | Server uptime, document count, version | ✅ |
 | `refresh` | Force cache rebuild after bulk changes | ⚠️ |
 
-`export_graph` can write a file within the workspace root. `refresh` rebuilds the internal cache. Both are safe but not strictly read-only.
+**Portfolio (3 tools — v4.1, always available):**
+
+| Tool | Purpose |
+|------|---------|
+| `project_registry` | Inventory of all known workspaces |
+| `search_portfolio` | FTS5 full-text search across workspaces |
+| `get_context_bundle` | Token-budgeted context bundle for a workspace |
+
+**Write (4 tools — v4.1, mutable mode only):**
+
+| Tool | Purpose |
+|------|---------|
+| `scaffold_document` | Create a new markdown file with scaffold frontmatter |
+| `log_session` | Create a dated session log |
+| `promote_document` | Change curation level without moving the file |
+| `rename_document` | Rename an ID across all referencing files |
+
+Write tools are registered only when the server runs without `--read-only`. All write operations use advisory flock locking for cross-process safety.
 
 ### 5. Verify
 
 ```bash
-ontos --version   # Should show 4.0.0
+ontos --version   # Should show 4.1.0
 ontos serve       # Starts the stdio server (Ctrl+C to stop)
 ```
 
@@ -393,10 +412,10 @@ Version 3 is when Ontos became public. The earlier versions live on in the desig
 
 | Version | Status | Highlights |
 |---------|--------|------------|
-| **v4.0.0** | ✅ Current | MCP server mode — 8 tools for native AI IDE integration |
-| **v4.1** | Next | Portfolio index, cross-project tools, HTTP/SSE transport |
+| **v4.1.0** | ✅ Current | Portfolio index, 4 write tools, advisory flock locking, shared rename orchestrator |
+| **v4.2** | Next | HTTP/SSE transport, cross-workspace writes |
 
-v3.0 transformed Ontos from repo-injected scripts into a pip-installable package. v3.1 made all CLI commands native Python. v3.2 added re-architecture support, environment detection, and activation resilience. v3.3 ships 62 audit-derived hardening fixes plus `link-check`, `rename`, unified JSON envelopes, and a canonical document loader. v3.3.1 reduced link-check false positives by 89% and added `promote_check` to the maintenance pipeline. v3.4 adds `--compact tiered` context maps for token-constrained agents. v4.0 adds an MCP server mode with 8 read-only tools, enabling native integration with AI IDEs like Claude Desktop and Cursor without CLI overhead.
+v3.0 transformed Ontos from repo-injected scripts into a pip-installable package. v3.1 made all CLI commands native Python. v3.2 added re-architecture support, environment detection, and activation resilience. v3.3 ships 62 audit-derived hardening fixes plus `link-check`, `rename`, unified JSON envelopes, and a canonical document loader. v3.3.1 reduced link-check false positives by 89% and added `promote_check` to the maintenance pipeline. v3.4 adds `--compact tiered` context maps for token-constrained agents. v4.0 adds an MCP server mode with 8 read-only tools, enabling native integration with AI IDEs like Claude Desktop and Cursor without CLI overhead. v4.1 expands MCP to 15 tools — 4 write tools (`scaffold_document`, `log_session`, `promote_document`, `rename_document`), a portfolio index with FTS5 search, advisory flock locking, and a shared rename orchestrator used by both CLI and MCP.
 
 ---
 

--- a/docs/logs/2026-04-12_v4-1-0-customer-facing-docs-update-for-pypi-publis.md
+++ b/docs/logs/2026-04-12_v4-1-0-customer-facing-docs-update-for-pypi-publis.md
@@ -1,0 +1,21 @@
+---
+id: log_20260412_v4-1-0-customer-facing-docs-update-for-pypi-publis
+type: log
+status: active
+event_type: chore
+source: Antigravity (Claude Opus 4.6 Thinking)
+branch: docs/v4.1.0-pypi-publish-prep
+created: 2026-04-12
+---
+
+# v4.1.0 customer-facing docs update for PyPI publish
+
+## Summary
+
+<!-- Brief description of what was done -->
+
+## Changes Made
+
+<!-- List of changes -->
+
+## Testing

--- a/docs/reference/Migration_v3_to_v4.md
+++ b/docs/reference/Migration_v3_to_v4.md
@@ -167,7 +167,7 @@ ontos serve
 
 ### Portfolio Index
 
-v4.1 introduces a per-session SQLite portfolio index with FTS5 full-text search. Three new MCP tools (`project_registry`, `search_portfolio`, `get_context_bundle`) let agents discover and search across workspaces.
+v4.1 introduces a per-session SQLite portfolio index with FTS5 full-text search. Three new MCP tools (`project_registry`, `search`, `get_context_bundle`) let agents discover and search across workspaces.
 
 Configure in `~/.config/ontos/portfolio.toml`:
 ```toml

--- a/docs/reference/Migration_v3_to_v4.md
+++ b/docs/reference/Migration_v3_to_v4.md
@@ -5,9 +5,9 @@ status: active
 depends_on: [ontos_manual]
 ---
 
-# Migration Guide: v3.x → v4.0
+# Migration Guide: v3.x → v4.x
 
-This guide covers the new capabilities in Ontos v4.0 and how to enable them. **There are no breaking changes** — all existing CLI commands, configuration, and frontmatter schemas are preserved.
+This guide covers the new capabilities in Ontos v4.0 and v4.1 and how to enable them. **There are no breaking changes** — all existing CLI commands, configuration, and frontmatter schemas are preserved.
 
 ## What's New in v4.0
 
@@ -45,7 +45,7 @@ pip install 'ontos[mcp]'    # Adds mcp>=1.2 and pydantic>=2.0
 
 > **Note:** MCP requires Python 3.10+. All other Ontos commands continue to work on Python 3.9+.
 
-### 8 MCP Tools
+### 8 Core MCP Tools (v4.0)
 
 | Tool | Purpose |
 |------|---------|
@@ -58,7 +58,28 @@ pip install 'ontos[mcp]'    # Adds mcp>=1.2 and pydantic>=2.0
 | `health` | Server uptime, document count, index freshness, version |
 | `refresh` | Force cache rebuild after bulk changes |
 
-All tools are read-only (except `export_graph` with `export_to_file`, which writes within the workspace root).
+### 7 New MCP Tools (v4.1)
+
+**Portfolio tools (always available):**
+
+| Tool | Purpose |
+|------|---------|
+| `project_registry` | Inventory of all known workspaces |
+| `search_portfolio` | FTS5 full-text search across workspaces |
+| `get_context_bundle` | Token-budgeted context bundle for a workspace |
+
+**Write tools (mutable mode only — omitted when `--read-only`):**
+
+| Tool | Purpose |
+|------|---------|
+| `scaffold_document` | Create a new markdown file with scaffold frontmatter |
+| `log_session` | Create a dated session log |
+| `promote_document` | Change curation level without moving the file |
+| `rename_document` | Rename an ID across all referencing files |
+
+All write tools use advisory flock locking (`workspace_lock()`) for cross-process safety and perform rollback-then-rebuild recovery on commit failure.
+
+All tools are read-only except `export_graph` with `export_to_file` (writes within workspace root) and the four write tools above.
 
 ### File-Mtime Cache Invalidation
 
@@ -111,7 +132,7 @@ pipx install --force 'ontos[mcp]'
 ### 2. Verify
 
 ```bash
-ontos --version  # Should show 4.0.0
+ontos --version  # Should show 4.1.0
 ontos doctor     # Check graph health
 ```
 
@@ -134,6 +155,41 @@ Test the server:
 ontos serve
 # Press Ctrl+C to stop
 ```
+
+## What's New in v4.1
+
+### Portfolio Index
+
+v4.1 introduces a per-session SQLite portfolio index with FTS5 full-text search. Three new MCP tools (`project_registry`, `search_portfolio`, `get_context_bundle`) let agents discover and search across workspaces.
+
+Configure in `~/.config/ontos/portfolio.toml`:
+```toml
+[portfolio]
+scan_roots = ["~/Dev"]
+exclude = ["~/Dev/.dev-hub", "~/Dev/archive"]
+registry_path = "~/Dev/.dev-hub/registry/projects.json"
+
+[bundle]
+token_budget = 8000
+max_logs = 20
+log_window_days = 30
+```
+
+### Write Tools
+
+Four write-capable MCP tools ship in v4.1: `scaffold_document`, `log_session`, `promote_document`, and `rename_document`. They are registered only when the server runs without `--read-only`.
+
+### Advisory Flock Locking
+
+All write paths (CLI and MCP) now use `workspace_lock()` with advisory flock on `<workspace>/.ontos.lock`. Ensure `.ontos.lock` is in your `.gitignore`.
+
+### Verify Subcommand
+
+`ontos verify --portfolio` audits portfolio consistency (slug collisions, malformed TOML).
+
+### Shared Rename Orchestrator
+
+`build_rename_plan` is now the single plan-builder used by both `ontos rename --apply` and MCP `rename_document`.
 
 ### 4. Configure Your IDE (Optional)
 
@@ -172,13 +228,14 @@ usage_logging = true
 
 Tool invocations are logged to `~/.config/ontos/usage.jsonl`. No document content is logged.
 
-## Known Limitations (v4.0)
+## Known Limitations (v4.1)
 
-- **Read-only tools only** — Write tools (scaffold, rename) deferred to v4.1
+- ~~**Read-only tools only** — Write tools (scaffold, rename) deferred to v4.1~~ ✅ Shipped in v4.1
 - **Single workspace per server** — Each `ontos serve` process serves one project
-- **Stdio transport only** — HTTP/SSE transport deferred to v4.1
+- **Stdio transport only** — HTTP/SSE transport deferred to a future release
 - **Python 3.10+** required for MCP (base package remains 3.9+)
-- **No cross-project search** — Portfolio index deferred to v4.1
+- ~~**No cross-project search** — Portfolio index deferred to v4.1~~ ✅ Shipped in v4.1
+- **No cross-workspace writes** — Write tools target the served workspace only
 
 ## Getting Help
 

--- a/docs/reference/Migration_v3_to_v4.md
+++ b/docs/reference/Migration_v3_to_v4.md
@@ -40,7 +40,7 @@ ontos serve --workspace /path  # Serve a specific project
 MCP support is opt-in. The base package is unchanged:
 ```bash
 pip install ontos            # Same as before — no new dependencies
-pip install 'ontos[mcp]'    # Adds mcp>=1.2 and pydantic>=2.0
+pip install 'ontos[mcp]'    # Adds mcp>=1.27.0 and pydantic>=2.0
 ```
 
 > **Note:** MCP requires Python 3.10+. All other Ontos commands continue to work on Python 3.9+.
@@ -60,13 +60,20 @@ pip install 'ontos[mcp]'    # Adds mcp>=1.2 and pydantic>=2.0
 
 ### 7 New MCP Tools (v4.1)
 
-**Portfolio tools (always available):**
+**Bundle tool (always available):**
+
+| Tool | Purpose |
+|------|---------|
+| `get_context_bundle` | Token-budgeted context bundle for a workspace |
+
+`get_context_bundle` is always registered. In portfolio mode it queries the portfolio index; otherwise it builds a bundle from the served workspace.
+
+**Portfolio tools (requires `--portfolio` flag):**
 
 | Tool | Purpose |
 |------|---------|
 | `project_registry` | Inventory of all known workspaces |
-| `search_portfolio` | FTS5 full-text search across workspaces |
-| `get_context_bundle` | Token-budgeted context bundle for a workspace |
+| `search` | FTS5 full-text search across workspaces |
 
 **Write tools (mutable mode only — omitted when `--read-only`):**
 

--- a/docs/reference/Ontos_Agent_Instructions.md
+++ b/docs/reference/Ontos_Agent_Instructions.md
@@ -7,8 +7,8 @@ depends_on: [ontos_manual]
 
 # Ontos Agent Instructions
 
-> **v4.0:** All CLI commands use `ontos <command>` (package installed via pip).
-> Agents can also connect via MCP server (`ontos serve`) for native integration.
+> **v4.1:** All CLI commands use `ontos <command>` (package installed via pip).
+> Agents can also connect via MCP server (`ontos serve`) for native integration — 15 tools including 4 write tools and portfolio search.
 > Use `python3 -m ontos <command>` if not installed globally.
 > See [Ontos Manual](Ontos_Manual.md) for details.
 
@@ -41,6 +41,8 @@ If the IDE supports MCP and the Ontos server is configured:
 
 **MCP vs CLI:** MCP tools return structured JSON and support live cache invalidation. Use MCP when available; fall back to CLI when MCP is not configured.
 
+**Core tools:**
+
 | Tool | Purpose |
 |------|---------|
 | `workspace_overview` | Project orientation (key docs, stats, warnings) |
@@ -52,10 +54,28 @@ If the IDE supports MCP and the Ontos server is configured:
 | `health` | Server health and index freshness |
 | `refresh` | Force cache rebuild after bulk changes |
 
+**Portfolio tools (v4.1):**
+
+| Tool | Purpose |
+|------|---------|
+| `project_registry` | Inventory of all known workspaces |
+| `search_portfolio` | FTS5 full-text search across workspaces |
+| `get_context_bundle` | Token-budgeted context bundle for a workspace |
+
+**Write tools (v4.1, mutable mode only):**
+
+| Tool | Purpose |
+|------|---------|
+| `scaffold_document` | Create a new markdown file with scaffold frontmatter |
+| `log_session` | Create a dated session log |
+| `promote_document` | Change curation level without moving the file |
+| `rename_document` | Rename an ID across all referencing files |
+
 ### "Start MCP Server" (v4.0)
 ```bash
 ontos serve                    # Serve current directory
 ontos serve --workspace /path  # Serve specific workspace
+ontos serve --read-only        # Read + portfolio tools only (no write tools)
 ```
 Starts a stdio MCP server. Configure in your IDE's MCP settings. Requires `pip install 'ontos[mcp]'`.
 

--- a/docs/reference/Ontos_Agent_Instructions.md
+++ b/docs/reference/Ontos_Agent_Instructions.md
@@ -8,7 +8,7 @@ depends_on: [ontos_manual]
 # Ontos Agent Instructions
 
 > **v4.1:** All CLI commands use `ontos <command>` (package installed via pip).
-> Agents can also connect via MCP server (`ontos serve`) for native integration — 15 tools including 4 write tools and portfolio search.
+> Agents can also connect via MCP server (`ontos serve`) for native integration — up to 15 tools including 4 write tools and portfolio search.
 > Use `python3 -m ontos <command>` if not installed globally.
 > See [Ontos Manual](Ontos_Manual.md) for details.
 
@@ -53,14 +53,14 @@ If the IDE supports MCP and the Ontos server is configured:
 | `query` | Dependency details for one document |
 | `health` | Server health and index freshness |
 | `refresh` | Force cache rebuild after bulk changes |
+| `get_context_bundle` | Token-budgeted context bundle for a workspace |
 
-**Portfolio tools (v4.1):**
+**Portfolio tools (v4.1, requires `--portfolio` flag):**
 
 | Tool | Purpose |
 |------|---------|
 | `project_registry` | Inventory of all known workspaces |
-| `search_portfolio` | FTS5 full-text search across workspaces |
-| `get_context_bundle` | Token-budgeted context bundle for a workspace |
+| `search` | FTS5 full-text search across workspaces |
 
 **Write tools (v4.1, mutable mode only):**
 
@@ -75,7 +75,7 @@ If the IDE supports MCP and the Ontos server is configured:
 ```bash
 ontos serve                    # Serve current directory
 ontos serve --workspace /path  # Serve specific workspace
-ontos serve --read-only        # Read + portfolio tools only (no write tools)
+ontos serve --read-only        # Omit write tools from the server
 ```
 Starts a stdio MCP server. Configure in your IDE's MCP settings. Requires `pip install 'ontos[mcp]'`.
 

--- a/docs/reference/Ontos_Manual.md
+++ b/docs/reference/Ontos_Manual.md
@@ -5,7 +5,7 @@ status: active
 depends_on: []
 ---
 
-# Ontos Manual v4.0
+# Ontos Manual v4.1
 
 *The complete reference for Project Ontos*
 
@@ -28,7 +28,7 @@ pip install 'ontos[mcp]'
 ontos serve
 ```
 
-> **v4.0 Note:** v4.0 adds MCP server mode for native AI IDE integration. See the [Migration Guide v3→v4](Migration_v3_to_v4.md). For v2.x users, see [Migration v2→v3](Migration_v2_to_v3.md).
+> **v4.1 Note:** v4.0 added MCP server mode for native AI IDE integration. v4.1 adds write tools, portfolio index, and advisory flock locking. See the [Migration Guide v3→v4](Migration_v3_to_v4.md). For v2.x users, see [Migration v2→v3](Migration_v2_to_v3.md).
 
 ---
 
@@ -399,7 +399,7 @@ To enable MCP server mode for IDE integration:
 pip install 'ontos[mcp]'
 ```
 
-This adds `mcp>=1.2` and `pydantic>=2.0` as dependencies. Python 3.10+ is required.
+This adds `mcp>=1.27.0` and `pydantic>=2.0` as dependencies. Python 3.10+ is required.
 
 For pipx users (fresh install):
 ```bash
@@ -728,11 +728,11 @@ usage_log_path = "~/.config/ontos/usage.jsonl"    # Default path
 
 No document content is logged — only tool names and timestamps.
 
-#### Limitations (v4.0+)
+#### Limitations (v4.1)
 
 - **Single workspace per server** — One `ontos serve` process per project
 - **No cross-workspace writes** — Write tools target the served workspace only
-- **Stdio transport only** — HTTP/SSE transport deferred to v4.1
+- **Stdio transport only** — HTTP/SSE transport deferred to a future release
 - **Python 3.10+** required — Install with `pip install 'ontos[mcp]'`
 
 ---

--- a/docs/reference/Ontos_Manual.md
+++ b/docs/reference/Ontos_Manual.md
@@ -690,10 +690,20 @@ The server runs in the foreground and communicates via stdin/stdout. Press Ctrl+
 | `query` | Dependency details for a single document | `entity_id` |
 | `health` | Server uptime, document count, index freshness | — |
 | `refresh` | Force cache rebuild | — |
+| `get_context_bundle` | Token-budgeted context bundle for a workspace | `workspace_id`, `token_budget` |
+
+#### Portfolio Tools (v4.1)
+
+When the server runs with `--portfolio`, it also registers:
+
+| Tool | Description | Key Parameters |
+|------|-------------|----------------|
+| `project_registry` | Inventory of all indexed workspaces | `workspace_id` |
+| `search` | FTS5 full-text search across portfolio documents | `query_string`, `workspace_id`, `offset`, `limit` |
 
 #### Write Tools (v4.1)
 
-When the server runs in mutable mode, it may also expose:
+When the server runs without `--read-only`, it also registers:
 
 | Tool | Description | Key Parameters |
 |------|-------------|----------------|

--- a/ontos/__init__.py
+++ b/ontos/__init__.py
@@ -7,7 +7,7 @@ Package structure:
     ontos.ui   - I/O layer (CLI, output, prompts)
 """
 
-__version__ = "4.0.0"
+__version__ = "4.1.0"
 
 # Re-export commonly used items for convenience
 from ontos.core.context import SessionContext, FileOperation, PendingWrite

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ontos"
-version = "4.0.0"
+version = "4.1.0"
 description = "Local-first documentation management for AI-assisted development"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

Update all customer-facing documentation for the v4.1.0 PyPI publish.

### Version Metadata
- `pyproject.toml` version → `4.1.0`
- `ontos/__init__.py` `__version__` → `4.1.0`

### Feature Documentation (4 files)
- **README.md** — MCP tool table expanded from 8 to 15 (core/portfolio/write categories), roadmap updated to v4.1.0 Current, version strings bumped
- **Ontos_Manual.md** — Title bumped to v4.1, quick-start note updated, MCP dependency corrected (`mcp>=1.27.0`), limitations refreshed
- **Migration_v3_to_v4.md** — Title expanded to "v3.x → v4.x", full "What's New in v4.1" section added, tool table updated to 15, known limitations updated with shipped items struck through
- **Ontos_Agent_Instructions.md** — Header bumped to v4.1, MCP tool table expanded with portfolio and write tool sections, `--read-only` flag documented

### Changelog
- **Ontos_CHANGELOG.md** — Added 4 missing entries: v4.1.0, v4.0.0, v3.4.0, v3.3.1 (all Keep-a-Changelog format)

### Verification
- No stale `4.0.0` references in customer-facing docs (grep clean)
- `ontos doctor` — 8 passed, 0 failed

---
*Created by Antigravity (Claude Opus 4.6 Thinking). Merge requires explicit user approval.*