### PR TITLE
fix(mcp): omit export_graph outputSchema to unblock strict clients (#97)

### DIFF
--- a/docs/logs/2026-04-13_fix-mcp-export-graph-output-schema.md
+++ b/docs/logs/2026-04-13_fix-mcp-export-graph-output-schema.md
@@ -1,0 +1,113 @@
+---
+id: log_20260413_fix-mcp-export-graph-output-schema
+type: log
+status: active
+event_type: fix
+source: Claude Code
+branch: fix/mcp-export-graph-output-schema
+created: 2026-04-13
+---
+
+# Fix MCP export_graph outputSchema (issue #97, PR #98)
+
+## Summary
+
+Fixed a v4.1.1 defect where the `export_graph` tool advertised a root
+`{"oneOf": [...]}` outputSchema, violating the MCP spec (outputSchema
+describes `CallToolResult.structuredContent`, which must be an object).
+Claude Code's MCP client Zod-validates the entire `tools/list` response
+as one unit, so this single bad schema caused it to silently drop **all
+9** Ontos tools while the server still reported `Connected`.
+
+## Goal
+
+Ship the minimum point-release patch (Option B per issue #97) to unblock
+strict MCP clients, without touching runtime payload validation or the
+three-shape polymorphic return of `export_graph`. Defer the proper
+discriminated-union refactor (Option A) to 4.2.0.
+
+## Changes Made
+
+- `ontos/mcp/schemas.py` — `output_schema_for("export_graph")` now returns
+  `None` and has return type `Optional[Dict[str, Any]]`. Explanatory
+  docstring added. `EXPORT_GRAPH_ADAPTER`, `validate_success_payload`,
+  `ExportGraphResponse`, and `TOOL_SUCCESS_MODELS` untouched.
+- `ontos/mcp/server.py` (`register`) — skips `server.set_output_schema`
+  when the schema is `None`. `OntosFastMCP.list_tools()` already maps a
+  missing entry to `outputSchema=None` via `dict.get()`.
+- `tests/mcp/test_schemas.py` — replaced `test_export_graph_schema_is_one_of`
+  with `test_export_graph_schema_is_omitted`; loosened the validation-loop
+  assertion to accept `None`; added `test_every_advertised_output_schema_is_object_typed`
+  as a schema-layer regression guard over `TOOL_SUCCESS_MODELS`.
+- `tests/mcp/test_server_integration.py` — added two guards:
+  `test_list_tools_output_schemas_are_object_or_absent` (inspects
+  `list_tools()` return values) and `test_tools_list_wire_payload_has_object_typed_or_absent_output_schemas`
+  (a transport-level round-trip that mirrors the MCP SDK's exact wire
+  serialization at `mcp/shared/session.py:346` — `model_dump_json(by_alias=True,
+  exclude_none=True)` — re-parses the JSON, and asserts every tool entry
+  either omits `outputSchema` or types it as `object`, plus pins that
+  `export_graph` has no `outputSchema` key on the wire).
+
+## Key Decisions
+
+- **Option B over Option A in this PR.** The issue recommended the two-step
+  remediation; Option A requires a breaking change to the raw three-shape
+  response and belongs in a minor bump (4.2.0). Option B is a ~30-line
+  change that preserves runtime behavior identically.
+- **Omit the key vs. advertise an empty `{"type": "object"}`.** Chose
+  omission. Advertising `{"type": "object"}` with no properties would
+  disable structured validation on the client for `export_graph` but
+  imply *some* structured content is coming — omission is the more
+  honest signal until Option A lands.
+- **Transport-level wire test.** Added after reviewer flagged residual
+  coverage gap. The higher-level `list_tools()` assertion misses
+  serializer-layer regressions (e.g. a future Pydantic config change
+  that emits `outputSchema: null` instead of omitting the key — some
+  strict clients treat `null` as a validation failure). Test mirrors
+  the MCP SDK's exact `model_dump_json(by_alias=True, exclude_none=True)`
+  call so it pins the actual bytes Claude Code parses.
+
+## Alternatives Considered
+
+- **Option A now.** Rejected — breaking for any direct consumer of the
+  raw three-shape `export_graph` response; bundling it in a point
+  release would violate semver. Flagged as follow-up.
+- **Version bump + PyPI yank of 4.1.1 in this PR.** Out of scope.
+  `ontos/__init__.py` and `pyproject.toml` on `main` read `4.0.0`, so
+  the release train needs maintainer confirmation before tagging 4.1.2.
+
+## Testing
+
+- `pytest tests/mcp/test_schemas.py tests/mcp/test_server_integration.py`
+  → 13 passed (including the three new guards).
+- `pytest tests/mcp/` → 171 passed (was 170 pre-PR).
+- `pytest` (full repo) → 1138 passed, 2 skipped.
+- **Protocol-level repro** (from issue #97 appendix): JSON-RPC stdio
+  round-trip against `python3 -m ontos serve` on a freshly initialized
+  workspace. Every tool serialized `outputSchema.type == "object"`
+  except `export_graph`, which omitted the key entirely. Matches the
+  expected-fix output verbatim.
+- **Regression-catching verification** for the wire test: temporarily
+  force-restored the `oneOf` schema and re-ran the serializer; confirmed
+  the new guard would have failed.
+
+## Impacts
+
+- Claude Code (and any other strict-Zod MCP client) can now list and
+  call Ontos tools against an `ontos serve` instance that carries this
+  fix.
+- No behavior change for tool runtime or for lenient clients.
+- Future tools that reintroduce a non-object root outputSchema will be
+  caught at three layers: schema unit test, `list_tools()` integration
+  test, and serialized-wire round-trip.
+
+## Follow-ups
+
+- **4.2.0 Option A refactor.** Convert `ExportGraphResponse` to a
+  discriminated-union object (`mode: Literal["summary","full","file"]`
+  + optional payloads), re-advertise a proper object schema, update
+  `tools.export_graph()` callers. Breaking for direct consumers of the
+  raw three-shape response.
+- **Release-train reconciliation.** Confirm whether HEAD should ship
+  as 4.1.2 (point) or fold into 4.2.0 (minor bundled with Option A),
+  then yank 4.1.1 from PyPI.

--- a/ontos/mcp/schemas.py
+++ b/ontos/mcp/schemas.py
@@ -327,14 +327,18 @@ def validate_success_payload(tool_name: str, payload: Dict[str, Any]) -> Dict[st
     return normalized
 
 
-def output_schema_for(tool_name: str) -> Dict[str, Any]:
-    """Return the JSON Schema advertised for one tool."""
+def output_schema_for(tool_name: str) -> Optional[Dict[str, Any]]:
+    """Return the JSON Schema advertised for one tool, or ``None`` to omit it.
+
+    ``export_graph`` returns three distinct response shapes depending on its
+    arguments. MCP's ``Tool.outputSchema`` describes ``structuredContent``,
+    which must be an object — advertising a root ``oneOf`` has been observed
+    to trip strict clients (e.g., Claude Code) into discarding the entire
+    ``tools/list`` response. Until the response type is refactored into a
+    single discriminated object, we omit the schema so the client skips
+    structured-output validation for this one tool. Runtime payloads are
+    still validated via ``EXPORT_GRAPH_ADAPTER``.
+    """
     if tool_name == "export_graph":
-        return {
-            "oneOf": [
-                ExportGraphSummaryResponse.model_json_schema(by_alias=True),
-                ExportGraphFullResponse.model_json_schema(by_alias=True),
-                ExportGraphFileResponse.model_json_schema(by_alias=True),
-            ]
-        }
+        return None
     return TOOL_OUTPUT_SCHEMAS[tool_name]

--- a/ontos/mcp/server.py
+++ b/ontos/mcp/server.py
@@ -158,7 +158,9 @@ def create_server(
             meta=meta,
             structured_output=False,
         )(handler)
-        server.set_output_schema(name, output_schema_for(name))
+        schema = output_schema_for(name)
+        if schema is not None:
+            server.set_output_schema(name, schema)
 
     _register_core_tools(
         cache=cache,

--- a/tests/mcp/test_schemas.py
+++ b/tests/mcp/test_schemas.py
@@ -5,6 +5,7 @@ from ontos.mcp.schemas import (
     RenameDocumentResponse,
     ScaffoldDocumentResponse,
     TOOL_ERROR_SCHEMA,
+    TOOL_SUCCESS_MODELS,
     WriteToolErrorEnvelope,
     output_schema_for,
     validate_success_payload,
@@ -75,13 +76,25 @@ def test_success_payloads_validate_against_declared_schemas(tmp_path):
     for name, payload in payloads.items():
         normalized = validate_success_payload(name, payload)
         assert isinstance(normalized, dict)
-        assert output_schema_for(name)
+        schema = output_schema_for(name)
+        assert schema is None or schema.get("type") == "object"
 
 
-def test_export_graph_schema_is_one_of():
-    schema = output_schema_for("export_graph")
-    assert "oneOf" in schema
-    assert len(schema["oneOf"]) == 3
+def test_export_graph_schema_is_omitted():
+    # See schemas.output_schema_for: export_graph advertises no outputSchema
+    # because its three response shapes can't be expressed as a single object
+    # schema without a breaking change to the return type.
+    assert output_schema_for("export_graph") is None
+
+
+def test_every_advertised_output_schema_is_object_typed():
+    for name in TOOL_SUCCESS_MODELS:
+        schema = output_schema_for(name)
+        assert schema is None or schema["type"] == "object", (
+            f"Tool '{name}' advertises a non-object outputSchema; MCP clients "
+            "validate structuredContent as an object and will reject the "
+            "entire tools/list response."
+        )
 
 
 def test_write_tool_models_validate_success_payload_shapes():

--- a/tests/mcp/test_server_integration.py
+++ b/tests/mcp/test_server_integration.py
@@ -43,6 +43,16 @@ def test_server_lists_all_tools_with_correct_annotations(tmp_path):
         assert tool_map[name].annotations.readOnlyHint is True, f"{name} should be readOnly"
 
 
+def test_list_tools_output_schemas_are_object_or_absent(tmp_path):
+    root = create_workspace(tmp_path)
+    server = build_server(root)
+    for tool in list_tools(server):
+        assert tool.outputSchema is None or tool.outputSchema["type"] == "object", (
+            f"Tool '{tool.name}' advertises a non-object outputSchema; "
+            "strict MCP clients reject the entire tools/list response."
+        )
+
+
 def test_tool_descriptions_include_workspace_name(tmp_path):
     root = create_workspace(tmp_path)
     server = build_server(root)

--- a/tests/mcp/test_server_integration.py
+++ b/tests/mcp/test_server_integration.py
@@ -1,6 +1,9 @@
 """Integration tests for the MCP server (spec Section 7)."""
 
+import json
 from pathlib import Path
+
+from mcp.types import ListToolsResult
 
 from tests.mcp import build_cache, build_server, create_workspace, list_tools, write_file
 
@@ -51,6 +54,52 @@ def test_list_tools_output_schemas_are_object_or_absent(tmp_path):
             f"Tool '{tool.name}' advertises a non-object outputSchema; "
             "strict MCP clients reject the entire tools/list response."
         )
+
+
+def test_tools_list_wire_payload_has_object_typed_or_absent_output_schemas(tmp_path):
+    """Transport-level round-trip: serialize tools/list exactly as the MCP
+    SDK does on the wire (mcp/shared/session.py: model_dump(by_alias=True,
+    mode="json", exclude_none=True)), re-parse the JSON, and assert each
+    tool entry either omits ``outputSchema`` or types it as an object.
+
+    Higher-level tests inspect ``list_tools()`` return values, which can
+    mask bugs introduced by the Pydantic serializer (e.g. a future change
+    that emits ``outputSchema: null`` instead of omitting the key — some
+    strict clients treat ``null`` as a validation failure). This test
+    pins the actual bytes Claude Code parses.
+    """
+    root = create_workspace(tmp_path)
+    server = build_server(root)
+    result = ListToolsResult(tools=list_tools(server))
+
+    wire_json = result.model_dump_json(by_alias=True, exclude_none=True)
+    parsed = json.loads(wire_json)
+
+    tool_names = {entry["name"] for entry in parsed["tools"]}
+    assert "export_graph" in tool_names, "export_graph must still be advertised"
+
+    for entry in parsed["tools"]:
+        if "outputSchema" not in entry:
+            continue
+        schema = entry["outputSchema"]
+        assert isinstance(schema, dict), (
+            f"Tool '{entry['name']}' serialized outputSchema={schema!r}; "
+            "MCP clients expect an object or omission."
+        )
+        assert schema.get("type") == "object", (
+            f"Tool '{entry['name']}' wire outputSchema has type "
+            f"{schema.get('type')!r}; strict MCP clients (e.g. Claude Code) "
+            "reject the entire tools/list response when any outputSchema "
+            "is not root-typed as 'object'. See issue #97."
+        )
+
+    export_entry = next(t for t in parsed["tools"] if t["name"] == "export_graph")
+    assert "outputSchema" not in export_entry, (
+        "export_graph must NOT serialize an outputSchema key on the wire "
+        "until its response is refactored into a discriminated object "
+        "(Option A, deferred to 4.2.0). A serialized key of any value — "
+        "including null — risks regressing issue #97."
+    )
 
 
 def test_tool_descriptions_include_workspace_name(tmp_path):


### PR DESCRIPTION
## Summary

- `export_graph` advertised a root `{"oneOf": [...]}` outputSchema, which violates the MCP spec (outputSchema describes `CallToolResult.structuredContent`, always an object). Claude Code validates the entire `tools/list` response as one unit, so this single bad schema caused it to drop **all 9** Ontos tools while the server still reported `Connected`.
- `output_schema_for("export_graph")` now returns `None`, and `register()` skips `set_output_schema` when the schema is `None`. `list_tools()` already maps a missing entry to `outputSchema=None` via `dict.get()`. Runtime payload validation via `EXPORT_GRAPH_ADAPTER` is unchanged — the tool's three-shape polymorphic return is preserved.
- Adds two regression guards: `test_every_advertised_output_schema_is_object_typed` at the schema layer and `test_list_tools_output_schemas_are_object_or_absent` at the server-integration layer, so any future tool that reintroduces a root union trips the suite.

This is Option B from issue #97 — the minimum point-release patch. Option A (discriminated-union refactor of `ExportGraphResponse`) is out-of-scope and should land in a later 4.2.0 minor bump.

Fixes #97.

## Test plan

- [x] `pytest tests/mcp/test_schemas.py tests/mcp/test_server_integration.py -x` — 12 pass (incl. the two new guards and the updated `test_export_graph_schema_is_omitted`).
- [x] `pytest tests/mcp/ -x` — full MCP suite 170 pass; `test_export_graph_summary_and_full_payloads` and `test_export_graph_file_write_takes_precedence` confirm runtime behavior is unchanged.
- [x] `pytest -x` — full repo suite: 1138 passed, 2 skipped.
- [x] Protocol-level repro from the issue appendix: every tool prints `object` except `export_graph`, which prints `None`.
- [ ] Claude Code smoke test (manual, out-of-band for a reviewer with Claude Code installed): `claude mcp add ontos-dev <dev-bin> serve --workspace <ws> --read-only`, start a session, confirm `mcp__ontos__*` tools are listed, call `mcp__ontos__workspace_overview` and `mcp__ontos__export_graph`, and confirm `~/Library/Caches/claude-cli-nodejs/<session>/mcp-logs-ontos/*.jsonl` contains no `Failed to fetch tools` errors.

## Follow-up (not this PR)

- Option A: refactor `ExportGraphResponse` into a tagged object (`mode: Literal["summary","full","file"]` + optional payloads), re-advertise a proper object schema, update `tools.export_graph()`. Breaking change for direct consumers of the raw three-shape response — bundle with a minor bump.
- Version bump + changelog + PyPI yank of 4.1.1. `ontos/__init__.py` and `pyproject.toml` on `main` are versioned `4.0.0`, so the release train needs maintainer confirmation before tagging 4.1.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)