### PR TITLE
Bump GitHub Actions to Node 24-compatible pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -69,10 +69,10 @@ jobs:
   test-non-editable:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/golden-master.yml
+++ b/.github/workflows/golden-master.yml
@@ -17,10 +17,10 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -35,7 +35,7 @@ jobs:
 
       - name: Upload diff artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: golden-master-diffs-${{ matrix.python-version }}
           path: tests/golden/baselines/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,10 +20,10 @@ jobs:
     name: Run Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.11"
 
@@ -50,10 +50,10 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.11"
 
@@ -64,7 +64,7 @@ jobs:
         run: python -m build
 
       - name: Upload distribution artifacts
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: dist
           path: dist/
@@ -76,7 +76,7 @@ jobs:
     environment: testpypi
     steps:
       - name: Download distribution artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: dist
           path: dist/
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.11"
 
@@ -118,7 +118,7 @@ jobs:
     environment: pypi
     steps:
       - name: Download distribution artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
## Summary

Closes #123.

GitHub forces Actions onto Node.js 24 starting **2026-06-02** (soft) and removes Node 20 from runners on **2026-09-16** (hard). Every run of `publish.yml`, `ci.yml`, and `golden-master.yml` currently warns about this — most recently surfaced during the v4.6.0 publish run.

This PR bumps the four affected `actions/*` pins to their **latest** Node 24-compatible releases, still pinned by commit SHA. Scope is strictly the Node 20 deprecation set; `pypa/gh-action-pypi-publish` and `codecov/codecov-action` are not in that set and stay put.

## Pin updates

| Action | Old SHA · tag | New tag | New SHA |
|---|---|---|---|
| `actions/checkout` | `11bd71901bbe5b1630ceea73d27597364c9af683` · v4 | [v6.0.2](https://github.com/actions/checkout/releases/tag/v6.0.2) | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` |
| `actions/setup-python` | `0b93645e9fea7318ecaed2b359559ac225c90a2b` · v5 | [v6.2.0](https://github.com/actions/setup-python/releases/tag/v6.2.0) | `a309ff8b426b58ec0e2a45f0f869d46889d02405` |
| `actions/upload-artifact` | `6f51ac03b9356f520e9adb1b1b7802705f340c2b` · v4 | [v7.0.1](https://github.com/actions/upload-artifact/releases/tag/v7.0.1) | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` |
| `actions/download-artifact` | `fa0a91b85d4f404e444e00e005971372dc801d16` · v4 | [v8.0.1](https://github.com/actions/download-artifact/releases/tag/v8.0.1) | `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` |

Inline comments updated to `# v6` / `# v6` / `# v7` / `# v8` to match.

## Files touched

15 `uses:` lines across 3 workflows (`+15 -15`, no other changes):

- `.github/workflows/ci.yml` — 4 lines (checkout ×2, setup-python ×2)
- `.github/workflows/golden-master.yml` — 3 lines (checkout, setup-python, upload-artifact)
- `.github/workflows/publish.yml` — 8 lines (checkout ×2, setup-python ×3, upload-artifact, download-artifact ×2)

## Compatibility notes

- **`upload-artifact` v7** adds an opt-in `archive: false` direct-upload mode. No call site sets `archive`, so default (zipped) behavior is preserved.
- **`download-artifact` v8** migrated to ESM (transparent) and now errors on hash mismatches by default. Workflows produce and consume artifacts within the same run, so this is a safety improvement, not a regression risk.
- **Publishing semantics, codecov, and PyPI publish are unchanged.**

## Verification

```
# 1) All four bumped actions now exclusively on new SHAs (15 lines)
rg -n "actions/(checkout|setup-python|upload-artifact|download-artifact)@" .github/workflows
  → 15 matches, all new SHAs ✓

# 2) Old SHAs fully removed
rg -n "11bd71901bbe5b1630ceea73d27597364c9af683|0b93645e9fea7318ecaed2b359559ac225c90a2b|6f51ac03b9356f520e9adb1b1b7802705f340c2b|fa0a91b85d4f404e444e00e005971372dc801d16" .github/workflows
  → 0 matches ✓

# 3) YAML parses
python -c "import yaml; [yaml.safe_load(open(f)) for f in ['.github/workflows/publish.yml','.github/workflows/ci.yml','.github/workflows/golden-master.yml']]"
  → ok ✓

# 4) Test suite
.venv/bin/python -m pytest -q
  → 1339 passed, 2 skipped, 0 failed (53s) ✓

# 5) Framework health
scripts/llm-dev doctor
  → PASS ✓
```

## Test plan

- [ ] CI green on this PR (exercises `ci.yml`; `golden-master.yml` is `workflow_dispatch`-only)
- [ ] No Node 20 deprecation warnings in the CI run logs
- [ ] `publish.yml` warning will only clear on the next release tag run — expected, not blocking on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)