### PR TITLE
v4.2.1 — Issue #86 hardening (SF-1, SF-2, SF-5, m-4, m-6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 > For the full historical changelog with Ontos frontmatter (from v0.1.0), see [`Ontos_CHANGELOG.md`](Ontos_CHANGELOG.md).
 
+## [4.2.1] - 2026-04-14
+
+Patch release shipping the remaining Issue #86 release-hardening items for portfolio config semantics, FTS sanitization, slug-collision warnings, module exports, and bundle-order parity.
+
+### Fixed
+- **`registry_path` omission semantics** — Omitting `registry_path` in `portfolio.toml` now applies the default `~/Dev/.dev-hub/registry/projects.json` path; set `registry_path = ""` to disable registry metadata merging explicitly. This behavior change affects hand-edited configs with the key removed, not configs created by `ensure_portfolio_config()`.
+- **Plain FTS query sanitization** — behavior expansion: plain multi-term searches are now quoted before FTS5 execution, which turns previously failing queries like `hello-world`, `what a day!`, `.hidden`, and `'foo` into successful searches while preserving explicit FTS syntax passthrough and existing `E_INVALID_QUERY` behavior for malformed explicit syntax. Literal-colon queries such as `user:alice` remain an explicit-syntax limitation in this patch.
+- **Slug-collision visibility** — Portfolio discovery now emits a stderr warning when a numeric suffix is assigned after a slug collision, including the base slug, assigned slug, and workspace path.
+
+### Changed
+- **Module export hygiene** — Track A MCP modules now publish explicit `__all__` surfaces for `PortfolioIndex`, portfolio config helpers, scanner helpers, and context bundling entry points.
+- **Lost-in-the-middle ordering clarity** — `_lost_in_middle_order()` now uses the spec’s fixed-slot implementation directly while preserving the existing output order.
+
 ## [4.2.0] - 2026-04-14
 
 Adds managed Cursor MCP onboarding and a universal `print-config` fallback while preserving the shipped Antigravity contract. PR #102.

--- a/docs/releases/v4.2.1.md
+++ b/docs/releases/v4.2.1.md
@@ -1,0 +1,99 @@
+---
+id: v421
+type: log
+status: active
+ontos_schema: 2.2
+event_type: release
+concepts: [portfolio, fts, scanner, exports, hardening]
+---
+
+# v4.2.1 — "Issue #86 Release Hardening"
+
+**Release date:** 2026-04-14
+
+Patch release closing the remaining Issue #86 hardening items after the
+shipped `v4.2.0` Cursor MCP onboarding release.
+
+---
+
+## Summary
+
+- `v4.2.0` shipped Cursor onboarding and the universal MCP
+  `print-config` fallback.
+- `v4.2.1` hardens portfolio config semantics, FTS search behavior,
+  scanner collision visibility, public module exports, and the
+  lost-in-the-middle ordering implementation.
+- This release does not add new CLI commands or MCP tool surfaces.
+
+## Fixes
+
+### Portfolio config semantics
+
+`registry_path` handling is now explicit:
+
+- missing key -> default `~/Dev/.dev-hub/registry/projects.json`
+- non-empty string -> exact configured path
+- empty or whitespace-only string -> disable registry merge
+- non-string value -> fall back to the default path
+
+This is a behavior change for hand-edited configs that removed the
+`registry_path` key entirely. Configs created by
+`ensure_portfolio_config()` already include the key and keep their prior
+behavior.
+
+### FTS plain-query sanitization
+
+Plain-text searches now sanitize before they hit FTS5 by quoting each
+whitespace-separated term. This is a behavior expansion for queries that used to
+error even though the user intent was clear, including:
+
+- hyphenated terms such as `hello-world`
+- trailing punctuation such as `what a day!`
+- leading dots such as `.hidden`
+- leading apostrophes such as `'foo`
+
+Explicit FTS syntax still passes through unchanged for uppercase
+operators (`AND`, `OR`, `NOT`, `NEAR`) and marker characters (`"`, `*`,
+`:`, `(`, `)`). Lowercase plain-English words like `and` remain plain
+text, not syntax. Literal-colon queries such as `user:alice` remain a
+known limitation in this patch because `:` still forces explicit-syntax
+handling.
+
+### Scanner collision warnings
+
+Portfolio discovery now emits a stderr warning each time a numeric slug
+suffix is assigned:
+
+```text
+[ontos] slug collision: '<base>' -> '<suffixed>' for workspace '<path>'
+```
+
+The existing slug-allocation algorithm is unchanged; this release adds
+the missing visibility only.
+
+### Public module exports
+
+Track A MCP modules now declare explicit `__all__` exports for their
+intended public surfaces, including `PortfolioIndex`,
+`PORTFOLIO_CONFIG_PATH`, scanner helpers, and context bundle entry
+points.
+`PORTFOLIO_CONFIG_PATH` is now an explicit public API; future relocation or
+removal will be a semver-minor break.
+
+### Bundle ordering parity
+
+`_lost_in_middle_order()` now follows the fixed-slot algorithm directly,
+matching the spec literally while preserving the output order from the
+previous implementation.
+
+## Acceptance
+
+- Omitting `registry_path` now uses the default registry path.
+- Empty or whitespace-only `registry_path` disables registry metadata
+  merge explicitly.
+- Plain search queries like `hello-world` and `what a day!` succeed
+  without changing explicit FTS syntax handling.
+- Slug collisions emit deterministic stderr warnings during project
+  discovery.
+- Public module exports are pinned with tests.
+- Lost-in-the-middle ordering remains behaviorally identical.

--- a/ontos/__init__.py
+++ b/ontos/__init__.py
@@ -7,7 +7,7 @@ Package structure:
     ontos.ui   - I/O layer (CLI, output, prompts)
 """
 
-__version__ = "4.2.0"
+__version__ = "4.2.1"
 
 # Re-export commonly used items for convenience
 from ontos.core.context import SessionContext, FileOperation, PendingWrite

--- a/ontos/mcp/bundler.py
+++ b/ontos/mcp/bundler.py
@@ -14,6 +14,8 @@ from ontos.core.tokens import estimate_tokens
 from ontos.core.types import DocumentData
 from ontos.mcp.tools import TYPE_RANKS
 
+__all__ = ["BundleDocument", "build_context_bundle"]
+
 
 TOP_INDEGREE_COUNT = 10
 

--- a/ontos/mcp/bundler.py
+++ b/ontos/mcp/bundler.py
@@ -271,16 +271,19 @@ def _greedy_pack(
 
 def _lost_in_middle_order(docs: list[BundleDocument]) -> list[BundleDocument]:
     ranked = sorted(docs, key=lambda doc: (-doc.score, doc.id))
-    front: list[BundleDocument] = []
-    back: list[BundleDocument] = []
+    ordered: list[BundleDocument | None] = [None] * len(ranked)
+    left = 0
+    right = len(ranked) - 1
 
     for index, doc in enumerate(ranked):
         if index % 2 == 0:
-            front.append(doc)
+            ordered[left] = doc
+            left += 1
         else:
-            back.append(doc)
+            ordered[right] = doc
+            right -= 1
 
-    return front + list(reversed(back))
+    return [doc for doc in ordered if doc is not None]
 
 
 def _render_bundle_text(
@@ -341,4 +344,3 @@ def _detect_stale_documents(
 
 def _humanize_id(doc_id: str) -> str:
     return doc_id.replace("_", " ").title()
-

--- a/ontos/mcp/portfolio.py
+++ b/ontos/mcp/portfolio.py
@@ -17,6 +17,8 @@ from ontos.io.scan_scope import collect_scoped_documents, resolve_scan_scope
 from ontos.io.snapshot import create_snapshot
 from ontos.mcp.scanner import ProjectEntry, discover_projects
 
+__all__ = ["PortfolioIndex"]
+
 # Keep keyword detection case-sensitive and word-boundary-aware.
 # Naive substring matching would misclassify plain words like FORD, ANDROID,
 # NOTES, and NEARBY as explicit FTS syntax.

--- a/ontos/mcp/portfolio.py
+++ b/ontos/mcp/portfolio.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 import json
 from pathlib import Path
+import re
 import sqlite3
 import threading
 from typing import Any, Optional
@@ -15,6 +16,11 @@ from ontos.io.config import load_project_config
 from ontos.io.scan_scope import collect_scoped_documents, resolve_scan_scope
 from ontos.io.snapshot import create_snapshot
 from ontos.mcp.scanner import ProjectEntry, discover_projects
+
+# Keep keyword detection case-sensitive and word-boundary-aware.
+# Naive substring matching would misclassify plain words like FORD, ANDROID,
+# NOTES, and NEARBY as explicit FTS syntax.
+_FTS_SYNTAX_MARKERS = re.compile(r'\b(?:AND|OR|NOT|NEAR)\b|["*:()]')
 
 
 class PortfolioIndex:
@@ -173,12 +179,13 @@ class PortfolioIndex:
             raise OntosUserError("limit must be > 0.", code="E_INVALID_LIMIT")
         if not query or not query.strip():
             raise OntosUserError("query must be non-empty.", code="E_INVALID_QUERY")
+        sanitized_query = _sanitize_fts_query(query)
 
         with self._connect() as conn:
             try:
                 conn.execute("BEGIN;")
                 where = "fts_content MATCH ?"
-                params: list[Any] = [query]
+                params: list[Any] = [sanitized_query]
                 if workspace:
                     where += " AND documents.workspace = ?"
                     params.append(workspace)
@@ -636,3 +643,10 @@ class PortfolioIndex:
             stat = self._stat_fingerprint(path)
             fingerprint[rel_path] = [stat[0], stat[1]] if stat is not None else None
         return fingerprint
+
+
+def _sanitize_fts_query(query: str) -> str:
+    trimmed = query.strip()
+    if _FTS_SYNTAX_MARKERS.search(trimmed):
+        return trimmed
+    return " ".join(f'"{term}"' for term in trimmed.split())

--- a/ontos/mcp/portfolio_config.py
+++ b/ontos/mcp/portfolio_config.py
@@ -11,6 +11,13 @@ try:  # Python 3.11+
 except ImportError:  # pragma: no cover - Python 3.10 fallback
     import tomli as tomllib  # type: ignore
 
+__all__ = [
+    "PortfolioConfig",
+    "PORTFOLIO_CONFIG_PATH",
+    "ensure_portfolio_config",
+    "load_portfolio_config",
+]
+
 _DEFAULT_REGISTRY_PATH = "~/Dev/.dev-hub/registry/projects.json"
 _MISSING = object()
 

--- a/ontos/mcp/portfolio_config.py
+++ b/ontos/mcp/portfolio_config.py
@@ -11,12 +11,15 @@ try:  # Python 3.11+
 except ImportError:  # pragma: no cover - Python 3.10 fallback
     import tomli as tomllib  # type: ignore
 
+_DEFAULT_REGISTRY_PATH = "~/Dev/.dev-hub/registry/projects.json"
+_MISSING = object()
+
 
 @dataclass(frozen=True)
 class PortfolioConfig:
     scan_roots: List[str] = field(default_factory=lambda: ["~/Dev"])
     exclude: List[str] = field(default_factory=lambda: ["~/Dev/.dev-hub", "~/Dev/archive"])
-    registry_path: Optional[str] = "~/Dev/.dev-hub/registry/projects.json"
+    registry_path: Optional[str] = _DEFAULT_REGISTRY_PATH
     bundle_token_budget: int = 8000
     bundle_max_logs: int = 20
     bundle_log_window_days: int = 30
@@ -74,7 +77,10 @@ def load_portfolio_config() -> PortfolioConfig:
     return PortfolioConfig(
         scan_roots=_coerce_str_list(portfolio.get("scan_roots"), ["~/Dev"]),
         exclude=_coerce_str_list(portfolio.get("exclude"), ["~/Dev/.dev-hub", "~/Dev/archive"]),
-        registry_path=_coerce_optional_str(portfolio.get("registry_path"), "~/Dev/.dev-hub/registry/projects.json"),
+        registry_path=_coerce_registry_path(
+            portfolio.get("registry_path", _MISSING),
+            _DEFAULT_REGISTRY_PATH,
+        ),
         bundle_token_budget=_coerce_int(bundle.get("token_budget"), 8000),
         bundle_max_logs=_coerce_int(bundle.get("max_logs"), 20),
         bundle_log_window_days=_coerce_int(bundle.get("log_window_days"), 30),
@@ -87,11 +93,11 @@ def _coerce_str_list(value: object, default: List[str]) -> List[str]:
     return list(default)
 
 
-def _coerce_optional_str(value: object, default: Optional[str]) -> Optional[str]:
-    if value is None:
-        return None
+def _coerce_registry_path(value: object, default: str) -> Optional[str]:
+    if value is _MISSING:
+        return default
     if isinstance(value, str):
-        return value
+        return value if value.strip() else None
     return default
 
 

--- a/ontos/mcp/scanner.py
+++ b/ontos/mcp/scanner.py
@@ -11,6 +11,15 @@ from typing import Any
 
 from ontos.io.snapshot import create_snapshot
 
+__all__ = [
+    "ProjectEntry",
+    "RegistryRecord",
+    "slugify",
+    "discover_projects",
+    "load_registry_records",
+    "allocate_slug",
+]
+
 
 @dataclass(frozen=True)
 class ProjectEntry:

--- a/ontos/mcp/scanner.py
+++ b/ontos/mcp/scanner.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 import json
 from pathlib import Path
 import re
+import sys
 from typing import Any
 
 from ontos.io.snapshot import create_snapshot
@@ -94,6 +95,11 @@ def discover_projects(
 
         base_slug = slugify(path.name)
         slug = allocate_slug(base_slug, used_slugs)
+        if slug != base_slug:
+            print(
+                f"[ontos] slug collision: '{base_slug}' -> '{slug}' for workspace '{path}'",
+                file=sys.stderr,
+            )
         results.append(
             ProjectEntry(
                 slug=slug,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ontos"
-version = "4.2.0"
+version = "4.2.1"
 description = "Local-first documentation management for AI-assisted development"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/commands/test_verify_portfolio.py
+++ b/tests/commands/test_verify_portfolio.py
@@ -161,7 +161,7 @@ def test_verify_portfolio_scopes_to_workspace_id(tmp_path, capsys):
     assert "No discrepancies found." in captured.out
 
 
-def test_verify_portfolio_handles_same_basename_collision(tmp_path):
+def test_verify_portfolio_handles_same_basename_collision_without_stderr_warning(tmp_path, capsys):
     db_path = tmp_path / "portfolio.db"
     root_one = tmp_path / "DevA"
     root_two = tmp_path / "DevB"
@@ -210,7 +210,9 @@ def test_verify_portfolio_handles_same_basename_collision(tmp_path):
         json_output=True,
     )
 
+    captured = capsys.readouterr()
     assert exit_code == 0
+    assert captured.err == ""
 
 
 @pytest.mark.parametrize("registry_key", ["projects", "workspaces", "entries", "items"])

--- a/tests/mcp/test_bundler.py
+++ b/tests/mcp/test_bundler.py
@@ -1,10 +1,61 @@
 from datetime import date, timedelta
 
+import pytest
+
 from ontos.core.snapshot import DocumentSnapshot
 from ontos.io.snapshot import create_snapshot
-from ontos.mcp.bundler import build_context_bundle
+from ontos.mcp.bundler import BundleDocument, _lost_in_middle_order, build_context_bundle
 
 from tests.mcp import create_empty_workspace, create_workspace, write_file
+
+
+def _bundle_doc(doc_id: str, score: float) -> BundleDocument:
+    return BundleDocument(id=doc_id, type="atom", status="active", content="", score=score, token_estimate=1)
+
+
+def _legacy_lost_in_middle_order(docs: list[BundleDocument]) -> list[BundleDocument]:
+    ranked = sorted(docs, key=lambda doc: (-doc.score, doc.id))
+    front: list[BundleDocument] = []
+    back: list[BundleDocument] = []
+    for index, doc in enumerate(ranked):
+        if index % 2 == 0:
+            front.append(doc)
+        else:
+            back.append(doc)
+    return front + list(reversed(back))
+
+
+@pytest.mark.parametrize(
+    ("count", "expected"),
+    [
+        (0, []),
+        (1, ["a"]),
+        (2, ["a", "b"]),
+        (3, ["a", "c", "b"]),
+        (4, ["a", "c", "d", "b"]),
+        (5, ["a", "c", "e", "d", "b"]),
+        (6, ["a", "c", "e", "f", "d", "b"]),
+    ],
+)
+def test_lost_in_middle_order_matches_fixed_slot_fixture_table(count, expected):
+    docs = [_bundle_doc(chr(ord("a") + index), 1.0 - (index * 0.1)) for index in range(count)]
+
+    ordered = _lost_in_middle_order(docs)
+
+    assert [doc.id for doc in ordered] == expected
+
+
+def test_lost_in_middle_order_matches_legacy_behavior():
+    docs = [
+        _bundle_doc("alpha", 1.0),
+        _bundle_doc("beta", 0.95),
+        _bundle_doc("gamma", 0.95),
+        _bundle_doc("delta", 0.8),
+        _bundle_doc("epsilon", 0.7),
+        _bundle_doc("zeta", 0.6),
+    ]
+
+    assert _lost_in_middle_order(docs) == _legacy_lost_in_middle_order(docs)
 
 
 def test_build_context_bundle_scores_kernels_highest(tmp_path):

--- a/tests/mcp/test_module_exports.py
+++ b/tests/mcp/test_module_exports.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import ontos.mcp.bundler as bundler_module
+import ontos.mcp.portfolio as portfolio_module
+import ontos.mcp.portfolio_config as portfolio_config_module
+import ontos.mcp.scanner as scanner_module
+
+
+def test_portfolio_module_all_exports_public_surface():
+    assert sorted(portfolio_module.__all__) == ["PortfolioIndex"]
+    assert "_sanitize_fts_query" not in portfolio_module.__all__
+
+
+def test_scanner_module_all_exports_public_surface():
+    assert sorted(scanner_module.__all__) == sorted(
+        [
+            "ProjectEntry",
+            "RegistryRecord",
+            "slugify",
+            "discover_projects",
+            "load_registry_records",
+            "allocate_slug",
+        ]
+    )
+    assert "_allocate_slug" not in scanner_module.__all__
+    assert "_load_registry_records" not in scanner_module.__all__
+
+
+def test_bundler_module_all_exports_public_surface():
+    assert sorted(bundler_module.__all__) == sorted(["BundleDocument", "build_context_bundle"])
+    assert "_build_priority_order" not in bundler_module.__all__
+    assert "_to_bundle_doc" not in bundler_module.__all__
+
+
+def test_portfolio_config_module_all_exports_public_surface():
+    assert sorted(portfolio_config_module.__all__) == sorted(
+        [
+            "PortfolioConfig",
+            "PORTFOLIO_CONFIG_PATH",
+            "ensure_portfolio_config",
+            "load_portfolio_config",
+        ]
+    )

--- a/tests/mcp/test_portfolio.py
+++ b/tests/mcp/test_portfolio.py
@@ -8,7 +8,7 @@ import time
 import pytest
 
 from ontos.core.errors import OntosUserError
-from ontos.mcp.portfolio import PortfolioIndex
+from ontos.mcp.portfolio import PortfolioIndex, _sanitize_fts_query
 from tests.mcp import create_workspace, write_file
 
 
@@ -107,6 +107,59 @@ def test_search_fts_returns_ranked_results(tmp_path):
 
     assert result["total_hits"] > 0
     assert scores == sorted(scores)
+
+
+def test_sanitize_fts_query_quotes_plain_multi_term_queries():
+    assert _sanitize_fts_query("  alpha beta  ") == '"alpha" "beta"'
+
+
+def test_sanitize_fts_query_quotes_single_plain_term():
+    assert _sanitize_fts_query(" alpha ") == '"alpha"'
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "alpha AND beta",
+        "alpha OR beta",
+        "alpha NOT beta",
+        "alpha NEAR beta",
+        '"alpha beta"',
+        "title:alpha",
+        "alpha*",
+        "(alpha OR beta)",
+    ],
+)
+def test_sanitize_fts_query_preserves_explicit_fts_syntax(query):
+    assert _sanitize_fts_query(f"  {query}  ") == query
+
+
+def test_sanitize_fts_query_lowercase_and_is_not_marker():
+    assert _sanitize_fts_query(" bread and butter ") == '"bread" "and" "butter"'
+
+
+@pytest.mark.parametrize(
+    ("query", "body"),
+    [
+        ("hello-world", "Contains hello-world token."),
+        ("what a day!", "what a day!"),
+        (".hidden", ".hidden file"),
+        ("'foo", "'foo bar"),
+    ],
+)
+def test_search_fts_err_to_ok_queries_are_sanitized(tmp_path, query, body):
+    workspace_root = _make_custom_workspace(
+        tmp_path,
+        workspace_name="sanitize-workspace",
+        docs={"alpha.md": _doc_content("alpha_doc", body)},
+    )
+    index = PortfolioIndex(tmp_path / "portfolio.db")
+    index.rebuild_workspace("sanitize", workspace_root)
+
+    result = index.search_fts(query, workspace="sanitize", offset=0, limit=10)
+
+    assert result["total_hits"] == 1
+    assert result["results"][0]["doc_id"] == "alpha_doc"
 
 
 def test_search_fts_rejects_malformed_queries(tmp_path):

--- a/tests/mcp/test_portfolio_config.py
+++ b/tests/mcp/test_portfolio_config.py
@@ -71,6 +71,74 @@ def test_load_portfolio_config_custom_values(tmp_path, monkeypatch):
     assert cfg.bundle_log_window_days == 3
 
 
+def test_load_portfolio_config_missing_registry_path_uses_default(tmp_path, monkeypatch):
+    config_path = tmp_path / ".config" / "ontos" / "portfolio.toml"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        """
+        [portfolio]
+        scan_roots = ["~/Dev"]
+        """,
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(portfolio_config_module, "PORTFOLIO_CONFIG_PATH", config_path)
+
+    cfg = load_portfolio_config()
+
+    assert cfg.registry_path == "~/Dev/.dev-hub/registry/projects.json"
+
+
+def test_load_portfolio_config_empty_registry_path_disables_merge(tmp_path, monkeypatch):
+    config_path = tmp_path / ".config" / "ontos" / "portfolio.toml"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        """
+        [portfolio]
+        registry_path = ""
+        """,
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(portfolio_config_module, "PORTFOLIO_CONFIG_PATH", config_path)
+
+    cfg = load_portfolio_config()
+
+    assert cfg.registry_path is None
+
+
+def test_load_portfolio_config_whitespace_registry_path_disables_merge(tmp_path, monkeypatch):
+    config_path = tmp_path / ".config" / "ontos" / "portfolio.toml"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        """
+        [portfolio]
+        registry_path = "   "
+        """,
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(portfolio_config_module, "PORTFOLIO_CONFIG_PATH", config_path)
+
+    cfg = load_portfolio_config()
+
+    assert cfg.registry_path is None
+
+
+def test_load_portfolio_config_non_string_registry_path_falls_back_to_default(tmp_path, monkeypatch):
+    config_path = tmp_path / ".config" / "ontos" / "portfolio.toml"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        """
+        [portfolio]
+        registry_path = 42
+        """,
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(portfolio_config_module, "PORTFOLIO_CONFIG_PATH", config_path)
+
+    cfg = load_portfolio_config()
+
+    assert cfg.registry_path == "~/Dev/.dev-hub/registry/projects.json"
+
+
 def test_load_portfolio_config_invalid_toml_raises(tmp_path, monkeypatch):
     config_path = tmp_path / ".config" / "ontos" / "portfolio.toml"
     config_path.parent.mkdir(parents=True)
@@ -91,4 +159,3 @@ def test_ensure_portfolio_config_is_idempotent(tmp_path, monkeypatch):
     assert first == Path(config_path)
     assert second == Path(config_path)
     assert config_path.exists()
-

--- a/tests/mcp/test_portfolio_integration.py
+++ b/tests/mcp/test_portfolio_integration.py
@@ -4,7 +4,7 @@ from ontos.mcp import tools
 from ontos.mcp.portfolio import PortfolioIndex
 from ontos.mcp.schemas import validate_success_payload
 
-from tests.mcp import build_cache, create_workspace
+from tests.mcp import build_cache, create_workspace, write_file
 
 
 def test_portfolio_index_outputs_validate_against_track_a_tools(tmp_path):
@@ -30,3 +30,28 @@ def test_portfolio_index_outputs_validate_against_track_a_tools(tmp_path):
     assert search_payload["results"][0]["workspace_slug"] == "workspace"
     assert bundle_payload["workspace_slug"] == "workspace"
     assert bundle_payload["document_count"] >= 1
+
+
+def test_tools_search_uses_real_portfolio_index_for_sanitized_query(tmp_path):
+    root = create_workspace(tmp_path)
+    write_file(
+        root / "docs" / "hyphenated.md",
+        """
+        ---
+        id: hyphenated_doc
+        type: atom
+        status: active
+        ---
+        hello-world
+        """,
+    )
+    index = PortfolioIndex(tmp_path / "portfolio.db")
+
+    index.rebuild_workspace("workspace", root)
+    payload = validate_success_payload(
+        "search",
+        tools.search(index, query_string="hello-world", workspace_id="workspace"),
+    )
+
+    assert payload["total_hits"] == 1
+    assert payload["results"][0]["doc_id"] == "hyphenated_doc"

--- a/tests/mcp/test_scanner.py
+++ b/tests/mcp/test_scanner.py
@@ -39,6 +39,21 @@ def test_discover_projects_classifies_and_excludes(tmp_path):
     assert by_path[undocumented].status == "undocumented"
 
 
+def test_discover_projects_without_collisions_emits_no_warning(tmp_path, capsys):
+    scan_root = tmp_path / "Dev"
+    scan_root.mkdir()
+    _make_project(scan_root / "alpha", with_ontos=True, with_readme=True, doc_count=1)
+
+    discover_projects(
+        scan_roots=[scan_root],
+        exclude=[],
+        registry_path=None,
+    )
+
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+
 def test_discover_projects_merges_registry_metadata(tmp_path):
     scan_root = tmp_path / "Dev"
     scan_root.mkdir()
@@ -106,14 +121,14 @@ def test_discover_projects_resolves_registry_paths_from_dev_root(tmp_path):
     assert projects[0].path == project_path
 
 
-def test_discover_projects_handles_slug_collisions(tmp_path):
+def test_discover_projects_handles_slug_collisions(tmp_path, capsys):
     root_one = tmp_path / "DevA"
     root_two = tmp_path / "DevB"
     root_one.mkdir()
     root_two.mkdir()
 
     _make_project(root_one / "sample-app", with_ontos=True, with_readme=True, doc_count=5)
-    _make_project(root_two / "sample-app", with_ontos=True, with_readme=True, doc_count=5)
+    collided_path = _make_project(root_two / "sample-app", with_ontos=True, with_readme=True, doc_count=5)
 
     projects = discover_projects(
         scan_roots=[root_one, root_two],
@@ -121,8 +136,34 @@ def test_discover_projects_handles_slug_collisions(tmp_path):
         registry_path=None,
     )
 
+    captured = capsys.readouterr()
     slugs = sorted(entry.slug for entry in projects)
     assert slugs == ["sample-app", "sample-app-2"]
+    assert captured.err.strip() == (
+        f"[ontos] slug collision: 'sample-app' -> 'sample-app-2' "
+        f"for workspace '{collided_path}'"
+    )
+
+
+def test_discover_projects_triple_slug_collision_emits_one_warning_per_suffix(tmp_path, capsys):
+    roots = [tmp_path / name for name in ("DevA", "DevB", "DevC")]
+    for root in roots:
+        root.mkdir()
+        _make_project(root / "sample-app", with_ontos=True, with_readme=True, doc_count=1)
+
+    projects = discover_projects(
+        scan_roots=roots,
+        exclude=[],
+        registry_path=None,
+    )
+
+    captured = capsys.readouterr()
+    warnings = [line for line in captured.err.splitlines() if line]
+    assert sorted(entry.slug for entry in projects) == ["sample-app", "sample-app-2", "sample-app-3"]
+    assert warnings == [
+        f"[ontos] slug collision: 'sample-app' -> 'sample-app-2' for workspace '{(roots[1] / 'sample-app').resolve()}'",
+        f"[ontos] slug collision: 'sample-app' -> 'sample-app-3' for workspace '{(roots[2] / 'sample-app').resolve()}'",
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/mcp/test_write_tools.py
+++ b/tests/mcp/test_write_tools.py
@@ -385,8 +385,9 @@ def test_write_tool_rejects_cross_workspace_id(tmp_path):
     assert result.structuredContent["error"]["error_code"] == "E_PORTFOLIO_REQUIRED"
 
 
-def test_write_tool_without_workspace_id_targets_served_workspace_in_portfolio_mode(tmp_path):
+def test_write_tool_without_workspace_id_targets_served_workspace_in_portfolio_mode(tmp_path, capsys):
     left_root, right_root, index = _build_same_basename_portfolio(tmp_path)
+    capsys.readouterr()
     server = build_server(right_root, portfolio_index=index)
 
     before_left_ids = {doc["id"] for doc in index.get_workspace_documents("workspace")}
@@ -403,10 +404,12 @@ def test_write_tool_without_workspace_id_targets_served_workspace_in_portfolio_m
 
     after_left_ids = {doc["id"] for doc in index.get_workspace_documents("workspace")}
     after_right_ids = {doc["id"] for doc in index.get_workspace_documents("workspace-2")}
+    captured = capsys.readouterr()
     assert after_left_ids == before_left_ids
     assert after_right_ids == before_right_ids | {"current_workspace_only"}
     assert "current_workspace_only" not in after_left_ids
     assert not (left_root / "docs" / "current_workspace_only.md").exists()
+    assert captured.err == ""
 
 
 def test_write_tool_rejects_unknown_workspace_id_in_portfolio_mode(tmp_path):


### PR DESCRIPTION
## Summary

v4.2.1 patch addressing the five live remaining items from #86:

- **SF-1** — `registry_path` semantics pinned (behavior change for hand-edited configs)
- **SF-2** — Plain FTS query sanitization (behavior expansion)
- **SF-5** — Slug collision warnings emitted on portfolio discovery
- **m-4** — Explicit `__all__` exports across Track A MCP modules
- **m-6** — `_lost_in_middle_order` rewritten as fixed-slot parity

Plan: `.ontos-internal/strategy/proposals/v4.2/Ontos-v4.2.1-Issue-86-Release-Hardening-Plan.md`
Phase B verdict: `.ontos-internal/reviews/issue-86-hardening-B-verdict.md`
Phase D verdict: `.ontos-internal/reviews/issue-86-hardening-D-verdict.md`

## Behavior changes (user-visible)

**SF-1 — registry_path (behavior change).** Configs that omit the `registry_path` key will now apply the default path `~/Dev/.dev-hub/registry/projects.json` instead of disabling registry merging. Only affects hand-edited configs; configs bootstrapped via `ensure_portfolio_config()` already include the key. To explicitly disable registry metadata merge, set `registry_path = ""`.

**SF-2 — FTS sanitization (behavior expansion).** Plain queries containing hyphens, trailing punctuation, leading dots, or leading apostrophes now succeed as quoted-term searches instead of raising `E_INVALID_QUERY`. Marker detection is case-sensitive and word-boundary-aware (so `bread and butter` is plain text, `bread AND butter` is explicit FTS). Literal-colon queries (`user:alice`) remain on `E_INVALID_QUERY` as a known limitation.

## Test state

- Targeted: 116 passed
- Full: 1229 passed, 2 skipped (pre-existing golden-master skips)

## Commit structure

Five commits, one per item, for rollback granularity:

1. `57df005` SF-1 — registry_path semantics
2. `dc38d4c` SF-2 — FTS query sanitization
3. `5564210` SF-5 — Scanner collision warnings
4. `0d90de9` m-4 — Explicit `__all__` exports
5. `3818b01` m-6 — `_lost_in_middle_order` parity rewrite + v4.2.1 release scaffolding

## Issue #86 disposition

This PR narrows `#86` and closes it on merge. Disposition:

**In this PR:** SF-1, SF-2, SF-5, m-4, m-6

**Closed during Track B (PR #92 era):** SF-3, SF-4, SF-9, m-1, m-2, m-5, m-7, m-9, m-10, m-11, m-14, m-15, m-17

**Deferred to v4.3.x backlog:** SF-8, m-3, m-8, m-12, m-13, m-16 (cosmetic, test debt, or out-of-scope of Track A surface)

## Post-merge follow-up

D-verdict Minor items M-01 through M-09 will be tracked in a separate v4.2.2 backlog issue (created with this release).

## Closes

Closes #86
