### PR TITLE
[codex] add Antigravity MCP onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The litmus test: *Can a new person (or AI) become productive in under 10 minutes
 ## Use Cases
 
 ### Multi-AI Workflows
-Switch between Claude Code, Cursor, ChatGPT, and Gemini without re-explaining your project. Ontos can generate `AGENTS.md` and `.cursorrules` so your context activates automatically when supported.
+Switch between Claude Code, Cursor, ChatGPT, and Gemini without re-explaining your project. Ontos can generate `AGENTS.md` and `.cursorrules` where instruction artifacts are supported, while native MCP clients use their own client-specific config.
 
 ### Prototype → Production
 Built a demo in Streamlit? When you rewrite in FastAPI or Next.js, your atoms are disposable but your strategy survives. Three weeks of product decisions don't vanish with the old code.
@@ -127,7 +127,7 @@ Built a demo in Streamlit? When you rewrite in FastAPI or Next.js, your atoms ar
 Pass a project to another developer or agency. Because you own your context, everything travels with `git clone`—session logs, context map, decision history. No export wizard, no platform migration, no 2-hour call.
 
 ### Native IDE Integration (MCP)
-Run `ontos serve` to start an MCP server that exposes your knowledge graph directly to AI agents. Claude Desktop, Cursor, and other MCP-compatible IDEs connect natively — no CLI parsing, no context map re-reads, just structured tool calls with live cache invalidation.
+Run `ontos serve` to start an MCP server that exposes your knowledge graph directly to AI agents. Claude Desktop and Cursor are configured directly below, and other MCP clients can connect once their client-specific manifest points at `ontos serve`.
 
 ```json
 {
@@ -182,7 +182,7 @@ pip install ontos
 ```
 
 > [!TIP]
-> **Want native AI IDE integration?** See [MCP Setup](#mcp-setup) below to enable `ontos serve` for Claude Desktop, Cursor, and other MCP-compatible tools.
+> **Want native AI IDE integration?** See [MCP Setup](#mcp-setup) below to enable `ontos serve` for Claude Desktop, Cursor, and Antigravity native agents.
 
 > [!NOTE]
 > **"command not found: ontos"?** Your Python scripts directory may not be on PATH.
@@ -289,6 +289,29 @@ The server runs over stdio — your IDE manages the process lifecycle.
 
 > [!NOTE]
 > Cursor launches the MCP server from your project root by default. If your project is elsewhere, add `"--workspace", "/path/to/your/project"` to the `args` array.
+
+**Antigravity native agents** (`~/.gemini/antigravity/mcp_config.json`):
+
+Use Ontos to create or update the native Antigravity config:
+
+```bash
+ontos mcp install --client antigravity
+```
+
+This writes an `mcpServers.ontos` entry that points at your current Ontos workspace:
+
+```json
+{
+  "mcpServers": {
+    "ontos": {
+      "command": "/absolute/path/to/ontos",
+      "args": ["serve", "--workspace", "/absolute/path/to/your/project", "--read-only"]
+    }
+  }
+}
+```
+
+Use `--write-enabled` if you want mutable MCP tools instead of the default read-only profile. This native config is separate from editor-level manifests and separate from `AGENTS.md` / `.cursorrules`.
 
 ### 4. Available Tools
 

--- a/README.md
+++ b/README.md
@@ -313,6 +313,19 @@ This writes an `mcpServers.ontos` entry that points at your current Ontos worksp
 
 Use `--write-enabled` if you want mutable MCP tools instead of the default read-only profile. This native config is separate from editor-level manifests and separate from `AGENTS.md` / `.cursorrules`.
 
+**Client support policy**
+
+Ontos treats MCP integration as two separate concerns:
+
+- **Server health** — `ontos serve` starts correctly and answers MCP requests.
+- **Client onboarding** — the client discovers Ontos tools through its own config contract.
+
+Support is client-specific:
+
+- **First-class** — stable native config contract, so Ontos can ship `ontos mcp install --client ...` plus `ontos doctor` coverage. Antigravity is the first client in this tier.
+- **Supported** — explicit setup docs today, with automation added only after the client contract proves stable. Claude Desktop and Cursor currently fit here.
+- **Evolving** — docs and diagnostics first, automation later if the config surface becomes stable enough. This is the likely path for CLI-native agents such as Claude Code and Codex.
+
 ### 4. Available Tools
 
 The MCP server exposes up to 15 tools depending on server flags:

--- a/docs/logs/2026-04-13_merge-pr100-antigravity-mcp-onboarding.md
+++ b/docs/logs/2026-04-13_merge-pr100-antigravity-mcp-onboarding.md
@@ -1,0 +1,79 @@
+---
+id: log_20260413_merge-pr100-antigravity-mcp-onboarding
+type: log
+status: active
+event_type: fix
+source: codex
+branch: codex/issue-99-antigravity-mcp
+created: 2026-04-13
+---
+
+# merge-pr100-antigravity-mcp-onboarding
+
+## Goal
+
+Archive the Antigravity native MCP onboarding work for issue #99, including
+the D.4 PR #100 review fixes, and record the branch as merge-ready after the
+requested doctor detection, install error handling, and `--write-enabled`
+coverage updates landed.
+
+## Root Cause
+
+Ontos had fixed the stdio transport and `tools/list` schema issues in `v4.1.1`
+and `v4.1.2`, but still had no native Antigravity onboarding path. Users could
+run a healthy `ontos serve` while Antigravity remained tool-less because
+`~/.gemini/antigravity/mcp_config.json` was never installed, validated, or
+diagnosed from the CLI.
+
+## Summary
+
+Added Antigravity-native MCP client installation via `ontos mcp install
+--client antigravity`, shared config validation and initialize probing, doctor
+coverage for native config health, and docs for the native config path and
+support model. After review, tightened Antigravity detection to the user-scoped
+config directory, converted install write failures into exit-2 environment
+errors, and added a CLI integration test for `--write-enabled`.
+
+## Key Decisions
+
+- Kept Antigravity as the only supported native installer target in this patch
+  line rather than broadening the PR to Cursor, Claude Code, Codex, or other
+  clients.
+- Defaulted generated client config to read-only and kept `--write-enabled`
+  explicit so MCP write tools remain opt-in.
+- Tightened doctor detection to `~/.gemini/antigravity/` existence so users who
+  only have the app installed are not forced through the probe path.
+- Caught `OSError` only around config writes in `ontos mcp install`; existing
+  read/load error handling remains owned by `load_antigravity_config`.
+- Left the Antigravity initialize probe timeout behavior unchanged in this PR
+  and treated probe configurability as a follow-up item.
+
+## Alternatives Considered
+
+- Expanding the same installer methodology to other MCP clients in PR #100:
+  rejected for this pass to keep the issue #99 fix narrowly scoped and
+  reviewable.
+- Using app-bundle detection as the doctor trigger:
+  rejected because it nudged users who never opted into Ontos integration and
+  combined badly with the probe subprocess.
+- Relying on chmod-based filesystem tests for install permission failures:
+  rejected in favor of a deterministic monkeypatched `PermissionError`.
+
+## Impacts
+
+- PR #100 closes issue #99 with an explicit, diagnosable Antigravity-native MCP
+  onboarding path.
+- `ontos doctor` now only checks Antigravity native config after a user-scoped
+  opt-in signal exists.
+- `ontos mcp install` reports write-path environment failures clearly instead of
+  surfacing them as internal CLI errors.
+- A follow-up remains for probe timeout/configurability after opt-in.
+
+## Testing
+
+- `pytest tests/commands/test_doctor_phase4.py -v`
+- `pytest tests/commands/test_mcp_command.py -v`
+- `pytest tests/commands/test_mcp_command.py tests/commands/test_doctor_phase4.py -v`
+- Temp-`HOME` smoke check for doctor skip/install/write-enabled behavior
+- Full `pytest` collection remains blocked in this environment because the
+  external `mcp` package is unavailable to `tests/mcp/*`

--- a/docs/reference/Migration_v3_to_v4.md
+++ b/docs/reference/Migration_v3_to_v4.md
@@ -225,6 +225,27 @@ All write paths (CLI and MCP) now use `workspace_lock()` with advisory flock on 
 }
 ```
 
+**Antigravity native agents** (`~/.gemini/antigravity/mcp_config.json`):
+
+```bash
+ontos mcp install --client antigravity
+```
+
+This command creates or updates the native Antigravity config with an `mcpServers.ontos` entry:
+
+```json
+{
+  "mcpServers": {
+    "ontos": {
+      "command": "/absolute/path/to/ontos",
+      "args": ["serve", "--workspace", "/absolute/path/to/your/project", "--read-only"]
+    }
+  }
+}
+```
+
+Use `--write-enabled` if you want mutable MCP tools. This native config is separate from `AGENTS.md` / `.cursorrules` and from any editor-level MCP manifest.
+
 ### 5. Enable Usage Logging (Optional)
 
 Add to `.ontos.toml`:

--- a/docs/reference/Migration_v3_to_v4.md
+++ b/docs/reference/Migration_v3_to_v4.md
@@ -246,6 +246,19 @@ This command creates or updates the native Antigravity config with an `mcpServer
 
 Use `--write-enabled` if you want mutable MCP tools. This native config is separate from `AGENTS.md` / `.cursorrules` and from any editor-level MCP manifest.
 
+### Client Support Policy
+
+Ontos now treats MCP enablement as two separate jobs:
+
+- **Server health** — `ontos serve` works.
+- **Client onboarding** — the client discovers Ontos tools through its own config contract.
+
+That philosophy should stay consistent across clients, while the automation level stays client-specific:
+
+- **First-class** clients get `ontos mcp install --client ...` plus `ontos doctor` checks once their native config contract is stable. Antigravity is the first example.
+- **Supported** clients keep explicit manual setup docs until Ontos can rely on a stable contract. Claude Desktop and Cursor remain in this tier for now.
+- **Evolving** clients should get docs and diagnostics first, with automation deferred until the contract settles. Claude Code and Codex are the obvious candidates here.
+
 ### 5. Enable Usage Logging (Optional)
 
 Add to `.ontos.toml`:

--- a/docs/reference/Ontos_Manual.md
+++ b/docs/reference/Ontos_Manual.md
@@ -699,6 +699,19 @@ Ontos writes or updates `mcpServers.ontos` in the native Antigravity config:
 
 Use `--write-enabled` to expose mutable MCP tools. This native config is separate from repo-local instruction artifacts such as `AGENTS.md` and `.cursorrules`.
 
+#### Client Support Policy
+
+Ontos treats MCP support as two layers:
+
+- **Server health** — `ontos serve` is healthy and answers MCP requests.
+- **Client onboarding** — the client actually discovers Ontos tools through its own config format.
+
+Apply the same philosophy across clients, but not the same installer blindly:
+
+- **First-class** clients have a stable native config contract, so Ontos can ship `ontos mcp install --client ...` and `ontos doctor` validation. Antigravity currently fits here.
+- **Supported** clients have clear manual config docs today, with automation deferred until the contract is stable enough. Claude Desktop and Cursor currently fit here.
+- **Evolving** clients should get docs and diagnostics first, then automation later if the config surface stabilizes. This is the expected path for CLI-native agents such as Claude Code and Codex.
+
 #### Available Tools
 
 | Tool | Description | Key Parameters |

--- a/docs/reference/Ontos_Manual.md
+++ b/docs/reference/Ontos_Manual.md
@@ -678,6 +678,27 @@ The server runs in the foreground and communicates via stdin/stdout. Press Ctrl+
 }
 ```
 
+**Antigravity native agents** (`~/.gemini/antigravity/mcp_config.json`):
+
+```bash
+ontos mcp install --client antigravity
+```
+
+Ontos writes or updates `mcpServers.ontos` in the native Antigravity config:
+
+```json
+{
+  "mcpServers": {
+    "ontos": {
+      "command": "/absolute/path/to/ontos",
+      "args": ["serve", "--workspace", "/absolute/path/to/your/project", "--read-only"]
+    }
+  }
+}
+```
+
+Use `--write-enabled` to expose mutable MCP tools. This native config is separate from repo-local instruction artifacts such as `AGENTS.md` and `.cursorrules`.
+
 #### Available Tools
 
 | Tool | Description | Key Parameters |

--- a/docs/releases/v4.1.3.md
+++ b/docs/releases/v4.1.3.md
@@ -79,6 +79,14 @@ README, manual, and migration guidance now include a dedicated Antigravity
 native-agent section and explicitly separate repo-local instruction artifacts
 from native MCP client config.
 
+### Support policy clarified
+
+This patch also makes the broader direction explicit: Ontos should apply the
+same MCP onboarding philosophy across major IDEs and CLIs, but not assume they
+all share the same config shape. Stable native contracts can get first-class
+install + doctor support; other clients should get docs and diagnostics first,
+then automation later.
+
 ## Acceptance
 
 - `ontos mcp install --client antigravity` creates a valid native config on a

--- a/docs/releases/v4.1.3.md
+++ b/docs/releases/v4.1.3.md
@@ -1,0 +1,88 @@
+---
+id: v413
+type: log
+status: active
+ontos_schema: 2.2
+event_type: release
+concepts: [mcp, antigravity, doctor, client-config]
+---
+
+# v4.1.3 — "Antigravity Onboarding"
+
+**Release date:** 2026-04-13
+
+Patch release closing issue [#99](https://github.com/ohjonathan/Project-Ontos/issues/99):
+Ontos now installs and diagnoses the native Antigravity MCP client config
+instead of leaving users to discover `~/.gemini/antigravity/mcp_config.json`
+and its `mcpServers` shape manually.
+
+---
+
+## Summary
+
+- `v4.1.1` fixed the stdio transport bug from `#95`.
+- `v4.1.2` fixed the `tools/list` schema defect that caused strict clients to
+  drop Ontos tools.
+- `v4.1.3` addresses the remaining Antigravity-native onboarding gap: the
+  server was healthy, but native Antigravity agents still had no Ontos tools
+  until the user wrote their own `mcp_config.json`.
+
+## Fixes
+
+### New native client installer
+
+Ontos now ships:
+
+```bash
+ontos mcp install --client antigravity
+```
+
+The command creates or updates:
+
+```text
+~/.gemini/antigravity/mcp_config.json
+```
+
+with:
+
+```json
+{
+  "mcpServers": {
+    "ontos": {
+      "command": "/absolute/path/to/ontos",
+      "args": ["serve", "--workspace", "/absolute/path/to/your/project", "--read-only"]
+    }
+  }
+}
+```
+
+- Existing non-Ontos `mcpServers` entries are preserved.
+- The default profile is read-only.
+- Pass `--write-enabled` to omit `--read-only` and expose write tools.
+
+### New `doctor` coverage
+
+`ontos doctor` now includes an `antigravity_mcp` check that reports:
+
+- Antigravity not detected
+- native config missing
+- empty config file
+- invalid JSON / invalid root shape
+- missing `mcpServers.ontos`
+- non-executable command
+- missing or invalid workspace path
+- direct MCP `initialize` probe failure
+
+### Docs updated
+
+README, manual, and migration guidance now include a dedicated Antigravity
+native-agent section and explicitly separate repo-local instruction artifacts
+from native MCP client config.
+
+## Acceptance
+
+- `ontos mcp install --client antigravity` creates a valid native config on a
+  fresh Antigravity install.
+- `ontos doctor` reports Antigravity config state with actionable remediation.
+- Users no longer need to infer that `#95` is fixed while Antigravity-native
+  setup was still missing.

--- a/ontos/cli.py
+++ b/ontos/cli.py
@@ -99,6 +99,7 @@ def create_parser(include_hidden: bool = True) -> argparse.ArgumentParser:
     _register_link_check(subparsers, global_parser)
     _register_rename(subparsers, global_parser)
     _register_env(subparsers, global_parser)
+    _register_mcp(subparsers, global_parser)
     _register_serve(subparsers, global_parser)
     _register_agents(subparsers, global_parser)
     _register_export(subparsers, global_parser)
@@ -294,6 +295,44 @@ def _register_env(subparsers, parent):
         help="Output format (default: text). Short flag -f is deprecated."
     )
     p.set_defaults(func=_cmd_env)
+
+
+def _register_mcp(subparsers, parent):
+    """Register MCP client config commands."""
+    mcp_parser = subparsers.add_parser(
+        "mcp",
+        help="Install native MCP client configuration",
+        parents=[parent],
+    )
+    mcp_parser.set_defaults(func=_cmd_mcp_root, mcp_command=None, _mcp_parser=mcp_parser)
+    mcp_subparsers = mcp_parser.add_subparsers(
+        dest="mcp_command",
+        title="mcp commands",
+        metavar="<command>",
+    )
+
+    install_parser = mcp_subparsers.add_parser(
+        "install",
+        help="Install or update a native MCP client config",
+        parents=[parent],
+    )
+    install_parser.add_argument(
+        "--client",
+        choices=["antigravity"],
+        required=True,
+        help="Native MCP client to configure",
+    )
+    install_parser.add_argument(
+        "--workspace",
+        type=Path,
+        help="Workspace path to serve (defaults to the current Ontos project root)",
+    )
+    install_parser.add_argument(
+        "--write-enabled",
+        action="store_true",
+        help="Generate a writable Ontos server entry (default: read-only)",
+    )
+    install_parser.set_defaults(func=_cmd_mcp_install)
 
 
 def _register_serve(subparsers, parent):
@@ -842,6 +881,45 @@ def _cmd_env(args) -> int:
             print(output)
     elif not args.quiet and output:
         print(output)
+
+    return exit_code
+
+
+def _cmd_mcp_root(args) -> int:
+    """Handle bare `ontos mcp` by showing help."""
+    parser = getattr(args, "_mcp_parser", None)
+    if args.json:
+        _emit_handler_result_json(
+            command="mcp",
+            exit_code=2,
+            message="No mcp subcommand specified",
+            error_code="E_NO_COMMAND",
+        )
+    elif parser is not None and not args.quiet:
+        parser.print_help()
+    return 2
+
+
+def _cmd_mcp_install(args) -> int:
+    """Handle `ontos mcp install`."""
+    from ontos.commands.mcp import MCPInstallOptions, _run_mcp_install_command
+
+    options = MCPInstallOptions(
+        client=args.client,
+        workspace=getattr(args, "workspace", None),
+        write_enabled=getattr(args, "write_enabled", False),
+    )
+    exit_code, message, data = _run_mcp_install_command(options)
+
+    if args.json:
+        _emit_handler_result_json(
+            command="mcp-install",
+            exit_code=exit_code,
+            message=message,
+            data=data,
+        )
+    elif not args.quiet:
+        print(message)
 
     return exit_code
 

--- a/ontos/commands/__init__.py
+++ b/ontos/commands/__init__.py
@@ -121,6 +121,11 @@ from ontos.commands.rename import (
     RenameOptions,
 )
 
+from ontos.commands.mcp import (
+    MCPInstallOptions,
+    mcp_install_command,
+)
+
 __all__ = [
     # Native orchestration (Phase 2)
     "GenerateMapOptions",
@@ -165,4 +170,6 @@ __all__ = [
     "MaintainOptions",
     "rename_command",
     "RenameOptions",
+    "MCPInstallOptions",
+    "mcp_install_command",
 ]

--- a/ontos/commands/doctor.py
+++ b/ontos/commands/doctor.py
@@ -2,8 +2,7 @@
 """
 Health check and diagnostics command.
 
-Implements 7 health checks per Roadmap 6.4 and Spec v1.1 Section 4.2.
-Decision: Option B (Standard) - all 7 checks with graceful error handling.
+Implements the CLI health checks with graceful error handling.
 """
 
 import shutil
@@ -554,6 +553,28 @@ def check_environment_manifests(repo_root: Optional[Path] = None) -> CheckResult
         )
 
 
+def check_antigravity_mcp() -> CheckResult:
+    """Check 10: Antigravity native MCP config status."""
+    from ontos.core.antigravity_mcp import inspect_antigravity_ontos_config
+
+    try:
+        inspection = inspect_antigravity_ontos_config()
+    except Exception as exc:
+        return CheckResult(
+            name="antigravity_mcp",
+            status="warning",
+            message="Antigravity MCP check failed",
+            details=str(exc),
+        )
+
+    return CheckResult(
+        name="antigravity_mcp",
+        status="success" if inspection.ok else "warning",
+        message=inspection.message,
+        details=inspection.details,
+    )
+
+
 def _get_config_path(repo_root: Optional[Path] = None) -> Optional[Path]:
     """Get config path if it exists."""
     root = resolve_project_root(repo_root=repo_root)
@@ -622,6 +643,7 @@ def _run_doctor_command(options: DoctorOptions) -> Tuple[int, DoctorResult]:
         check_cli_availability,
         lambda: check_agents_staleness(repo_root),
         lambda: check_environment_manifests(repo_root),
+        check_antigravity_mcp,
     ]
 
     for check_fn in checks:

--- a/ontos/commands/mcp.py
+++ b/ontos/commands/mcp.py
@@ -60,7 +60,13 @@ def _run_mcp_install_command(options: MCPInstallOptions) -> Tuple[int, str, Dict
 
     entry = build_antigravity_ontos_entry(workspace_root, write_enabled=options.write_enabled)
     updated_config, action = upsert_antigravity_ontos_entry(existing, entry)
-    write_antigravity_config(config_path, updated_config)
+    try:
+        write_antigravity_config(config_path, updated_config)
+    except OSError as exc:
+        return 2, f"Could not write config: {config_path}: {exc}", {
+            "config_path": str(config_path),
+            "error": str(exc),
+        }
 
     mode = "write-enabled" if options.write_enabled else "read-only"
     verb = "Created" if action == "created" else "Updated"

--- a/ontos/commands/mcp.py
+++ b/ontos/commands/mcp.py
@@ -1,0 +1,81 @@
+"""Client-side MCP configuration commands."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+from ontos.core.antigravity_mcp import (
+    AntigravityConfigError,
+    antigravity_config_path,
+    build_antigravity_ontos_entry,
+    load_antigravity_config,
+    upsert_antigravity_ontos_entry,
+    write_antigravity_config,
+)
+from ontos.io.files import find_project_root
+
+
+@dataclass
+class MCPInstallOptions:
+    """Configuration for `ontos mcp install`."""
+
+    client: str = "antigravity"
+    workspace: Optional[Path] = None
+    write_enabled: bool = False
+
+
+def _resolve_workspace_root(workspace: Optional[Path]) -> Tuple[int, Optional[Path], str]:
+    """Resolve the served workspace root for client config generation."""
+    start_path = workspace or Path.cwd()
+    resolved_start = start_path.expanduser().resolve()
+    if not resolved_start.exists():
+        return 2, None, f"Workspace path does not exist: {start_path}"
+
+    try:
+        workspace_root = find_project_root(start_path=resolved_start)
+    except FileNotFoundError as exc:
+        return 2, None, str(exc)
+
+    return 0, workspace_root, ""
+
+
+def _run_mcp_install_command(options: MCPInstallOptions) -> Tuple[int, str, Dict[str, str]]:
+    """Install or update a supported native MCP client config."""
+    if options.client != "antigravity":
+        return 2, f"Unsupported MCP client: {options.client}", {}
+
+    exit_code, workspace_root, error_message = _resolve_workspace_root(options.workspace)
+    if exit_code != 0 or workspace_root is None:
+        return exit_code, error_message, {}
+
+    config_path = antigravity_config_path()
+    existing = None
+    if config_path.exists():
+        try:
+            existing = load_antigravity_config(config_path)
+        except AntigravityConfigError as exc:
+            return 2, str(exc), {"config_path": str(config_path)}
+
+    entry = build_antigravity_ontos_entry(workspace_root, write_enabled=options.write_enabled)
+    updated_config, action = upsert_antigravity_ontos_entry(existing, entry)
+    write_antigravity_config(config_path, updated_config)
+
+    mode = "write-enabled" if options.write_enabled else "read-only"
+    verb = "Created" if action == "created" else "Updated"
+    message = f"{verb} Antigravity MCP config at {config_path}"
+    data = {
+        "client": options.client,
+        "action": action,
+        "config_path": str(config_path),
+        "workspace": str(workspace_root),
+        "mode": mode,
+    }
+    return 0, message, data
+
+
+def mcp_install_command(options: MCPInstallOptions) -> int:
+    """Run `ontos mcp install` and return an exit code."""
+    exit_code, _, _ = _run_mcp_install_command(options)
+    return exit_code

--- a/ontos/core/antigravity_mcp.py
+++ b/ontos/core/antigravity_mcp.py
@@ -1,0 +1,406 @@
+"""Helpers for Antigravity native MCP configuration."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+
+ANTIGRAVITY_CONFIG_RELATIVE_PATH = Path(".gemini") / "antigravity" / "mcp_config.json"
+
+INITIALIZE_REQUEST = {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+        "protocolVersion": "2024-11-05",
+        "capabilities": {},
+        "clientInfo": {"name": "ontos-antigravity-check", "version": "0"},
+    },
+}
+
+
+class AntigravityConfigError(ValueError):
+    """Raised when the native Antigravity config is malformed."""
+
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class AntigravityInstallation:
+    """Detected Antigravity installation details."""
+
+    config_path: Path
+    app_path: Optional[Path]
+    detected: bool
+
+
+@dataclass(frozen=True)
+class AntigravityProbeResult:
+    """Result of a lightweight MCP initialize probe."""
+
+    ok: bool
+    message: str
+    details: Optional[str] = None
+    server_info: Optional[Dict[str, Any]] = None
+
+
+@dataclass(frozen=True)
+class AntigravityInspection:
+    """Inspection result for the native Antigravity Ontos MCP entry."""
+
+    code: str
+    ok: bool
+    message: str
+    details: Optional[str]
+    config_path: Path
+    detected: bool
+    mode: Optional[str] = None
+    command: Optional[str] = None
+    args: Tuple[str, ...] = ()
+    workspace: Optional[Path] = None
+    probe: Optional[AntigravityProbeResult] = None
+
+
+def antigravity_config_path(home: Optional[Path] = None) -> Path:
+    """Return the native Antigravity config path."""
+    base_home = Path(home) if home is not None else Path.home()
+    return base_home.expanduser() / ANTIGRAVITY_CONFIG_RELATIVE_PATH
+
+
+def antigravity_app_candidates(home: Optional[Path] = None) -> List[Path]:
+    """Return possible Antigravity app bundle locations."""
+    base_home = Path(home) if home is not None else Path.home()
+    return [
+        Path("/Applications/Antigravity.app"),
+        base_home.expanduser() / "Applications" / "Antigravity.app",
+    ]
+
+
+def detect_antigravity_installation(home: Optional[Path] = None) -> AntigravityInstallation:
+    """Detect whether Antigravity is installed or already configured."""
+    config_path = antigravity_config_path(home=home)
+    app_path = next((path for path in antigravity_app_candidates(home=home) if path.exists()), None)
+    detected = app_path is not None or config_path.exists() or config_path.parent.exists()
+    return AntigravityInstallation(config_path=config_path, app_path=app_path, detected=detected)
+
+
+def resolve_ontos_launcher() -> Tuple[str, List[str]]:
+    """Resolve the preferred Ontos launcher for external MCP clients."""
+    ontos_path = shutil.which("ontos")
+    if ontos_path:
+        return str(Path(ontos_path).resolve()), []
+    return str(Path(sys.executable).resolve()), ["-m", "ontos"]
+
+
+def build_antigravity_ontos_entry(workspace_root: Path, *, write_enabled: bool = False) -> Dict[str, Any]:
+    """Build the native Antigravity entry for the served Ontos workspace."""
+    command, prefix_args = resolve_ontos_launcher()
+    args = [*prefix_args, "serve", "--workspace", str(workspace_root.expanduser().resolve())]
+    if not write_enabled:
+        args.append("--read-only")
+    return {"command": command, "args": args}
+
+
+def load_antigravity_config(path: Path) -> Dict[str, Any]:
+    """Load and validate the top-level Antigravity config document."""
+    if not path.exists():
+        raise AntigravityConfigError("missing", f"Antigravity MCP config not found: {path}")
+
+    try:
+        if path.stat().st_size == 0:
+            raise AntigravityConfigError("empty", f"Antigravity MCP config is empty: {path}")
+    except OSError as exc:
+        raise AntigravityConfigError("unreadable", f"Could not read Antigravity MCP config: {exc}") from exc
+
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise AntigravityConfigError("unreadable", f"Could not read Antigravity MCP config: {exc}") from exc
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise AntigravityConfigError("invalid_json", f"Antigravity MCP config is invalid JSON: {path}") from exc
+
+    if not isinstance(data, dict):
+        raise AntigravityConfigError("invalid_root", "Antigravity MCP config root must be a JSON object")
+
+    servers = data.get("mcpServers")
+    if servers is not None and not isinstance(servers, dict):
+        raise AntigravityConfigError("invalid_root", "Antigravity MCP config field 'mcpServers' must be an object")
+
+    return data
+
+
+def write_antigravity_config(path: Path, data: Dict[str, Any]) -> None:
+    """Write the native Antigravity config with stable formatting."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def upsert_antigravity_ontos_entry(existing: Optional[Dict[str, Any]], entry: Dict[str, Any]) -> Tuple[Dict[str, Any], str]:
+    """Upsert only the Ontos server entry while preserving other servers."""
+    action = "created" if existing is None else "updated"
+    payload: Dict[str, Any] = dict(existing or {})
+    servers = payload.setdefault("mcpServers", {})
+    if not isinstance(servers, dict):
+        raise AntigravityConfigError("invalid_root", "Antigravity MCP config field 'mcpServers' must be an object")
+    servers["ontos"] = entry
+    return payload, action
+
+
+def extract_workspace_arg(args: List[str]) -> Optional[Path]:
+    """Extract the workspace argument from an Ontos stdio command line."""
+    for index, value in enumerate(args):
+        if value == "--workspace" and index + 1 < len(args):
+            return Path(args[index + 1]).expanduser()
+        if value.startswith("--workspace="):
+            return Path(value.split("=", 1)[1]).expanduser()
+    return None
+
+
+def resolve_executable(command: str) -> Optional[str]:
+    """Resolve a command to an executable path if possible."""
+    if not command:
+        return None
+    if os.path.sep in command or (os.path.altsep and os.path.altsep in command):
+        candidate = Path(command).expanduser()
+        if candidate.exists() and os.access(candidate, os.X_OK):
+            return str(candidate.resolve())
+        return None
+    resolved = shutil.which(command)
+    if not resolved:
+        return None
+    return str(Path(resolved).resolve())
+
+
+def probe_mcp_initialize(command: str, args: List[str], *, timeout: int = 15) -> AntigravityProbeResult:
+    """Probe the configured command with one MCP initialize request."""
+    payload = json.dumps(INITIALIZE_REQUEST) + "\n"
+
+    try:
+        result = subprocess.run(
+            [command, *args],
+            input=payload,
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError as exc:
+        return AntigravityProbeResult(ok=False, message="initialize probe failed", details=str(exc))
+    except subprocess.TimeoutExpired as exc:
+        return AntigravityProbeResult(ok=False, message="initialize probe timed out", details=str(exc))
+    except OSError as exc:
+        return AntigravityProbeResult(ok=False, message="initialize probe failed", details=str(exc))
+
+    if result.returncode != 0:
+        details = result.stderr.strip() or result.stdout.strip() or f"exit code {result.returncode}"
+        return AntigravityProbeResult(ok=False, message="initialize probe failed", details=details)
+
+    stdout = result.stdout.strip()
+    if not stdout:
+        return AntigravityProbeResult(ok=False, message="initialize probe failed", details="stdout was empty")
+
+    first_line = stdout.splitlines()[0]
+    try:
+        response = json.loads(first_line)
+    except json.JSONDecodeError as exc:
+        return AntigravityProbeResult(
+            ok=False,
+            message="initialize probe failed",
+            details=f"Invalid JSON-RPC response: {exc}",
+        )
+
+    result_payload = response.get("result")
+    if not isinstance(result_payload, dict):
+        return AntigravityProbeResult(
+            ok=False,
+            message="initialize probe failed",
+            details=f"Unexpected response payload: {response}",
+        )
+
+    server_info = result_payload.get("serverInfo")
+    return AntigravityProbeResult(
+        ok=True,
+        message="initialize probe passed",
+        server_info=server_info if isinstance(server_info, dict) else None,
+    )
+
+
+def inspect_antigravity_ontos_config(home: Optional[Path] = None) -> AntigravityInspection:
+    """Inspect the native Antigravity Ontos MCP configuration."""
+    installation = detect_antigravity_installation(home=home)
+    config_path = installation.config_path
+
+    if not installation.detected:
+        return AntigravityInspection(
+            code="not_detected",
+            ok=True,
+            message="Antigravity not detected; skipping native MCP config check",
+            details=None,
+            config_path=config_path,
+            detected=False,
+        )
+
+    if not config_path.exists():
+        return AntigravityInspection(
+            code="missing",
+            ok=False,
+            message="Antigravity native MCP config is missing",
+            details=f"Run 'ontos mcp install --client antigravity' to create {config_path}.",
+            config_path=config_path,
+            detected=True,
+        )
+
+    try:
+        data = load_antigravity_config(config_path)
+    except AntigravityConfigError as exc:
+        detail_map = {
+            "empty": f"Run 'ontos mcp install --client antigravity' to write {config_path}.",
+            "invalid_json": f"Fix or remove {config_path}, then rerun 'ontos mcp install --client antigravity'.",
+            "invalid_root": f"Fix or remove {config_path}, then rerun 'ontos mcp install --client antigravity'.",
+            "unreadable": str(exc),
+        }
+        return AntigravityInspection(
+            code=exc.code,
+            ok=False,
+            message=str(exc),
+            details=detail_map.get(exc.code, str(exc)),
+            config_path=config_path,
+            detected=True,
+        )
+
+    servers = data.get("mcpServers") or {}
+    entry = servers.get("ontos")
+    if not isinstance(entry, dict):
+        return AntigravityInspection(
+            code="missing_ontos_entry",
+            ok=False,
+            message="Antigravity config is missing mcpServers.ontos",
+            details="Run 'ontos mcp install --client antigravity' to add the Ontos server entry.",
+            config_path=config_path,
+            detected=True,
+        )
+
+    command = entry.get("command")
+    args = entry.get("args") or []
+    if not isinstance(command, str) or not command.strip():
+        return AntigravityInspection(
+            code="bad_command",
+            ok=False,
+            message="Antigravity Ontos entry is missing a valid command",
+            details="Run 'ontos mcp install --client antigravity' to regenerate the Ontos entry.",
+            config_path=config_path,
+            detected=True,
+        )
+    if not isinstance(args, list) or any(not isinstance(item, str) for item in args):
+        return AntigravityInspection(
+            code="bad_command",
+            ok=False,
+            message="Antigravity Ontos entry has invalid args",
+            details="Expected 'args' to be a list of strings.",
+            config_path=config_path,
+            detected=True,
+            command=command,
+        )
+
+    if resolve_executable(command) is None:
+        return AntigravityInspection(
+            code="bad_command",
+            ok=False,
+            message=f"Antigravity Ontos command is not executable: {command}",
+            details="Run 'ontos mcp install --client antigravity' to rewrite the command path.",
+            config_path=config_path,
+            detected=True,
+            command=command,
+            args=tuple(args),
+        )
+
+    if "serve" not in args:
+        return AntigravityInspection(
+            code="bad_command",
+            ok=False,
+            message="Antigravity Ontos entry does not invoke 'serve'",
+            details="Expected args to include 'serve'.",
+            config_path=config_path,
+            detected=True,
+            command=command,
+            args=tuple(args),
+        )
+
+    workspace = extract_workspace_arg(args)
+    if workspace is None:
+        return AntigravityInspection(
+            code="bad_workspace",
+            ok=False,
+            message="Antigravity Ontos entry is missing --workspace",
+            details="Run 'ontos mcp install --client antigravity' to add an absolute workspace path.",
+            config_path=config_path,
+            detected=True,
+            command=command,
+            args=tuple(args),
+        )
+    if not workspace.is_absolute():
+        return AntigravityInspection(
+            code="bad_workspace",
+            ok=False,
+            message="Antigravity Ontos workspace must be an absolute path",
+            details=f"Observed workspace: {workspace}",
+            config_path=config_path,
+            detected=True,
+            command=command,
+            args=tuple(args),
+            workspace=workspace,
+        )
+    if not workspace.exists():
+        return AntigravityInspection(
+            code="bad_workspace",
+            ok=False,
+            message=f"Antigravity Ontos workspace does not exist: {workspace}",
+            details="Run 'ontos mcp install --client antigravity --workspace /absolute/path' with a valid project root.",
+            config_path=config_path,
+            detected=True,
+            command=command,
+            args=tuple(args),
+            workspace=workspace,
+        )
+
+    mode = "read-only" if "--read-only" in args else "write-enabled"
+    probe = probe_mcp_initialize(command, args)
+    if not probe.ok:
+        return AntigravityInspection(
+            code="probe_failed",
+            ok=False,
+            message="Antigravity Ontos entry failed a direct MCP initialize probe",
+            details=probe.details or probe.message,
+            config_path=config_path,
+            detected=True,
+            mode=mode,
+            command=command,
+            args=tuple(args),
+            workspace=workspace,
+            probe=probe,
+        )
+
+    return AntigravityInspection(
+        code="ok",
+        ok=True,
+        message=f"Antigravity Ontos entry valid ({mode})",
+        details=None,
+        config_path=config_path,
+        detected=True,
+        mode=mode,
+        command=command,
+        args=tuple(args),
+        workspace=workspace,
+        probe=probe,
+    )

--- a/ontos/core/antigravity_mcp.py
+++ b/ontos/core/antigravity_mcp.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 
 ANTIGRAVITY_CONFIG_RELATIVE_PATH = Path(".gemini") / "antigravity" / "mcp_config.json"
@@ -76,21 +76,11 @@ def antigravity_config_path(home: Optional[Path] = None) -> Path:
     return base_home.expanduser() / ANTIGRAVITY_CONFIG_RELATIVE_PATH
 
 
-def antigravity_app_candidates(home: Optional[Path] = None) -> List[Path]:
-    """Return possible Antigravity app bundle locations."""
-    base_home = Path(home) if home is not None else Path.home()
-    return [
-        Path("/Applications/Antigravity.app"),
-        base_home.expanduser() / "Applications" / "Antigravity.app",
-    ]
-
-
 def detect_antigravity_installation(home: Optional[Path] = None) -> AntigravityInstallation:
-    """Detect whether Antigravity is installed or already configured."""
+    """Detect whether the user has created Antigravity native MCP config state."""
     config_path = antigravity_config_path(home=home)
-    app_path = next((path for path in antigravity_app_candidates(home=home) if path.exists()), None)
-    detected = app_path is not None or config_path.exists() or config_path.parent.exists()
-    return AntigravityInstallation(config_path=config_path, app_path=app_path, detected=detected)
+    detected = config_path.parent.exists()
+    return AntigravityInstallation(config_path=config_path, app_path=None, detected=detected)
 
 
 def resolve_ontos_launcher() -> Tuple[str, List[str]]:

--- a/tests/commands/test_antigravity_mcp_docs.py
+++ b/tests/commands/test_antigravity_mcp_docs.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def test_readme_mentions_antigravity_native_mcp_setup() -> None:
+    content = _read("README.md")
+
+    for token in (
+        "Antigravity native agents",
+        "~/.gemini/antigravity/mcp_config.json",
+        "ontos mcp install --client antigravity",
+    ):
+        assert token in content
+
+
+def test_manual_and_migration_guide_mention_antigravity_native_mcp_setup() -> None:
+    for path in ("docs/reference/Ontos_Manual.md", "docs/reference/Migration_v3_to_v4.md"):
+        content = _read(path)
+        for token in (
+            "~/.gemini/antigravity/mcp_config.json",
+            "ontos mcp install --client antigravity",
+            '"mcpServers"',
+        ):
+            assert token in content, f"Missing {token!r} from {path}"
+
+
+def test_v413_release_notes_cover_issue_99_antigravity_fix() -> None:
+    content = _read("docs/releases/v4.1.3.md")
+    assert "#99" in content
+    assert "Antigravity" in content
+    assert "ontos mcp install --client antigravity" in content

--- a/tests/commands/test_doctor_phase4.py
+++ b/tests/commands/test_doctor_phase4.py
@@ -12,6 +12,7 @@ from ontos.commands.doctor import (
     CheckResult,
     DoctorOptions,
     DoctorResult,
+    check_antigravity_mcp,
     check_docs_directory,
     check_configuration,
     check_git_hooks,
@@ -46,15 +47,15 @@ class TestDoctorResult:
     """Tests for DoctorResult dataclass."""
 
     def test_status_pass_when_no_failures(self):
-        result = DoctorResult(passed=7, failed=0, warnings=0)
+        result = DoctorResult(passed=8, failed=0, warnings=0)
         assert result.status == "success"
 
     def test_status_fail_when_has_failures(self):
-        result = DoctorResult(passed=5, failed=2, warnings=0)
+        result = DoctorResult(passed=6, failed=2, warnings=0)
         assert result.status == "failed"
 
     def test_status_warn_when_only_warnings(self):
-        result = DoctorResult(passed=5, failed=0, warnings=2)
+        result = DoctorResult(passed=6, failed=0, warnings=2)
         assert result.status == "warning"
 
 
@@ -115,10 +116,11 @@ class TestDoctorCommand:
              patch("ontos.commands.doctor.check_validation") as mock_valid, \
              patch("ontos.commands.doctor.check_cli_availability") as mock_cli, \
              patch("ontos.commands.doctor.check_agents_staleness") as mock_agents, \
-             patch("ontos.commands.doctor.check_environment_manifests") as mock_env:
+             patch("ontos.commands.doctor.check_environment_manifests") as mock_env, \
+             patch("ontos.commands.doctor.check_antigravity_mcp") as mock_antigravity:
 
             for mock in [mock_config, mock_hooks, mock_python, mock_docs,
-                        mock_map, mock_valid, mock_cli, mock_agents, mock_env]:
+                        mock_map, mock_valid, mock_cli, mock_agents, mock_env, mock_antigravity]:
                 mock.return_value = CheckResult(
                     name="test", status="success", message="OK"
                 )
@@ -128,7 +130,7 @@ class TestDoctorCommand:
             exit_code, result = _run_doctor_command(options)
 
             assert exit_code == 0
-            assert result.passed == 9
+            assert result.passed == 10
             assert result.failed == 0
 
     def test_returns_exit_code_1_when_check_fails(self):
@@ -141,10 +143,11 @@ class TestDoctorCommand:
              patch("ontos.commands.doctor.check_validation") as mock_valid, \
              patch("ontos.commands.doctor.check_cli_availability") as mock_cli, \
              patch("ontos.commands.doctor.check_agents_staleness") as mock_agents, \
-             patch("ontos.commands.doctor.check_environment_manifests") as mock_env:
+             patch("ontos.commands.doctor.check_environment_manifests") as mock_env, \
+             patch("ontos.commands.doctor.check_antigravity_mcp") as mock_antigravity:
 
             for mock in [mock_hooks, mock_python, mock_docs,
-                        mock_map, mock_valid, mock_cli, mock_agents, mock_env]:
+                        mock_map, mock_valid, mock_cli, mock_agents, mock_env, mock_antigravity]:
                 mock.return_value = CheckResult(
                     name="test", status="success", message="OK"
                 )
@@ -274,6 +277,47 @@ class TestCheckAgentsStaleness:
         
         assert result.status == "warning"
         assert "no source files" in result.message.lower()
+
+
+class TestCheckAntigravityMCP:
+    """Tests for check_antigravity_mcp."""
+
+    def test_skips_cleanly_when_not_detected(self):
+        with patch("ontos.core.antigravity_mcp.inspect_antigravity_ontos_config") as mock_inspect:
+            from ontos.core.antigravity_mcp import AntigravityInspection
+
+            mock_inspect.return_value = AntigravityInspection(
+                code="not_detected",
+                ok=True,
+                message="Antigravity not detected; skipping native MCP config check",
+                details=None,
+                config_path=Path("/tmp/mcp_config.json"),
+                detected=False,
+            )
+
+            result = check_antigravity_mcp()
+
+        assert result.status == "success"
+        assert "skipping" in result.message.lower()
+
+    def test_warns_when_native_config_is_missing(self):
+        with patch("ontos.core.antigravity_mcp.inspect_antigravity_ontos_config") as mock_inspect:
+            from ontos.core.antigravity_mcp import AntigravityInspection
+
+            mock_inspect.return_value = AntigravityInspection(
+                code="missing",
+                ok=False,
+                message="Antigravity native MCP config is missing",
+                details="Run 'ontos mcp install --client antigravity'",
+                config_path=Path("/tmp/mcp_config.json"),
+                detected=True,
+            )
+
+            result = check_antigravity_mcp()
+
+        assert result.status == "warning"
+        assert "missing" in result.message.lower()
+        assert "mcp install" in (result.details or "")
 
 
 def test_check_docs_directory_scope_library_includes_internal(tmp_path, monkeypatch):

--- a/tests/commands/test_mcp_command.py
+++ b/tests/commands/test_mcp_command.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import json
+import os
+import site
+import subprocess
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run_ontos(
+    cwd: Path,
+    *args: str,
+    home: Path,
+    path_override: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    pythonpath_entries = [str(PROJECT_ROOT)]
+    for entry in [site.getusersitepackages(), *site.getsitepackages()]:
+        if entry and entry not in pythonpath_entries:
+            pythonpath_entries.append(entry)
+    env["PYTHONPATH"] = os.pathsep.join(pythonpath_entries)
+    env["HOME"] = str(home)
+    if path_override is not None:
+        env["PATH"] = path_override
+    return subprocess.run(
+        [sys.executable, "-m", "ontos", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def _init_workspace(root: Path) -> None:
+    (root / ".ontos.toml").write_text("[ontos]\nversion = '4.1'\n", encoding="utf-8")
+    (root / "docs").mkdir()
+    (root / "docs" / "doc.md").write_text(
+        "---\nid: sample\ntype: atom\nstatus: active\n---\n",
+        encoding="utf-8",
+    )
+
+
+def test_mcp_install_creates_antigravity_config_with_read_only_default(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    home = tmp_path / "home"
+    workspace.mkdir()
+    home.mkdir()
+    _init_workspace(workspace)
+
+    result = _run_ontos(
+        workspace,
+        "mcp",
+        "install",
+        "--client",
+        "antigravity",
+        home=home,
+    )
+
+    assert result.returncode == 0, result.stderr
+    config_path = home / ".gemini" / "antigravity" / "mcp_config.json"
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+
+    entry = payload["mcpServers"]["ontos"]
+    assert Path(entry["command"]).is_absolute()
+    assert entry["args"][-1] == "--read-only"
+    assert "--workspace" in entry["args"]
+    workspace_index = entry["args"].index("--workspace")
+    assert entry["args"][workspace_index + 1] == str(workspace.resolve())
+
+
+def test_mcp_install_merges_existing_servers(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    home = tmp_path / "home"
+    workspace.mkdir()
+    home.mkdir()
+    _init_workspace(workspace)
+
+    config_path = home / ".gemini" / "antigravity" / "mcp_config.json"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "github-mcp-server": {
+                        "command": "docker",
+                        "args": ["run", "-i", "--rm", "ghcr.io/github/github-mcp-server"],
+                    }
+                }
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = _run_ontos(
+        workspace,
+        "mcp",
+        "install",
+        "--client",
+        "antigravity",
+        home=home,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    assert "github-mcp-server" in payload["mcpServers"]
+    assert "ontos" in payload["mcpServers"]
+
+
+def test_mcp_install_falls_back_to_python_module_when_ontos_not_on_path(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    home = tmp_path / "home"
+    workspace.mkdir()
+    home.mkdir()
+    _init_workspace(workspace)
+
+    result = _run_ontos(
+        workspace,
+        "mcp",
+        "install",
+        "--client",
+        "antigravity",
+        home=home,
+        path_override="/usr/bin:/bin",
+    )
+
+    assert result.returncode == 0, result.stderr
+    config_path = home / ".gemini" / "antigravity" / "mcp_config.json"
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    entry = payload["mcpServers"]["ontos"]
+    assert entry["command"] == str(Path(sys.executable).resolve())
+    assert entry["args"][:3] == ["-m", "ontos", "serve"]
+
+
+def test_mcp_install_rejects_invalid_existing_json_without_rewriting(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    home = tmp_path / "home"
+    workspace.mkdir()
+    home.mkdir()
+    _init_workspace(workspace)
+
+    config_path = home / ".gemini" / "antigravity" / "mcp_config.json"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text("{ invalid json\n", encoding="utf-8")
+    original = config_path.read_text(encoding="utf-8")
+
+    result = _run_ontos(
+        workspace,
+        "mcp",
+        "install",
+        "--client",
+        "antigravity",
+        home=home,
+    )
+
+    assert result.returncode == 2
+    assert "invalid json" in result.stdout.lower() or "invalid json" in result.stderr.lower()
+    assert config_path.read_text(encoding="utf-8") == original
+
+
+def test_mcp_install_json_envelope_reports_created_config(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    home = tmp_path / "home"
+    workspace.mkdir()
+    home.mkdir()
+    _init_workspace(workspace)
+
+    result = _run_ontos(
+        workspace,
+        "--json",
+        "mcp",
+        "install",
+        "--client",
+        "antigravity",
+        home=home,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["command"] == "mcp-install"
+    assert payload["data"]["client"] == "antigravity"
+    assert payload["data"]["mode"] == "read-only"

--- a/tests/commands/test_mcp_command.py
+++ b/tests/commands/test_mcp_command.py
@@ -7,6 +7,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from ontos.commands.mcp import MCPInstallOptions, _run_mcp_install_command
+
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
@@ -185,3 +187,26 @@ def test_mcp_install_json_envelope_reports_created_config(tmp_path: Path) -> Non
     assert payload["command"] == "mcp-install"
     assert payload["data"]["client"] == "antigravity"
     assert payload["data"]["mode"] == "read-only"
+
+
+def test_mcp_install_unwritable_config_dir(tmp_path: Path, monkeypatch) -> None:
+    workspace = tmp_path / "workspace"
+    home = tmp_path / "home"
+    workspace.mkdir()
+    home.mkdir()
+    _init_workspace(workspace)
+    monkeypatch.chdir(workspace)
+    monkeypatch.setenv("HOME", str(home))
+
+    def _raise_permission_error(path: Path, data: dict) -> None:
+        raise PermissionError("Permission denied")
+
+    monkeypatch.setattr("ontos.commands.mcp.write_antigravity_config", _raise_permission_error)
+
+    exit_code, message, data = _run_mcp_install_command(MCPInstallOptions(client="antigravity"))
+
+    assert exit_code == 2
+    assert message.startswith("Could not write config:")
+    assert str(home / ".gemini" / "antigravity" / "mcp_config.json") in message
+    assert data["config_path"] == str(home / ".gemini" / "antigravity" / "mcp_config.json")
+    assert data["error"] == "Permission denied"

--- a/tests/commands/test_mcp_command.py
+++ b/tests/commands/test_mcp_command.py
@@ -189,6 +189,34 @@ def test_mcp_install_json_envelope_reports_created_config(tmp_path: Path) -> Non
     assert payload["data"]["mode"] == "read-only"
 
 
+def test_mcp_install_write_enabled_omits_read_only(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    home = tmp_path / "home"
+    workspace.mkdir()
+    home.mkdir()
+    _init_workspace(workspace)
+
+    result = _run_ontos(
+        workspace,
+        "--json",
+        "mcp",
+        "install",
+        "--client",
+        "antigravity",
+        "--write-enabled",
+        home=home,
+    )
+
+    assert result.returncode == 0, result.stderr
+    envelope = json.loads(result.stdout)
+    assert envelope["data"]["mode"] == "write-enabled"
+
+    config_path = home / ".gemini" / "antigravity" / "mcp_config.json"
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    entry = payload["mcpServers"]["ontos"]
+    assert "--read-only" not in entry["args"]
+
+
 def test_mcp_install_unwritable_config_dir(tmp_path: Path, monkeypatch) -> None:
     workspace = tmp_path / "workspace"
     home = tmp_path / "home"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -76,7 +76,7 @@ class TestUnifiedCLI:
 
     # Test all v3.0 commands respond to --help
     @pytest.mark.parametrize("command", [
-        'init', 'map', 'log', 'doctor', 'maintain', 'link-check', 'agents', 'export', 'hook', 'agent-export',
+        'init', 'map', 'log', 'doctor', 'maintain', 'link-check', 'agents', 'export', 'mcp', 'hook', 'agent-export',
         'verify', 'query', 'migrate', 'consolidate', 'promote', 'scaffold', 'stub', 'env', 'rename',
         'tree', 'validate'
     ])
@@ -161,7 +161,7 @@ class TestCLICommands:
         """All v3.0 commands should appear in --help output."""
         result = self.run_cli('--help')
         expected_commands = [
-            'init', 'map', 'log', 'doctor', 'maintain', 'link-check', 'agents', 'export',
+            'init', 'map', 'log', 'doctor', 'maintain', 'link-check', 'agents', 'export', 'mcp',
             'verify', 'query', 'migrate', 'consolidate', 'promote', 'scaffold', 'stub', 'env', 'rename'
         ]
         for cmd in expected_commands:
@@ -184,6 +184,11 @@ class TestCLICommands:
     def test_agents_runs(self):
         """agents command should run without crashing."""
         result = self.run_cli('agents', '--help')
+        assert result.returncode == 0
+
+    def test_mcp_runs(self):
+        """mcp command should run without crashing."""
+        result = self.run_cli('mcp', '--help')
         assert result.returncode == 0
 
 

--- a/tests/test_cli_phase4.py
+++ b/tests/test_cli_phase4.py
@@ -99,6 +99,16 @@ class TestCLICommands:
         assert "data" in result.stdout.lower()
         assert "claude" in result.stdout.lower()
 
+    def test_mcp_install_help(self):
+        """mcp install --help should work."""
+        result = subprocess.run(
+            [sys.executable, "-m", "ontos", "mcp", "install", "--help"],
+            capture_output=True, text=True
+        )
+        assert result.returncode == 0
+        assert "antigravity" in result.stdout.lower()
+        assert "write-enabled" in result.stdout.lower()
+
     def test_hook_help(self):
         """hook --help should work."""
         result = subprocess.run(
@@ -192,6 +202,9 @@ class TestCLIDoctorCommand:
     def test_doctor_json(self, tmp_path, monkeypatch):
         """--json doctor should output JSON."""
         monkeypatch.chdir(tmp_path)
+        (tmp_path / ".ontos.toml").write_text("[ontos]\nversion = '3.0'\n")
+        (tmp_path / "docs").mkdir()
+        (tmp_path / "docs" / "doc.md").write_text("---\nid: sample\ntype: atom\nstatus: active\n---\n")
         result = subprocess.run(
             [sys.executable, "-m", "ontos", "--json", "doctor"],
             capture_output=True, text=True
@@ -200,6 +213,7 @@ class TestCLIDoctorCommand:
         assert "status" in data
         assert "data" in data
         assert "checks" in data["data"]
+        assert any(check["name"] == "antigravity_mcp" for check in data["data"]["checks"])
 
 
 class TestCLIExportCommand:


### PR DESCRIPTION
## Summary
- add a native MCP client installer via `ontos mcp install --client antigravity`
- add shared Antigravity config validation and direct MCP initialize probing
- extend `ontos doctor` with an `antigravity_mcp` check and remediation guidance
- document Antigravity-native setup in the README, manual, migration guide, and a new `v4.1.3` release note

## Root Cause
`v4.1.1` fixed the stdio transport bug from #95 and `v4.1.2` fixed the `tools/list` schema defect, but Ontos still had no Antigravity-native onboarding path. The server could be healthy while native Antigravity agents had no Ontos tools because `~/.gemini/antigravity/mcp_config.json` was never installed or validated.

## What Changed
- new CLI surface: `ontos mcp install --client antigravity`
- default generated Antigravity config is read-only; `--write-enabled` opts into mutable MCP tools
- installer preserves existing non-Ontos `mcpServers` entries and only upserts `mcpServers.ontos`
- `doctor` now checks for missing, empty, invalid, or broken Antigravity config and runs a lightweight initialize probe
- docs now separate repo-local instruction artifacts from native MCP client config

## Validation
- `pytest tests/commands/test_mcp_command.py tests/commands/test_doctor_phase4.py tests/test_cli.py tests/test_cli_phase4.py tests/commands/test_antigravity_mcp_docs.py`
- `pytest tests/commands/test_json_contract_a3.py tests/commands/test_mcp_write_tool_docs.py`

## Impact
This closes issue #99 by making Antigravity-native MCP setup explicit, installable, and diagnosable instead of relying on undocumented manual `mcp_config.json` edits.