### PR TITLE
Fix ontos-validate check mode side effects

### DIFF
--- a/.ontos/scripts/ontos_generate_context_map.py
+++ b/.ontos/scripts/ontos_generate_context_map.py
@@ -919,9 +919,10 @@ def get_status_indicator(status: str) -> str:
     return ''
 
 
-def generate_context_map(target_dirs: list[str], quiet: bool = False, strict: bool = False, 
+def generate_context_map(target_dirs: list[str], quiet: bool = False, strict: bool = False,
                          lint: bool = False, include_rejected: bool = False,
-                         include_archived: bool = False, skip_history: bool = False) -> int:
+                         include_archived: bool = False, skip_history: bool = False,
+                         check: bool = False) -> int:
     """Main function to generate the Ontos_Context_Map.md file.
 
     Args:
@@ -930,6 +931,8 @@ def generate_context_map(target_dirs: list[str], quiet: bool = False, strict: bo
         include_rejected: Include rejected proposals in context map.
         include_archived: Include archived logs in context map.
         skip_history: Skip regenerating decision_history.md.
+        check: Validate only; skip writing Ontos_Context_Map.md and
+            decision_history.md. Intended for pre-commit/CI use.
 
     Returns:
         Number of issues found.
@@ -1057,35 +1060,41 @@ Scanned Directory: `{dirs_str}`
 {staleness_audit}
 """
 
-    # v2.8: Use transactional write
-    try:
-        ctx.buffer_write(Path(OUTPUT_FILE), content)
-        
-        # v2.7: Buffer decision_history.md unless --skip-history
-        if not skip_history:
-            output.info("Regenerating decision_history.md (v2.7 immutable history)...")
-            logs_dir = get_logs_dir()
-            archive_logs_dir = get_archive_logs_dir()
-            history_path = get_decision_history_path()
-            # Generate content without writing (we buffer it ourselves)
-            history_content, history_warnings = generate_decision_history(
-                [logs_dir, archive_logs_dir],
-                None  # Don't write directly, we'll buffer it
-            )
-            ctx.buffer_write(Path(history_path), history_content)
-        
-        # Commit all writes atomically
-        modified = ctx.commit()
-        
-        output.success(f"Successfully generated {OUTPUT_FILE}")
-        output.info(f"Scanned {len(files_data)} documents, found {len(issues)} issues.")
-        if not skip_history:
-            output.info(f"  Generated {history_path}")
-            
-    except Exception as e:
-        ctx.rollback()
-        output.error(f"Failed to write files: {e}")
-        sys.exit(1)
+    # v2.8: Use transactional write — skipped in --check mode (validate-only)
+    if check:
+        output.info(
+            f"Check mode: validated {len(files_data)} documents, "
+            f"found {len(issues)} issues. Skipping writes."
+        )
+    else:
+        try:
+            ctx.buffer_write(Path(OUTPUT_FILE), content)
+
+            # v2.7: Buffer decision_history.md unless --skip-history
+            if not skip_history:
+                output.info("Regenerating decision_history.md (v2.7 immutable history)...")
+                logs_dir = get_logs_dir()
+                archive_logs_dir = get_archive_logs_dir()
+                history_path = get_decision_history_path()
+                # Generate content without writing (we buffer it ourselves)
+                history_content, history_warnings = generate_decision_history(
+                    [logs_dir, archive_logs_dir],
+                    None  # Don't write directly, we'll buffer it
+                )
+                ctx.buffer_write(Path(history_path), history_content)
+
+            # Commit all writes atomically
+            modified = ctx.commit()
+
+            output.success(f"Successfully generated {OUTPUT_FILE}")
+            output.info(f"Scanned {len(files_data)} documents, found {len(issues)} issues.")
+            if not skip_history:
+                output.info(f"  Generated {history_path}")
+
+        except Exception as e:
+            ctx.rollback()
+            output.error(f"Failed to write files: {e}")
+            sys.exit(1)
 
     # Count error-level issues (exclude INFO for strict mode purposes)
     error_issues = [i for i in issues if '[INFO]' not in i]
@@ -1242,6 +1251,9 @@ Examples:
                         help='Include archived logs in context map (default: excluded)')
     parser.add_argument('--skip-history', action='store_true',
                         help='Skip regenerating decision_history.md (v2.7)')
+    parser.add_argument('--check', action='store_true',
+                        help='Validate only; do not write Ontos_Context_Map.md or '
+                             'decision_history.md (intended for pre-commit/CI use)')
     args = parser.parse_args()
 
     # Default to docs directory if none specified
@@ -1258,10 +1270,11 @@ Examples:
         watch_mode(target_dirs, args.quiet)
         return 0
     else:
-        issue_count = generate_context_map(target_dirs, args.quiet, args.strict, args.lint, 
+        issue_count = generate_context_map(target_dirs, args.quiet, args.strict, args.lint,
                                            getattr(args, 'include_rejected', False),
                                            getattr(args, 'include_archived', False),
-                                           getattr(args, 'skip_history', False))
+                                           getattr(args, 'skip_history', False),
+                                           getattr(args, 'check', False))
         
         # v2.5: Check consolidation status for prompted/advisory modes
         if not args.quiet:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,12 +6,9 @@ repos:
     hooks:
       - id: ontos-validate
         name: Validate Ontos Context Map
-        entry: python3 .ontos/scripts/ontos_generate_context_map.py --strict --quiet
+        entry: python3 .ontos/scripts/ontos_generate_context_map.py --strict --quiet --check
         language: system
         pass_filenames: false
-        always_run: true
-        stages: [commit]
-
         always_run: true
         stages: [commit]
 

--- a/tests/test_pre_commit_check.py
+++ b/tests/test_pre_commit_check.py
@@ -225,6 +225,95 @@ class TestMainNeverBlocks:
     
     def test_returns_zero_on_exception(self):
         from ontos_pre_commit_check import main
-        
+
         with patch('ontos_pre_commit_check.should_consolidate', side_effect=Exception('Test error')):
             assert main() == 0
+
+
+class TestValidateCheckMode:
+    """Regression coverage for issue #122: --check must validate without writing."""
+
+    REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    SCRIPT = os.path.join(REPO_ROOT, '.ontos', 'scripts', 'ontos_generate_context_map.py')
+
+    @staticmethod
+    def _read_bytes(path):
+        with open(path, 'rb') as f:
+            return f.read()
+
+    def _run_check(self, *extra_args, cwd=None):
+        import subprocess
+        return subprocess.run(
+            [sys.executable, self.SCRIPT, '--strict', '--quiet', '--check', *extra_args],
+            cwd=cwd or self.REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env={**os.environ, 'ONTOS_NO_DEPRECATION_WARNINGS': '1'},
+        )
+
+    def test_check_mode_does_not_write_context_map(self):
+        context_map = os.path.join(self.REPO_ROOT, 'Ontos_Context_Map.md')
+        if not os.path.exists(context_map):
+            pytest.skip("Ontos_Context_Map.md not present; nothing to compare against.")
+
+        before = self._read_bytes(context_map)
+        before_mtime = os.stat(context_map).st_mtime_ns
+
+        result = self._run_check()
+
+        assert result.returncode in (0, 1), (
+            f"unexpected exit {result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert self._read_bytes(context_map) == before, (
+            "Ontos_Context_Map.md was rewritten by --check (issue #122 regression)"
+        )
+        assert os.stat(context_map).st_mtime_ns == before_mtime, (
+            "Ontos_Context_Map.md mtime changed under --check (issue #122 regression)"
+        )
+
+    def test_check_mode_does_not_write_decision_history(self):
+        history = os.path.join(
+            self.REPO_ROOT, '.ontos-internal', 'reference', 'decision_history.md'
+        )
+        if not os.path.exists(history):
+            pytest.skip("decision_history.md not present; nothing to compare against.")
+
+        before = self._read_bytes(history)
+        before_mtime = os.stat(history).st_mtime_ns
+
+        result = self._run_check()
+
+        assert result.returncode in (0, 1), (
+            f"unexpected exit {result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert self._read_bytes(history) == before, (
+            "decision_history.md was rewritten by --check (issue #122 regression)"
+        )
+        assert os.stat(history).st_mtime_ns == before_mtime, (
+            "decision_history.md mtime changed under --check (issue #122 regression)"
+        )
+
+    def test_check_mode_still_reports_validation_errors(self, tmp_path):
+        docs = tmp_path / 'docs'
+        docs.mkdir()
+        (docs / 'good.md').write_text(
+            "---\nid: good_doc\ntype: atom\nstatus: active\n---\n# Good\n",
+            encoding='utf-8',
+        )
+        (docs / 'bad.md').write_text(
+            "---\nid: bad_doc\ntype: atom\nstatus: active\n"
+            "depends_on: [nonexistent_dep_for_test_122]\n---\n# Bad\n",
+            encoding='utf-8',
+        )
+
+        result = self._run_check('--dir', str(docs), cwd=tmp_path)
+
+        assert result.returncode != 0, (
+            "--strict --check must exit non-zero when validation errors exist.\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        combined = (result.stdout + result.stderr).lower()
+        assert 'nonexistent_dep_for_test_122' in combined, (
+            f"Expected broken-dep error in output. Got:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )


### PR DESCRIPTION
## Summary

Closes [#122](https://github.com/ohjonathan/Project-Ontos/issues/122).

The `ontos-validate` pre-commit hook called `.ontos/scripts/ontos_generate_context_map.py --strict --quiet`, which unconditionally rewrote `Ontos_Context_Map.md` and `.ontos-internal/reference/decision_history.md` with fresh `datetime.now()` timestamps on every invocation — dirtying the working tree on every commit, forcing re-staging, and causing the hook to spuriously fail on second passes even when strict validation passed.

This change:

- Adds a `--check` flag to the legacy regenerator that runs every validation step but skips the `buffer_write` / `commit` block (function signature gains `check: bool = False`).
- Flips the pre-commit hook entry to `--strict --quiet --check`.
- Drops a stray duplicated `always_run: true` / `stages: [commit]` block in `.pre-commit-config.yaml`.
- Adds three regression tests under a new `TestValidateCheckMode` class:
  - `--check` does not write `Ontos_Context_Map.md`
  - `--check` does not write `decision_history.md`
  - `--check --strict` still exits non-zero on validation errors

The modern `ontos.commands.map.generate_context_map()` already returns `(content, validation)` and lets the caller decide whether to write — only the legacy script (still owned by the hook) needed the split.

## Verification

| Check | Result |
|---|---|
| New tests in isolation | 3 pass, **zero** repo drift |
| Full pytest suite | 1339 passed, 2 skipped (was 1336, no regressions) |
| Direct `--check` invocation on live repo | exit 0, no writes |
| `.venv/bin/pre-commit run ontos-validate --all-files` | **Passed**, no writes |
| Commit-time hook run (this PR's own commit) | **Passed**, no writes — `git status` clean after commit |
| Diff size | 3 files, +137 / −38 |

## Out of scope

Spotted while working in these files but intentionally not bundled — best as separate micro-PRs / tickets:

- **pre-commit `stages: [commit]` deprecation.** pre-commit warns `uses deprecated stage names (commit) which will be removed in a future version` on every run; the fix is renaming to `[pre-commit]`. Trivial, unrelated to #122.
- **Other pre-existing tests dirty the live tree.** Running the full `pytest` suite still produces drift in `Ontos_Context_Map.md`, `decision_history.md`, and creates an untracked log file (`.ontos-internal/logs/2026-05-23_init.md`). Same family of bug as #122 (validation/test paths writing into the working tree) but different actors — those tests should use `tmp_path` rather than the real repo. Worth its own issue once #122 lands so the diff stays scoped.
- **`ontos.commands.activate.activate_command` always passes `write_map=True`** ([ontos/commands/activate.py:27](https://github.com/ohjonathan/Project-Ontos/blob/main/ontos/commands/activate.py#L27)) — the same timestamp churn fires whenever an agent runs `mcp__ontos__activate` or `ontos activate`. Defaulting to `write_map=False` (or only writing on content change) would close the gap fully; covered in the issue thread for #122.

## Test plan

- [x] `.venv/bin/python -m pytest tests/test_pre_commit_check.py::TestValidateCheckMode -v` — 3 passed
- [x] `.venv/bin/python -m pytest -q` — 1339 passed, 2 skipped
- [x] `.venv/bin/pre-commit run ontos-validate --all-files` — passed, tree clean
- [x] `python3 .ontos/scripts/ontos_generate_context_map.py --strict --quiet --check` against the live repo — exit 0, tree clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)