### PR TITLE
[codex] Address issue #105 residual hardening items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to this project will be documented in this file.
 
 > For the full historical changelog with Ontos frontmatter (from v0.1.0), see [`Ontos_CHANGELOG.md`](Ontos_CHANGELOG.md).
 
+## [4.2.2] - 2026-04-15
+
+Patch release closing the residual Issue #105 hardening items on top of the
+shipped `v4.2.1` release.
+
+### Fixed
+- **Plain-word FTS regression coverage** — Sanitized plain queries are now
+  pinned against substring traps like `FORD`, `ANDROID`, `NOTES`, and
+  `NEARBY`, plus marker-only and bare-marker negative cases.
+- **FTS length-cap enforcement** — Queries longer than 10,000 characters now
+  fail before any strip-based copy, including whitespace-flood inputs; the
+  `== 10,000` boundary is test-pinned as accepted. This is a new
+  `E_INVALID_QUERY` behavior commitment in `v4.2.2`.
+- **Unicode search parity** — Cross-form NFC/NFD search behavior is now
+  explicitly test-asserted against the `unicode61` tokenizer contract.
+- **`registry_path` coercion observability** — Non-string
+  `portfolio.registry_path` values now emit a `WARNING` before falling back to
+  the default path, and outer whitespace on string paths is normalized.
+- **Malformed explicit FTS error translation** — SQLite `"no such column"`
+  errors produced by malformed explicit syntax now map to `E_INVALID_QUERY`
+  alongside the existing syntax-error family.
+
+### Changed
+- **Bundle ordering traceability** — `_lost_in_middle_order()` now carries an
+  inline fixed-slot rationale comment, and equal-score tiebreak behavior is
+  independently pinned by test.
+- **Scanner warning policy** — Repeated portfolio discovery passes now
+  explicitly document and test that slug-collision warnings re-emit per call.
+
 ## [4.2.1] - 2026-04-14
 
 Patch release shipping the remaining Issue #86 release-hardening items for portfolio config semantics, FTS sanitization, slug-collision warnings, module exports, and bundle-order parity.

--- a/docs/releases/v4.2.2.md
+++ b/docs/releases/v4.2.2.md
@@ -1,0 +1,97 @@
+---
+id: v422
+type: log
+status: active
+ontos_schema: 2.2
+event_type: release
+concepts: [portfolio, fts, unicode, scanner, hardening]
+---
+
+# v4.2.2 — "Issue #105 Residual Hardening"
+
+**Release date:** 2026-04-15
+
+Patch release closing the residual low-severity hardening items tracked in
+Issue #105 after the shipped `v4.2.1` release.
+
+---
+
+## Summary
+
+- `v4.2.1` closed the main Issue #86 hardening pass.
+- `v4.2.2` finishes the deferred Minor items that were still worth shipping as
+  a patch: FTS query hardening, config-coercion observability, scanner warning
+  policy pinning, and bundle-order traceability.
+- This release does not add new CLI commands or MCP tools.
+
+## Fixes
+
+### FTS query hardening
+
+This release tightens the remaining search edge cases from Issue #105:
+
+- plain-word substring traps like `FORD`, `ANDROID`, `NOTES`, and `NEARBY`
+  are now explicitly pinned as plain text, not syntax
+- marker-only and bare-marker malformed queries remain `E_INVALID_QUERY`
+- the 10,000-character query cap now rejects overlong input before any
+  strip-based copy, including whitespace-flood queries
+- the `== 10,000` character boundary is explicitly accepted
+
+The invalid-query classifier also now treats SQLite `"no such column"` errors
+as malformed explicit FTS syntax so queries like `foo:bar` stay inside the
+existing `E_INVALID_QUERY` contract instead of leaking raw SQLite errors.
+
+### Unicode tokenizer parity
+
+Search behavior across composed and decomposed Unicode forms is now
+test-asserted against SQLite FTS5 `unicode61` behavior:
+
+- composed fixture, decomposed query -> hit
+- decomposed fixture, composed query -> hit
+
+This formalizes the tokenizer parity that was previously relied on but not
+proven by a cross-form test.
+
+### Portfolio config observability
+
+`portfolio.registry_path` handling now emits a warning when a non-string value
+falls back to the default path. Outer whitespace on string paths is normalized
+before the path is used.
+
+This keeps the `v4.2.1` semantics intact while making hand-edited config
+mistakes more visible.
+
+### Scanner warning policy
+
+Slug-collision warnings are now explicitly tested as re-emitting once per
+discovery pass. The warning format and allocation logic remain unchanged.
+
+### Bundle ordering traceability
+
+`_lost_in_middle_order()` now carries an inline fixed-slot rationale comment,
+and equal-score ordering is independently pinned by test so future refactors do
+not rely only on the legacy-parity fixture.
+
+## Issue #105 coverage
+
+This release closes the shipped portion of Issue #105:
+
+- **M-01** — substring-trap assertions
+- **M-02** — plan-traceability comment on `_lost_in_middle_order()`
+- **M-03** — negative tests for marker-only / bare-marker inputs
+- **M-04** — observable warning on non-string `registry_path`
+- **M-05** — whitespace handling on `registry_path`
+- **M-06** — independent tiebreak assertion for equal-score ordering
+- **M-07** — Unicode normalization coverage
+- **M-08** — FTS query length cap hardening
+- **M-09** — repeated slug-collision warning policy pinning
+
+## Acceptance
+
+- overlong queries fail with `E_INVALID_QUERY` before strip-based copies
+- `foo:bar` and similar malformed explicit syntax stay inside the
+  `E_INVALID_QUERY` envelope
+- composed/decomposed Unicode search works cross-form
+- non-string `registry_path` values emit a warning before default fallback
+- repeated slug-collision warnings are stable and intentional
+- bundle ordering intent is directly documented and independently tested

--- a/ontos/__init__.py
+++ b/ontos/__init__.py
@@ -7,7 +7,7 @@ Package structure:
     ontos.ui   - I/O layer (CLI, output, prompts)
 """
 
-__version__ = "4.2.1"
+__version__ = "4.2.2"
 
 # Re-export commonly used items for convenience
 from ontos.core.context import SessionContext, FileOperation, PendingWrite

--- a/ontos/mcp/bundler.py
+++ b/ontos/mcp/bundler.py
@@ -270,6 +270,7 @@ def _greedy_pack(
 
 
 def _lost_in_middle_order(docs: list[BundleDocument]) -> list[BundleDocument]:
+    # m-6: fixed-slot, no list.insert; see plan §m-6.
     ranked = sorted(docs, key=lambda doc: (-doc.score, doc.id))
     ordered: list[BundleDocument | None] = [None] * len(ranked)
     left = 0

--- a/ontos/mcp/portfolio.py
+++ b/ontos/mcp/portfolio.py
@@ -23,6 +23,7 @@ __all__ = ["PortfolioIndex"]
 # Naive substring matching would misclassify plain words like FORD, ANDROID,
 # NOTES, and NEARBY as explicit FTS syntax.
 _FTS_SYNTAX_MARKERS = re.compile(r'\b(?:AND|OR|NOT|NEAR)\b|["*:()]')
+_MAX_FTS_QUERY_LENGTH = 10_000
 
 
 class PortfolioIndex:
@@ -179,9 +180,11 @@ class PortfolioIndex:
             raise OntosUserError("offset must be >= 0.", code="E_INVALID_OFFSET")
         if limit <= 0:
             raise OntosUserError("limit must be > 0.", code="E_INVALID_LIMIT")
-        if not query or not query.strip():
+        if not query:
             raise OntosUserError("query must be non-empty.", code="E_INVALID_QUERY")
         sanitized_query = _sanitize_fts_query(query)
+        if not sanitized_query:
+            raise OntosUserError("query must be non-empty.", code="E_INVALID_QUERY")
 
         with self._connect() as conn:
             try:
@@ -607,6 +610,9 @@ class PortfolioIndex:
             or "syntax error" in message
             or "unterminated string" in message
             or "unknown special query" in message
+            # Explicit FTS column selectors like foo:bar surface as "no such
+            # column" when SQLite parses "foo" as an unknown FTS column name.
+            or "no such column" in message
         )
 
     @staticmethod
@@ -648,6 +654,11 @@ class PortfolioIndex:
 
 
 def _sanitize_fts_query(query: str) -> str:
+    if len(query) > _MAX_FTS_QUERY_LENGTH:
+        raise OntosUserError(
+            f"Query exceeds maximum length of {_MAX_FTS_QUERY_LENGTH} characters.",
+            code="E_INVALID_QUERY",
+        )
     trimmed = query.strip()
     if _FTS_SYNTAX_MARKERS.search(trimmed):
         return trimmed

--- a/ontos/mcp/portfolio_config.py
+++ b/ontos/mcp/portfolio_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import logging
 from pathlib import Path
 from typing import List, Optional
 
@@ -17,6 +18,8 @@ __all__ = [
     "ensure_portfolio_config",
     "load_portfolio_config",
 ]
+
+logger = logging.getLogger(__name__)
 
 _DEFAULT_REGISTRY_PATH = "~/Dev/.dev-hub/registry/projects.json"
 _MISSING = object()
@@ -104,7 +107,9 @@ def _coerce_registry_path(value: object, default: str) -> Optional[str]:
     if value is _MISSING:
         return default
     if isinstance(value, str):
-        return value if value.strip() else None
+        stripped = value.strip()
+        return stripped or None
+    logger.warning("Ignoring non-string portfolio.registry_path value %r; using default path.", value)
     return default
 
 

--- a/ontos/mcp/scanner.py
+++ b/ontos/mcp/scanner.py
@@ -105,6 +105,8 @@ def discover_projects(
         base_slug = slugify(path.name)
         slug = allocate_slug(base_slug, used_slugs)
         if slug != base_slug:
+            # Warnings are emitted per discovery pass; repeated scans intentionally
+            # re-emit them instead of tracking process-global dedupe state.
             print(
                 f"[ontos] slug collision: '{base_slug}' -> '{slug}' for workspace '{path}'",
                 file=sys.stderr,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ontos"
-version = "4.2.1"
+version = "4.2.2"
 description = "Local-first documentation management for AI-assisted development"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/mcp/test_bundler.py
+++ b/tests/mcp/test_bundler.py
@@ -58,6 +58,19 @@ def test_lost_in_middle_order_matches_legacy_behavior():
     assert _lost_in_middle_order(docs) == _legacy_lost_in_middle_order(docs)
 
 
+def test_lost_in_middle_order_tiebreaks_equal_scores_by_id_ascending():
+    docs = [
+        _bundle_doc("gamma", 1.0),
+        _bundle_doc("alpha", 1.0),
+        _bundle_doc("beta", 1.0),
+        _bundle_doc("delta", 0.8),
+    ]
+
+    ordered = _lost_in_middle_order(docs)
+
+    assert [doc.id for doc in ordered] == ["alpha", "gamma", "delta", "beta"]
+
+
 def test_build_context_bundle_scores_kernels_highest(tmp_path):
     root = create_workspace(tmp_path)
     snapshot = create_snapshot(root=root, include_content=True, filters=None, git_commit_provider=None, scope=None)

--- a/tests/mcp/test_portfolio.py
+++ b/tests/mcp/test_portfolio.py
@@ -8,7 +8,7 @@ import time
 import pytest
 
 from ontos.core.errors import OntosUserError
-from ontos.mcp.portfolio import PortfolioIndex, _sanitize_fts_query
+from ontos.mcp.portfolio import PortfolioIndex, _MAX_FTS_QUERY_LENGTH, _sanitize_fts_query
 from tests.mcp import create_workspace, write_file
 
 
@@ -138,6 +138,11 @@ def test_sanitize_fts_query_lowercase_and_is_not_marker():
     assert _sanitize_fts_query(" bread and butter ") == '"bread" "and" "butter"'
 
 
+@pytest.mark.parametrize("query", ["FORD", "ANDROID", "NOTES", "NEARBY"])
+def test_sanitize_fts_query_does_not_treat_plain_words_as_syntax(query):
+    assert _sanitize_fts_query(query) == f'"{query}"'
+
+
 @pytest.mark.parametrize(
     ("query", "body"),
     [
@@ -171,6 +176,78 @@ def test_search_fts_rejects_malformed_queries(tmp_path):
         index.search_fts('"unterminated', workspace=None, offset=0, limit=10)
 
     assert exc_info.value.code == "E_INVALID_QUERY"
+
+
+@pytest.mark.parametrize("query", [":", "AND", "NOT foo", "foo:bar", 'foo " bar'])
+def test_search_fts_marker_only_or_bare_marker_queries_raise_invalid_query(tmp_path, query):
+    workspace_root = create_workspace(tmp_path)
+    index = PortfolioIndex(tmp_path / "portfolio.db")
+    index.rebuild_workspace("workspace", workspace_root)
+
+    with pytest.raises(OntosUserError) as exc_info:
+        index.search_fts(query, workspace=None, offset=0, limit=10)
+
+    assert exc_info.value.code == "E_INVALID_QUERY"
+
+
+def test_sanitize_fts_query_rejects_excessively_long_queries():
+    with pytest.raises(OntosUserError) as exc_info:
+        _sanitize_fts_query("a" * (_MAX_FTS_QUERY_LENGTH + 1))
+
+    assert exc_info.value.code == "E_INVALID_QUERY"
+    assert str(_MAX_FTS_QUERY_LENGTH) in str(exc_info.value)
+
+
+def test_sanitize_fts_query_rejects_whitespace_flood_before_strip():
+    with pytest.raises(OntosUserError) as exc_info:
+        _sanitize_fts_query(" " * (_MAX_FTS_QUERY_LENGTH + 1))
+
+    assert exc_info.value.code == "E_INVALID_QUERY"
+
+
+def test_sanitize_fts_query_accepts_exact_length_boundary():
+    assert _sanitize_fts_query("a" * _MAX_FTS_QUERY_LENGTH) == f'"{"a" * _MAX_FTS_QUERY_LENGTH}"'
+
+
+def test_search_fts_rejects_whitespace_flood_before_strip(tmp_path):
+    workspace_root = create_workspace(tmp_path)
+    index = PortfolioIndex(tmp_path / "portfolio.db")
+    index.rebuild_workspace("workspace", workspace_root)
+
+    with pytest.raises(OntosUserError) as exc_info:
+        index.search_fts(" " * (_MAX_FTS_QUERY_LENGTH + 1), workspace=None, offset=0, limit=10)
+
+    assert exc_info.value.code == "E_INVALID_QUERY"
+
+
+def test_search_fts_matches_decomposed_query_against_composed_fixture(tmp_path):
+    workspace_root = _make_custom_workspace(
+        tmp_path,
+        workspace_name="unicode-composed",
+        docs={"unicode.md": _doc_content("composed_doc", "café")},
+    )
+    index = PortfolioIndex(tmp_path / "portfolio.db")
+    index.rebuild_workspace("unicode", workspace_root)
+
+    decomposed = index.search_fts("cafe\u0301", workspace="unicode", offset=0, limit=10)
+
+    assert decomposed["total_hits"] == 1
+    assert decomposed["results"][0]["doc_id"] == "composed_doc"
+
+
+def test_search_fts_matches_composed_query_against_decomposed_fixture(tmp_path):
+    workspace_root = _make_custom_workspace(
+        tmp_path,
+        workspace_name="unicode-decomposed",
+        docs={"unicode.md": _doc_content("decomposed_doc", "cafe\u0301")},
+    )
+    index = PortfolioIndex(tmp_path / "portfolio.db")
+    index.rebuild_workspace("unicode", workspace_root)
+
+    composed = index.search_fts("café", workspace="unicode", offset=0, limit=10)
+
+    assert composed["total_hits"] == 1
+    assert composed["results"][0]["doc_id"] == "decomposed_doc"
 
 
 def test_connect_uses_nonzero_timeout(tmp_path, monkeypatch):

--- a/tests/mcp/test_portfolio_config.py
+++ b/tests/mcp/test_portfolio_config.py
@@ -122,6 +122,23 @@ def test_load_portfolio_config_whitespace_registry_path_disables_merge(tmp_path,
     assert cfg.registry_path is None
 
 
+def test_load_portfolio_config_strips_outer_whitespace_from_registry_path(tmp_path, monkeypatch):
+    config_path = tmp_path / ".config" / "ontos" / "portfolio.toml"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        """
+        [portfolio]
+        registry_path = "   ~/Dev/custom-registry.json   "
+        """,
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(portfolio_config_module, "PORTFOLIO_CONFIG_PATH", config_path)
+
+    cfg = load_portfolio_config()
+
+    assert cfg.registry_path == "~/Dev/custom-registry.json"
+
+
 def test_load_portfolio_config_non_string_registry_path_falls_back_to_default(tmp_path, monkeypatch):
     config_path = tmp_path / ".config" / "ontos" / "portfolio.toml"
     config_path.parent.mkdir(parents=True)
@@ -137,6 +154,29 @@ def test_load_portfolio_config_non_string_registry_path_falls_back_to_default(tm
     cfg = load_portfolio_config()
 
     assert cfg.registry_path == "~/Dev/.dev-hub/registry/projects.json"
+
+
+def test_load_portfolio_config_non_string_registry_path_warns_and_falls_back_to_default(
+    tmp_path,
+    monkeypatch,
+    caplog,
+):
+    config_path = tmp_path / ".config" / "ontos" / "portfolio.toml"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        """
+        [portfolio]
+        registry_path = true
+        """,
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(portfolio_config_module, "PORTFOLIO_CONFIG_PATH", config_path)
+
+    with caplog.at_level("WARNING"):
+        cfg = load_portfolio_config()
+
+    assert cfg.registry_path == "~/Dev/.dev-hub/registry/projects.json"
+    assert "Ignoring non-string portfolio.registry_path value" in caplog.text
 
 
 def test_load_portfolio_config_invalid_toml_raises(tmp_path, monkeypatch):

--- a/tests/mcp/test_scanner.py
+++ b/tests/mcp/test_scanner.py
@@ -166,6 +166,27 @@ def test_discover_projects_triple_slug_collision_emits_one_warning_per_suffix(tm
     ]
 
 
+def test_discover_projects_repeated_calls_reemit_collision_warnings(tmp_path, capsys):
+    root_one = tmp_path / "DevA"
+    root_two = tmp_path / "DevB"
+    root_one.mkdir()
+    root_two.mkdir()
+    _make_project(root_one / "sample-app", with_ontos=True, with_readme=True, doc_count=1)
+    collided_path = _make_project(root_two / "sample-app", with_ontos=True, with_readme=True, doc_count=1)
+
+    discover_projects(scan_roots=[root_one, root_two], exclude=[], registry_path=None)
+    first = capsys.readouterr()
+    discover_projects(scan_roots=[root_one, root_two], exclude=[], registry_path=None)
+    second = capsys.readouterr()
+
+    expected = (
+        f"[ontos] slug collision: 'sample-app' -> 'sample-app-2' "
+        f"for workspace '{collided_path.resolve()}'"
+    )
+    assert first.err.strip() == expected
+    assert second.err.strip() == expected
+
+
 @pytest.mark.parametrize(
     "payload_factory",
     [


### PR DESCRIPTION
## Summary

`v4.2.2` patch addressing the residual hardening items tracked in #105 after the shipped `v4.2.1` release.

This PR closes the remaining low-severity MCP portfolio edges without adding new CLI commands or MCP tool capabilities.

## What changed

- hardens FTS query sanitization and error translation for the remaining Issue #105 edge cases
- moves the query-length guard ahead of any strip-based copy so whitespace-flood inputs fail before allocation-heavy normalization
- adds cross-form Unicode search coverage (composed fixture / decomposed query and the reverse) against the `unicode61` tokenizer contract
- adds observability for non-string `portfolio.registry_path` fallback and normalizes outer whitespace on string paths
- pins repeated slug-collision warning behavior as intentional per discovery pass
- adds direct traceability and independent tiebreak assertions for `_lost_in_middle_order()`
- scaffolds the release vehicle for these runtime-visible changes as `v4.2.2`

## Release vehicle

This branch now carries the `v4.2.2` scaffold required by review:

- `ontos/__init__.py` -> `4.2.2`
- `pyproject.toml` -> `4.2.2`
- `CHANGELOG.md` -> new `[4.2.2]` section
- `docs/releases/v4.2.2.md` -> release note covering Issue #105 plus the derivative behavior commitments surfaced in review

## Behavior changes (user-visible)

- overlong FTS queries now return `E_INVALID_QUERY` before strip-based normalization, including whitespace-flood inputs
- malformed explicit FTS syntax that SQLite surfaces as `"no such column"` now stays inside the existing `E_INVALID_QUERY` envelope
- non-string `portfolio.registry_path` values now emit a `WARNING` before falling back to the default path
- Unicode NFC/NFD search parity is now test-asserted as part of the release contract

## Validation

- `python3 -m pytest tests/mcp/test_portfolio.py -q`
- `python3 -m pytest tests/mcp/test_portfolio_config.py tests/mcp/test_scanner.py tests/mcp/test_bundler.py -q`
- `python3 -m pytest -q`

Result: `1248 passed, 2 skipped, 2 warnings`

## Commit structure

Five commits, grouped for rollback-friendly independence:

1. `1e860a8` — `fix(mcp): harden FTS query edge cases (#105 M-01 M-03 M-07 M-08)`
2. `f25e341` — `fix(mcp): clarify registry_path coercion behavior (#105 M-04 M-05)`
3. `3b552c8` — `test(mcp): pin scanner collision warning policy (#105 M-09)`
4. `bf4fc09` — `test(mcp): document bundle ordering intent (#105 M-02 M-06)`
5. `8abe9f3` — `chore(release): scaffold v4.2.2 for issue #105 hardening`

## Scope

This PR covers the shipped portion of Issue #105. It does not pull in the deeper residual follow-up items called out by review (PathLike / None coercion policy, Unicode-whitespace strip asymmetry, SQLite error-string fragility, broken-pipe handling, and related polish).

Closes #105
