### PR TITLE
Bump codecov-action to Node 24-compatible pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload coverage
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         if: matrix.python-version == '3.11'
         with:
           files: coverage.xml


### PR DESCRIPTION
## Summary
- Bumps the SHA-pinned `codecov/codecov-action` in `.github/workflows/ci.yml:62` from `b9fd7d1` (v4, Node 20) to `e79a696` (v6.0.1, Node 24).
- Follow-up to [#125](https://github.com/ohjonathan/Project-Ontos/pull/125) (issue [#123](https://github.com/ohjonathan/Project-Ontos/issues/123)): the CI run on that PR still listed `codecov/codecov-action@b9fd7d16…` in the Node 20 deprecation warning. After this bump, `codecov/codecov-action` no longer appears in that warning.
- Bonus: v6.0.1 includes the [VULN-1652](https://github.com/codecov/codecov-action/releases/tag/v6.0.1) template-injection fix for user-controlled values in `run:` steps.

## Note on remaining Node 20 warning
The deprecation warning has not gone away entirely. After this PR, the CI logs still emit a Node 20 warning, now flagging `actions/checkout@11bd7190…` (v4) and `actions/setup-python@0b93645e…` (v5). Those pins were updated by #125 but to releases that still default to Node 20 (Node 24 only ships in `actions/checkout@v5+` and `actions/setup-python@v6+`). A separate follow-up will be needed to fully clear the warning before the 2026-06-02 enforcement date.

## Test plan
- [x] `rg -n "codecov/codecov-action@" .github/workflows` shows only the new SHA
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` parses cleanly
- [x] `pytest -q` → 1339 passed, 2 skipped locally
- [x] CI green on this PR (all 5 jobs pass)
- [x] `gh run view 26334366311 --log | rg -i node` confirms `codecov/codecov-action` is no longer in the Node 20 warning (checkout/setup-python still are — see note above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)