### PR TITLE
feat(validation): allowlisted external file dependencies at info severity (#134)

### DIFF
--- a/ontos/commands/activate.py
+++ b/ontos/commands/activate.py
@@ -146,7 +146,7 @@ def run_activation(
         warnings_page, warnings_total, warnings_truncated = select_warning_records(
             validation_warnings, rule_id=warning_rule, limit=limit
         )
-        info_page, _, _ = select_warning_records(
+        info_page, info_total, _ = select_warning_records(
             validation_infos, rule_id=warning_rule, limit=limit
         )
     else:
@@ -156,6 +156,11 @@ def run_activation(
         warnings_page = []
         warnings_truncated = warnings_total > 0
         info_page = []
+        # info_total honors the rule filter just like warnings_total
+        # (Codex review finding 7 on #140).
+        _, info_total, _ = select_warning_records(
+            validation_infos, rule_id=warning_rule
+        )
     # (#134) Info records (allowlisted external file deps) get the same
     # grouping budget — 188 inline records would re-create the #132 flood.
     info_groups = group_warning_records(validation_infos, rule_id=warning_rule)
@@ -181,7 +186,7 @@ def run_activation(
                 groups, include_samples=(warnings_mode != "summary")
             ),
             "info": info_page,
-            "info_total": len(validation_infos),
+            "info_total": info_total,
             "info_groups": groups_to_payload(
                 info_groups, include_samples=(warnings_mode != "summary")
             ),

--- a/ontos/commands/activate.py
+++ b/ontos/commands/activate.py
@@ -109,6 +109,9 @@ def run_activation(
         "scope": effective_scope.value,
         "allowed_orphan_types": config.validation.allowed_orphan_types,
         "allowed_orphan_paths": config.validation.allowed_orphan_paths,
+        "allowed_external_dependency_paths": (
+            config.validation.allowed_external_dependency_paths
+        ),
         "project_root": str(project_root),
         "docs_dir": str(config.paths.docs_dir),
         "logs_dir": str(config.paths.logs_dir),
@@ -117,6 +120,7 @@ def run_activation(
     map_refreshed = False
     validation_errors = []
     validation_warnings = []
+    validation_infos = []
     if docs:
         content, validation = generate_context_map(
             docs,
@@ -125,6 +129,7 @@ def run_activation(
         )
         validation_errors = [issue.to_dict() for issue in validation.errors]
         validation_warnings = [issue.to_dict() for issue in validation.warnings]
+        validation_infos = [issue.to_dict() for issue in validation.infos]
         if write_map:
             output_path.parent.mkdir(parents=True, exist_ok=True)
             output_path.write_text(content, encoding="utf-8")
@@ -141,12 +146,19 @@ def run_activation(
         warnings_page, warnings_total, warnings_truncated = select_warning_records(
             validation_warnings, rule_id=warning_rule, limit=limit
         )
+        info_page, _, _ = select_warning_records(
+            validation_infos, rule_id=warning_rule, limit=limit
+        )
     else:
         _, warnings_total, _ = select_warning_records(
             validation_warnings, rule_id=warning_rule
         )
         warnings_page = []
         warnings_truncated = warnings_total > 0
+        info_page = []
+    # (#134) Info records (allowlisted external file deps) get the same
+    # grouping budget — 188 inline records would re-create the #132 flood.
+    info_groups = group_warning_records(validation_infos, rule_id=warning_rule)
 
     payload = {
         "status": status,
@@ -168,11 +180,17 @@ def run_activation(
             "warning_groups": groups_to_payload(
                 groups, include_samples=(warnings_mode != "summary")
             ),
+            "info": info_page,
+            "info_total": len(validation_infos),
+            "info_groups": groups_to_payload(
+                info_groups, include_samples=(warnings_mode != "summary")
+            ),
         },
         "summary": {
             "load_issues": len(load_result.issues),
             "validation_errors": len(validation_errors),
             "validation_warnings": len(validation_warnings),
+            "validation_info": len(validation_infos),
         },
         "recommendation": (
             "continue; use direct reads for task-critical docs"
@@ -247,11 +265,15 @@ def _not_usable(
             "warnings_total": 0,
             "warnings_truncated": False,
             "warning_groups": [],
+            "info": [],
+            "info_total": 0,
+            "info_groups": [],
         },
         "summary": {
             "load_issues": len(issues or []),
             "validation_errors": 0,
             "validation_warnings": 0,
+            "validation_info": 0,
         },
         "recommendation": "halt; no usable Ontos context is available",
     }

--- a/ontos/commands/link_check.py
+++ b/ontos/commands/link_check.py
@@ -136,6 +136,11 @@ def _emit_human_report(
     print("Summary")
     print(f"  duplicate_ids: {result.summary.duplicate_ids}")
     print(f"  broken_references: {result.summary.broken_references}")
+    print(f"  file_dependencies: {result.summary.file_dependencies}")
+    print(
+        "  unallowlisted_file_dependencies: "
+        f"{result.summary.unallowlisted_file_dependencies}"
+    )
     print(f"  external_references: {result.summary.external_references}")
     print(f"  parse_failed_candidates: {result.summary.parse_failed_candidates}")
     print(f"  orphans: {result.summary.orphans}")
@@ -145,6 +150,7 @@ def _emit_human_report(
     if not summary_only:
         _emit_duplicates(result)
         _emit_broken_by_field(result)
+        _emit_file_dependencies(result)
         _emit_external_refs(result)
         _emit_parse_failed_candidates(result)
         _emit_suggestions(result)
@@ -194,6 +200,20 @@ def _emit_broken_by_field(result: LinkDiagnosticsResult) -> None:
             if finding.location is not None:
                 base += f" (line {finding.location.line}, {finding.location.match_type})"
             print(base)
+    print()
+
+
+def _emit_file_dependencies(result: LinkDiagnosticsResult) -> None:
+    if not result.file_dependencies:
+        return
+    print("File Dependencies (resolved on disk)")
+    for item in result.file_dependencies:
+        marker = "allowlisted" if item.allowlisted else "review"
+        print(
+            "  - "
+            f"{item.source_doc_id} [{item.field}] -> {item.value} "
+            f"[{marker}] ({item.resolved_path})"
+        )
     print()
 
 

--- a/ontos/commands/maintain.py
+++ b/ontos/commands/maintain.py
@@ -652,6 +652,22 @@ def _task_check_links(ctx: MaintainContext) -> TaskResult:
     if len(diagnostics.duplicates) > 5:
         details.append(f"... and {len(diagnostics.duplicates) - 5} more duplicate IDs")
 
+    # (#134 review) Unallowlisted file deps drive exit 1 — they must be
+    # visible in the failure details, not just the metrics.
+    unallowlisted = [
+        item for item in diagnostics.file_dependencies if not item.allowlisted
+    ]
+    for item in unallowlisted[:10]:
+        details.append(
+            f"❌ {item.source_doc_id} [depends_on] -> {item.value} "
+            f"(file exists at {item.resolved_path}; not in "
+            "allowed_external_dependency_paths)"
+        )
+    if len(unallowlisted) > 10:
+        details.append(
+            f"... and {len(unallowlisted) - 10} more unallowlisted file dependencies"
+        )
+
     metrics = {
         "broken_links": diagnostics.summary.broken_references,
         "orphans": diagnostics.summary.orphans,
@@ -669,8 +685,12 @@ def _task_check_links(ctx: MaintainContext) -> TaskResult:
     if diagnostics.exit_code == 1:
         return _fail(
             (
-                "Found broken references or duplicate IDs "
-                f"(broken={diagnostics.summary.broken_references}, duplicates={diagnostics.summary.duplicate_ids})."
+                "Found broken references, duplicate IDs, or unallowlisted "
+                "file dependencies "
+                f"(broken={diagnostics.summary.broken_references}, "
+                f"duplicates={diagnostics.summary.duplicate_ids}, "
+                "unallowlisted_file_deps="
+                f"{diagnostics.summary.unallowlisted_file_dependencies})."
             ),
             details=details,
             metrics=metrics,

--- a/ontos/commands/maintain.py
+++ b/ontos/commands/maintain.py
@@ -658,6 +658,12 @@ def _task_check_links(ctx: MaintainContext) -> TaskResult:
         "external_refs": diagnostics.summary.external_references,
         "duplicates": diagnostics.summary.duplicate_ids,
         "load_issues": diagnostics.summary.load_warnings,
+        # (#134) Resolved-on-disk deps re-bucketed out of broken_links;
+        # surfaced here so the broken_links drop is not silent.
+        "file_dependencies": diagnostics.summary.file_dependencies,
+        "unallowlisted_file_dependencies": (
+            diagnostics.summary.unallowlisted_file_dependencies
+        ),
     }
 
     if diagnostics.exit_code == 1:

--- a/ontos/commands/map.py
+++ b/ontos/commands/map.py
@@ -138,6 +138,9 @@ def generate_context_map(
             "max_dependency_depth": options.max_dependency_depth,
             "allowed_orphan_types": config.get("allowed_orphan_types", ["atom", "log"]),
             "allowed_orphan_paths": config.get("allowed_orphan_paths", []),
+            "allowed_external_dependency_paths": config.get(
+                "allowed_external_dependency_paths", []
+            ),
             "severity_map": {
                 "broken_link": "warning",
                 "concepts": "warning"
@@ -486,10 +489,20 @@ def _generate_validation_section(result: ValidationResult, errors_only: bool = F
             lines.append(f"- ⚠️ **{warning.doc_id}**: {warning.message}")
             if warning.fix_suggestion:
                 lines.append(f"    {warning.fix_suggestion}")
-    
+
+    # (#134) Allowlisted external file deps are informational; show a bounded
+    # sample so they are visible without dominating the section.
+    if not errors_only and result.infos:
+        lines.append("")
+        lines.append(f"### Info ({len(result.infos)})")
+        for info in result.infos[:10]:
+            lines.append(f"- ℹ️ **{info.doc_id}**: {info.message}")
+        if len(result.infos) > 10:
+            lines.append(f"- ... and {len(result.infos) - 10} more")
+
     if errors_only and not result.errors:
         return ""
-        
+
     return "\n".join(lines)
 
 
@@ -919,6 +932,9 @@ def map_command(options: MapOptions) -> int:
         "scope": effective_scope.value,
         "allowed_orphan_types": config.validation.allowed_orphan_types,
         "allowed_orphan_paths": config.validation.allowed_orphan_paths,
+        "allowed_external_dependency_paths": (
+            config.validation.allowed_external_dependency_paths
+        ),
         "project_root": str(project_root),
         "docs_dir": str(config.paths.docs_dir),
         "logs_dir": str(config.paths.logs_dir),
@@ -988,13 +1004,15 @@ def map_command(options: MapOptions) -> int:
         from ontos.core.warning_groups import group_warning_records, groups_to_payload
 
         diagnostic_records = [
-            issue.to_dict() for issue in [*result.errors, *result.warnings]
+            issue.to_dict()
+            for issue in [*result.errors, *result.warnings, *result.infos]
         ]
         payload = {
             "path": str(output_path),
             "documents": len(docs),
             "errors": len(result.errors),
             "warnings": len(result.warnings),
+            "info": len(result.infos),
             "result_status": (
                 "clean" if exit_code == 0 else ("warnings" if exit_code == 2 else "failing")
             ),

--- a/ontos/core/config.py
+++ b/ontos/core/config.py
@@ -66,6 +66,10 @@ class ValidationConfig:
     # (logs are intentional root artifacts and tolerated as orphans).
     allowed_orphan_types: List[str] = field(default_factory=lambda: ["atom", "log"])
     allowed_orphan_paths: List[str] = field(default_factory=list)
+    # (#134) Workspace-relative globs (same segment-aware semantics as
+    # allowed_orphan_paths) marking depends_on targets that exist on disk
+    # outside the doc scope as intentional external file dependencies.
+    allowed_external_dependency_paths: List[str] = field(default_factory=list)
 
 
 @dataclass
@@ -146,6 +150,7 @@ def _validate_types(data: dict) -> None:
     list_of_str_requirements = [
         ("validation", "allowed_orphan_types"),
         ("validation", "allowed_orphan_paths"),
+        ("validation", "allowed_external_dependency_paths"),
     ]
     for section, key in list_of_str_requirements:
         if section in data and key in data[section]:

--- a/ontos/core/graph.py
+++ b/ontos/core/graph.py
@@ -29,6 +29,10 @@ DESCRIBES_SEVERITY_DEFAULT = "warning"
 # verify-frontmatter and link-check share the same severity floor.
 OUT_OF_SCOPE_DEPENDENCY_SEVERITY = "warning"
 
+# (#134) Resolved-on-disk deps matching allowed_external_dependency_paths
+# are intentional doc-to-file edges, not graph damage.
+EXTERNAL_FILE_DEPENDENCY_SEVERITY = "info"
+
 
 def _looks_like_path(dep_id: str) -> bool:
     # A pure doc-id never contains a path separator or '.md' suffix.
@@ -41,14 +45,19 @@ def _resolve_depends_on_path(
     docs_by_resolved_path: Dict[Path, str],
     workspace_root: Optional[Path],
     workspace_root_resolved: Optional[Path],
-) -> Tuple[Optional[str], Optional[Path]]:
+) -> Tuple[Optional[str], Optional[Path], Optional[Path]]:
     """Try to resolve a `depends_on` entry as a filesystem path.
 
-    Returns (resolved_doc_id, external_path):
-        (id, None) — path resolved to a loaded doc; caller treats as a graph edge.
-        (None, p)  — path exists on disk inside the workspace but is not loaded;
-                      caller treats as an out-of-scope dependency (warning).
-        (None, None) — no path resolution OR resolved path escapes the
+    Returns (resolved_doc_id, external_path, external_resolved):
+        (id, None, None) — path resolved to a loaded doc; caller treats as a
+                      graph edge.
+        (None, p, r) — path exists on disk inside the workspace but is not
+                      loaded; caller treats as an out-of-scope dependency
+                      (warning). `p` is the matched candidate (kept for
+                      message stability), `r` its fully resolved form —
+                      allowlist checks must use `r` so symlinked candidates
+                      cannot dodge or false-match patterns (#134).
+        (None, None, None) — no path resolution OR resolved path escapes the
                        workspace; caller falls back to broken-link.
 
     Containment: any candidate whose resolved path (with symlinks followed)
@@ -58,7 +67,7 @@ def _resolve_depends_on_path(
     must not leak filesystem state through the activation warnings channel.
     """
     if workspace_root is None or not _looks_like_path(dep_id):
-        return None, None
+        return None, None, None
 
     candidates: List[Path] = []
     raw = Path(dep_id)
@@ -80,10 +89,10 @@ def _resolve_depends_on_path(
             except ValueError:
                 continue
         if resolved in docs_by_resolved_path:
-            return docs_by_resolved_path[resolved], None
+            return docs_by_resolved_path[resolved], None, None
         if candidate.exists():
-            return None, candidate
-    return None, None
+            return None, candidate, resolved
+    return None, None, None
 
 
 @dataclass
@@ -116,6 +125,7 @@ def build_graph(
     docs: Dict[str, DocumentData],
     severity_map: Optional[Dict[str, str]] = None,
     workspace_root: Optional[Path] = None,
+    allowed_external_dependency_paths: Optional[Sequence[str]] = None,
 ) -> Tuple[DependencyGraph, List[ValidationError]]:
     """Build dependency graph from document dictionary.
 
@@ -128,6 +138,10 @@ def build_graph(
             before being reported as broken (#117). Loaded-doc-path matches
             become normal edges; existing-but-not-loaded paths become a
             soft OUT_OF_SCOPE_DEPENDENCY warning instead of a hard error.
+        allowed_external_dependency_paths: (#134) Workspace-relative globs;
+            a resolved-on-disk dep matching one is reported as an
+            EXTERNAL_FILE_DEPENDENCY at info severity instead of an
+            out-of-scope warning.
 
     Returns:
         Tuple of (DependencyGraph, list of broken/out-of-scope link errors)
@@ -144,6 +158,10 @@ def build_graph(
     out_of_scope_severity = severity_map.get(
         "out_of_scope_dependency", OUT_OF_SCOPE_DEPENDENCY_SEVERITY
     )
+    external_file_severity = severity_map.get(
+        "external_file_dependency", EXTERNAL_FILE_DEPENDENCY_SEVERITY
+    )
+    external_allowlist = list(allowed_external_dependency_paths or [])
 
     # (#135) One suggestion index per build, with results memoized per unique
     # dep value — the same broken target declared from many docs used to
@@ -178,29 +196,67 @@ def build_graph(
                 resolved_depends_on.append(dep_id)
                 continue
 
-            resolved_id, external_path = _resolve_depends_on_path(
+            resolved_id, external_path, external_resolved = _resolve_depends_on_path(
                 dep_id, doc, docs_by_resolved_path, workspace_root, workspace_root_resolved
             )
             if resolved_id is not None:
                 resolved_depends_on.append(resolved_id)
                 continue
             if external_path is not None:
-                errors.append(ValidationError(
-                    error_type=ValidationErrorType.OUT_OF_SCOPE_DEPENDENCY,
-                    doc_id=doc_id,
-                    filepath=str(doc.filepath),
-                    message=(
-                        f"External dependency resolved from disk: '{dep_id}' "
-                        f"(declared in {doc_id}) exists at "
-                        f"'{external_path}' but is not a loaded document."
-                    ),
-                    fix_suggestion=(
-                        "If the target should be tracked as a doc, add an "
-                        "Ontos frontmatter id; otherwise this can be left as a "
-                        "soft external reference."
-                    ),
-                    severity=out_of_scope_severity,
-                ))
+                rel_posix: Optional[str] = None
+                if external_resolved is not None and workspace_root_resolved is not None:
+                    try:
+                        rel_posix = external_resolved.relative_to(
+                            workspace_root_resolved
+                        ).as_posix()
+                    except ValueError:
+                        rel_posix = None
+                allowlisted = bool(
+                    external_allowlist
+                    and rel_posix is not None
+                    and _path_matches_allowlist(rel_posix, external_allowlist)
+                )
+                if allowlisted:
+                    errors.append(ValidationError(
+                        error_type=ValidationErrorType.EXTERNAL_FILE_DEPENDENCY,
+                        doc_id=doc_id,
+                        filepath=str(doc.filepath),
+                        message=(
+                            f"External file dependency (allowlisted): '{dep_id}' "
+                            f"(declared in {doc_id}) resolved to '{rel_posix}'."
+                        ),
+                        fix_suggestion="",
+                        severity=external_file_severity,
+                        context={
+                            "dep_value": dep_id,
+                            "resolved_path": rel_posix,
+                            "allowlisted": True,
+                        },
+                    ))
+                else:
+                    errors.append(ValidationError(
+                        error_type=ValidationErrorType.OUT_OF_SCOPE_DEPENDENCY,
+                        doc_id=doc_id,
+                        filepath=str(doc.filepath),
+                        message=(
+                            f"External dependency resolved from disk: '{dep_id}' "
+                            f"(declared in {doc_id}) exists at "
+                            f"'{external_path}' but is not a loaded document."
+                        ),
+                        fix_suggestion=(
+                            "If the target should be tracked as a doc, add an "
+                            "Ontos frontmatter id; otherwise this can be left as a "
+                            "soft external reference."
+                        ),
+                        severity=out_of_scope_severity,
+                        context={
+                            "dep_value": dep_id,
+                            "resolved_path": (
+                                rel_posix if rel_posix is not None else str(external_path)
+                            ),
+                            "allowlisted": False,
+                        },
+                    ))
                 continue
 
             if dep_id not in suggestion_memo:

--- a/ontos/core/link_diagnostics.py
+++ b/ontos/core/link_diagnostics.py
@@ -73,6 +73,24 @@ class ExternalReference:
 
 
 @dataclass(frozen=True)
+class FileDependencyReference:
+    """(#134) depends_on target that exists on disk but is not a loaded doc.
+
+    `allowlisted` is True when the resolved path matches the project's
+    allowed_external_dependency_paths globs (intentional doc-to-file edge);
+    False means the dep resolved on disk but is not declared intentional.
+    """
+
+    source_doc_id: str
+    source_path: Path
+    value: str
+    resolved_path: str
+    allowlisted: bool
+    severity: str
+    field: str = "depends_on"
+
+
+@dataclass(frozen=True)
 class ParseFailedCandidate:
     """Reference candidate found in parse-failed raw scan."""
 
@@ -105,6 +123,10 @@ class LinkDiagnosticsSummary:
     external_references: int
     parse_failed_candidates: int
     orphans: int
+    # (#134) Resolved-on-disk depends_on targets, re-bucketed out of
+    # broken_references. Only the unallowlisted subset drives exit code 1.
+    file_dependencies: int = 0
+    unallowlisted_file_dependencies: int = 0
 
 
 @dataclass
@@ -122,6 +144,7 @@ class LinkDiagnosticsResult:
     orphans: List[OrphanDocument]
     load_warnings: List[DocumentLoadIssue]
     timings_ms: Dict[str, int] = field(default_factory=dict)
+    file_dependencies: List[FileDependencyReference] = field(default_factory=list)
 
     @property
     def result_status(self) -> str:
@@ -189,6 +212,18 @@ class LinkDiagnosticsResult:
         sections: Dict[str, List[object]] = {
             "duplicates": duplicates,
             "broken_references": broken,
+            "file_dependencies": [
+                {
+                    "source_doc_id": item.source_doc_id,
+                    "source_path": str(item.source_path),
+                    "field": item.field,
+                    "value": item.value,
+                    "resolved_path": item.resolved_path,
+                    "allowlisted": item.allowlisted,
+                    "severity": item.severity,
+                }
+                for item in self.file_dependencies
+            ],
             "external_references": [
                 {
                     "source_doc_id": finding.source_doc_id,
@@ -252,6 +287,10 @@ class LinkDiagnosticsResult:
                 "external_references": self.summary.external_references,
                 "parse_failed_candidates": self.summary.parse_failed_candidates,
                 "orphans": self.summary.orphans,
+                "file_dependencies": self.summary.file_dependencies,
+                "unallowlisted_file_dependencies": (
+                    self.summary.unallowlisted_file_dependencies
+                ),
             },
             "timings_ms": dict(self.timings_ms),
             "findings_truncated": bool(truncated_sections),
@@ -334,8 +373,35 @@ def run_link_diagnostics(
         docs,
         severity_map=_LINK_CHECK_SEVERITY,
         workspace_root=repo_root,
+        allowed_external_dependency_paths=(
+            config.validation.allowed_external_dependency_paths
+        ),
     )
+    file_dependencies: List[FileDependencyReference] = []
+    file_dep_seen: Set[Tuple[str, str, str]] = set()
     for error in broken_depends_on:
+        # (#134) Resolved-on-disk deps carry structured context and land in
+        # the file_dependencies bucket instead of broken_references.
+        if error.error_type in (
+            ValidationErrorType.OUT_OF_SCOPE_DEPENDENCY,
+            ValidationErrorType.EXTERNAL_FILE_DEPENDENCY,
+        ):
+            dep_value = error.context.get("dep_value", "")
+            key = (error.doc_id, str(error.filepath), dep_value)
+            if key in file_dep_seen:
+                continue
+            file_dep_seen.add(key)
+            file_dependencies.append(
+                FileDependencyReference(
+                    source_doc_id=error.doc_id,
+                    source_path=Path(error.filepath),
+                    value=dep_value,
+                    resolved_path=error.context.get("resolved_path", ""),
+                    allowlisted=bool(error.context.get("allowlisted", False)),
+                    severity=error.severity,
+                )
+            )
+            continue
         value = _extract_reference_value(error.message)
         if value is None:
             continue
@@ -521,10 +587,15 @@ def run_link_diagnostics(
 
     duplicates = {doc_id: sorted(paths) for doc_id, paths in load_result.duplicate_ids.items()}
 
+    unallowlisted_file_deps = len(
+        [item for item in file_dependencies if not item.allowlisted]
+    )
+
     exit_code = _resolve_exit_code(
         duplicate_count=len(duplicates),
         broken_count=len(broken_references),
         orphan_count=len(orphans),
+        unallowlisted_file_dependency_count=unallowlisted_file_deps,
     )
 
     summary = LinkDiagnosticsSummary(
@@ -538,6 +609,8 @@ def run_link_diagnostics(
         external_references=len(external_references),
         parse_failed_candidates=len(parse_failed_candidates),
         orphans=len(orphans),
+        file_dependencies=len(file_dependencies),
+        unallowlisted_file_dependencies=unallowlisted_file_deps,
     )
 
     timings_ms["total"] = _elapsed_ms(total_start)
@@ -554,6 +627,7 @@ def run_link_diagnostics(
         orphans=orphans,
         load_warnings=load_result.issues,
         timings_ms=timings_ms,
+        file_dependencies=file_dependencies,
     )
 
 
@@ -637,8 +711,16 @@ def _extract_reference_value(message: str) -> Optional[str]:
     return match.group(1)
 
 
-def _resolve_exit_code(duplicate_count: int, broken_count: int, orphan_count: int) -> int:
-    if duplicate_count > 0 or broken_count > 0:
+def _resolve_exit_code(
+    duplicate_count: int,
+    broken_count: int,
+    orphan_count: int,
+    unallowlisted_file_dependency_count: int = 0,
+) -> int:
+    # (#134) Unallowlisted resolved-on-disk deps preserve the pre-rebucketing
+    # exit-1 semantics for unconfigured repos; allowlisted ones never drive
+    # exit codes.
+    if duplicate_count > 0 or broken_count > 0 or unallowlisted_file_dependency_count > 0:
         return 1
     if orphan_count > 0:
         return 2

--- a/ontos/core/types.py
+++ b/ontos/core/types.py
@@ -99,6 +99,10 @@ class ValidationErrorType(Enum):
     # the target is not a loaded doc — treat as a soft external dependency
     # rather than a hard broken-link error.
     OUT_OF_SCOPE_DEPENDENCY = "out_of_scope_dependency"
+    # (#134) Same resolution as OUT_OF_SCOPE_DEPENDENCY but the path matches
+    # the project's allowed_external_dependency_paths allowlist — an
+    # intentional doc-to-file edge, reported at info severity.
+    EXTERNAL_FILE_DEPENDENCY = "external_file_dependency"
 
 
 # =============================================================================
@@ -130,6 +134,12 @@ class ValidationError:
     message: str
     fix_suggestion: str
     severity: str  # 'error', 'warning', 'info'
+    # (#134) Structured machine context (e.g. dep_value / resolved_path /
+    # allowlisted) so consumers never parse messages. Deliberately NOT
+    # serialized by to_dict(): the public record shape {severity, message,
+    # rule_id, document_id, file_path} is asserted byte-for-byte by CLI/MCP
+    # parity tests and must stay stable.
+    context: Dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
         record: Dict[str, Any] = {"severity": self.severity, "message": self.message}
@@ -148,6 +158,9 @@ class ValidationResult:
     """Result of running all validations."""
     errors: List[ValidationError] = field(default_factory=list)
     warnings: List[ValidationError] = field(default_factory=list)
+    # (#134) Info-severity records (e.g. allowlisted external file deps) are
+    # kept out of warnings so they never flip activation status.
+    infos: List[ValidationError] = field(default_factory=list)
 
     @property
     def exit_code(self) -> int:
@@ -157,6 +170,8 @@ class ValidationResult:
         """Add an error to the result."""
         if error.severity == "error":
             self.errors.append(error)
+        elif error.severity == "info":
+            self.infos.append(error)
         else:
             self.warnings.append(error)
 

--- a/ontos/core/validation.py
+++ b/ontos/core/validation.py
@@ -100,11 +100,16 @@ class ValidationOrchestrator:
         self.workspace_root = workspace_root
         self.errors: List[ValidationError] = []
         self.warnings: List[ValidationError] = []
+        # (#134) Info-severity records (allowlisted external file deps) are
+        # tracked separately so they never count as warnings.
+        self.infos: List[ValidationError] = []
 
     def _report(self, error: ValidationError) -> None:
-        """Report an error or warning based on its severity."""
+        """Report an error, warning, or info based on its severity."""
         if error.severity == "error":
             self.errors.append(error)
+        elif error.severity == "info":
+            self.infos.append(error)
         else:
             self.warnings.append(error)
 
@@ -112,7 +117,7 @@ class ValidationOrchestrator:
         """Run all validations and return collected results.
 
         Returns:
-            ValidationResult with all errors and warnings
+            ValidationResult with all errors, warnings, and infos
         """
         self.validate_graph()
         self.validate_log_schema()
@@ -122,7 +127,8 @@ class ValidationOrchestrator:
 
         return ValidationResult(
             errors=self.errors,
-            warnings=self.warnings
+            warnings=self.warnings,
+            infos=self.infos,
         )
 
     def validate_graph(self) -> None:
@@ -131,9 +137,12 @@ class ValidationOrchestrator:
             self.docs,
             severity_map=self.severity_map,
             workspace_root=self.workspace_root,
+            allowed_external_dependency_paths=self.config.get(
+                "allowed_external_dependency_paths", []
+            ),
         )
-        self.errors.extend([e for e in broken_link_errors if e.severity == "error"])
-        self.warnings.extend([e for e in broken_link_errors if e.severity == "warning"])
+        for link_error in broken_link_errors:
+            self._report(link_error)
 
         # Detect cycles
         cycles = detect_cycles(graph)

--- a/ontos/io/snapshot.py
+++ b/ontos/io/snapshot.py
@@ -85,6 +85,9 @@ def create_snapshot(
         {
             "allowed_orphan_types": config.validation.allowed_orphan_types,
             "allowed_orphan_paths": config.validation.allowed_orphan_paths,
+            "allowed_external_dependency_paths": (
+                config.validation.allowed_external_dependency_paths
+            ),
         },
         workspace_root=root,
     )

--- a/ontos/mcp/schemas.py
+++ b/ontos/mcp/schemas.py
@@ -30,6 +30,9 @@ class ValidationIssue(StrictModel):
 class ValidationPayload(StrictModel):
     errors: List[ValidationIssue]
     warnings: List[ValidationIssue]
+    # (#134) Info-severity records (allowlisted external file dependencies).
+    # Default keeps payloads from older snapshots schema-valid.
+    info: List[ValidationIssue] = Field(default_factory=list)
 
 
 class WarningGroup(StrictModel):
@@ -128,6 +131,11 @@ class ActivateResponse(StrictModel):
     warnings_truncated: bool
     warning_groups: List[WarningGroup]
     warnings: List[ValidationIssue]
+    # (#134) Allowlisted external file deps: grouped summary only; page full
+    # records via list_validation_warnings(severity="info"). Never merged
+    # into warnings — info must not flip activation status.
+    info_total: int = 0
+    info_groups: List[WarningGroup] = Field(default_factory=list)
 
 
 class ListValidationWarningsResponse(StrictModel):

--- a/ontos/mcp/tools.py
+++ b/ontos/mcp/tools.py
@@ -178,9 +178,12 @@ def activate(
         key=lambda doc: (-len(view.snapshot.graph.reverse_edges.get(doc.id, [])), doc.id),
     )[:5]]
     # Status derives from the full record list; the budget below only
-    # shapes what is inlined in the response.
+    # shapes what is inlined in the response. (#134) Info records are
+    # excluded from the status formula by construction.
     status = "usable" if not records else "usable_with_warnings"
     groups = group_warning_records(records)
+    info_records = _validation_issues(view.snapshot.validation_result.infos)
+    info_groups = group_warning_records(info_records)
     return {
         "status": status,
         "workspace": view.workspace_root.name,
@@ -197,6 +200,10 @@ def activate(
             groups, include_samples=(warnings_mode == "grouped")
         ),
         "warnings": [],
+        "info_total": len(info_records),
+        "info_groups": groups_to_payload(
+            info_groups, include_samples=(warnings_mode == "grouped")
+        ),
     }
 
 
@@ -220,6 +227,9 @@ def list_validation_warnings(
         cache.snapshot.validation_result,
         cache.snapshot.warnings,
     )
+    # (#134) Info records are pageable here (filter severity="info") even
+    # though activate only inlines their grouped summary.
+    records = records + _validation_issues(cache.snapshot.validation_result.infos)
     page, total, _ = select_warning_records(
         records, rule_id=rule_id, severity=severity, offset=offset, limit=limit
     )
@@ -257,6 +267,9 @@ def context_map(
         "scope": resolve_scan_scope(None, cache.config.scanning.default_scope).value,
         "allowed_orphan_types": cache.config.validation.allowed_orphan_types,
         "allowed_orphan_paths": cache.config.validation.allowed_orphan_paths,
+        "allowed_external_dependency_paths": (
+            cache.config.validation.allowed_external_dependency_paths
+        ),
         "docs_dir": str(cache.config.paths.docs_dir),
         "logs_dir": str(cache.config.paths.logs_dir),
         "is_contributor_mode": (cache.workspace_root / ".ontos-internal").is_dir(),
@@ -677,6 +690,7 @@ def _validation_payload(validation: ValidationResult) -> dict[str, Any]:
     return {
         "errors": _validation_issues(validation.errors),
         "warnings": _validation_issues(validation.warnings),
+        "info": _validation_issues(getattr(validation, "infos", [])),
     }
 
 
@@ -702,6 +716,7 @@ _SNAPSHOT_RULE_PREFIXES = (
     ("invalid frontmatter", "schema.invalid_frontmatter"),
     ("Impact reference", "impacts.broken"),
     ("Broken dependency", "broken_link"),
+    ("External file dependency", "external_file_dependency"),
     ("External dependency resolved from disk", "out_of_scope_dependency"),
     ("Document has no incoming dependencies", "orphan"),
     ("Dependency depth", "depth"),

--- a/tests/commands/test_activate_json_warning_metadata.py
+++ b/tests/commands/test_activate_json_warning_metadata.py
@@ -678,3 +678,77 @@ def test_cli_and_mcp_grouping_parity() -> None:
     cli_payload = groups_to_payload(group_warning_records(list(records)))
     mcp_payload = groups_to_payload(group_warning_records(list(records)))
     assert cli_payload == mcp_payload
+
+
+# =============================================================================
+# (#134) Allowlisted external file dependencies land in the info bucket
+# =============================================================================
+
+
+def _external_dep_workspace(root: Path) -> Path:
+    _write(
+        root / ".ontos.toml",
+        """
+        [ontos]
+        version = "4.6"
+
+        [validation]
+        allowed_orphan_types = ["atom", "log"]
+        allowed_external_dependency_paths = ["external/**"]
+        """,
+    )
+    _write(root / "external/notes.txt", "not a doc\n")
+    _write(
+        root / "docs/anchor.md",
+        """
+        ---
+        id: anchor_doc
+        type: atom
+        status: active
+        depends_on: [external/notes.txt]
+        ---
+        Anchor body.
+        """,
+    )
+    return root
+
+
+def test_activate_json_allowlisted_dep_lands_in_info_not_warnings(tmp_path: Path) -> None:
+    root = _external_dep_workspace(tmp_path)
+
+    result = _run(root, "--json", "activate", "--warnings", "full")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+
+    validation = payload["data"]["validation"]
+    assert validation["info"], "expected the allowlisted dep in validation.info"
+    record = validation["info"][0]
+    assert record["rule_id"] == "external_file_dependency"
+    assert record["severity"] == "info"
+    assert record["document_id"] == "anchor_doc"
+    assert payload["data"]["summary"]["validation_info"] == 1
+
+    # The allowlisted dep must NOT appear among warnings or flip status.
+    assert all(
+        w.get("rule_id") != "external_file_dependency" for w in validation["warnings"]
+    )
+    # atom is an allowed orphan type, so the workspace is fully clean -> usable.
+    assert payload["data"]["status"] == "usable"
+    assert payload["data"]["summary"]["validation_warnings"] == 0
+
+
+def test_activate_json_info_groups_follow_warning_budget(tmp_path: Path) -> None:
+    root = _external_dep_workspace(tmp_path)
+
+    result = _run(root, "--json", "activate")  # default grouped mode
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+
+    validation = payload["data"]["validation"]
+    assert validation["info"] == []  # inline records only in full mode
+    assert validation["info_total"] == 1
+    groups = validation["info_groups"]
+    assert len(groups) == 1
+    assert groups[0]["rule_id"] == "external_file_dependency"
+    assert groups[0]["count"] == 1
+    assert groups[0]["samples"]

--- a/tests/commands/test_activate_json_warning_metadata.py
+++ b/tests/commands/test_activate_json_warning_metadata.py
@@ -771,3 +771,26 @@ def test_activate_json_rejects_invalid_limit_with_envelope(tmp_path: Path) -> No
     human = _run(root, "activate", "--limit", "0")
     assert human.returncode == 1
     assert "--limit must be >= 1" in human.stdout
+
+
+def test_activate_warning_rule_filters_info_total(tmp_path: Path) -> None:
+    """(#140 review) --warning-rule must filter info_total/info_groups the
+    same way it filters warnings_total."""
+    root = _external_dep_workspace(tmp_path)
+
+    result = _run(root, "--json", "activate", "--warning-rule", "orphan")
+    assert result.returncode == 0, result.stderr
+    validation = json.loads(result.stdout)["data"]["validation"]
+
+    # The only info record is external_file_dependency; under an orphan
+    # filter the info channel must be empty AND its total must say so.
+    assert validation["info"] == []
+    assert validation["info_groups"] == []
+    assert validation["info_total"] == 0
+
+    matching = _run(
+        root, "--json", "activate", "--warning-rule", "external_file_dependency"
+    )
+    validation = json.loads(matching.stdout)["data"]["validation"]
+    assert validation["info_total"] == 1
+    assert validation["info_groups"][0]["rule_id"] == "external_file_dependency"

--- a/tests/commands/test_link_check.py
+++ b/tests/commands/test_link_check.py
@@ -482,3 +482,67 @@ def test_link_check_json_and_quiet_keep_stderr_silent(tmp_path: Path):
 
     quiet_run = _run_ontos(tmp_path, "link-check", "--quiet")
     assert quiet_run.stderr.strip() == ""
+
+
+# =============================================================================
+# (#134) file_dependencies bucket in CLI JSON
+# =============================================================================
+
+
+def test_link_check_json_file_dependencies_bucket(tmp_path: Path):
+    _init_repo(
+        tmp_path,
+        extra_config=(
+            "\n[validation]\n"
+            "allowed_orphan_types=['atom']\n"
+            "allowed_external_dependency_paths=['apps/**']\n"
+        ),
+    )
+    (tmp_path / "apps").mkdir()
+    (tmp_path / "apps" / "real.py").write_text("code", encoding="utf-8")
+    (tmp_path / "tools").mkdir()
+    (tmp_path / "tools" / "other.py").write_text("code", encoding="utf-8")
+    _write_doc(
+        tmp_path / "docs" / "handoff.md",
+        "handoff_doc",
+        depends_on="[apps/real.py, tools/other.py]",
+    )
+
+    result = _run_ontos(tmp_path, "--json", "link-check")
+    envelope = json.loads(result.stdout)
+    data = envelope["data"]
+
+    assert data["summary"]["file_dependencies"] == 2
+    assert data["summary"]["unallowlisted_file_dependencies"] == 1
+    assert data["summary"]["broken_references"] == 0
+    assert data["summary"]["broken_frontmatter"] == 0
+    items = {item["value"]: item for item in data["file_dependencies"]}
+    assert items["apps/real.py"]["allowlisted"] is True
+    assert items["apps/real.py"]["severity"] == "info"
+    assert items["tools/other.py"]["allowlisted"] is False
+    # The unallowlisted file dep preserves exit-1 semantics.
+    assert result.returncode == envelope["exit_code"] == 1
+
+
+def test_link_check_all_allowlisted_file_deps_exit_0(tmp_path: Path):
+    _init_repo(
+        tmp_path,
+        extra_config=(
+            "\n[validation]\n"
+            "allowed_orphan_types=['atom']\n"
+            "allowed_external_dependency_paths=['apps/**']\n"
+        ),
+    )
+    (tmp_path / "apps").mkdir()
+    (tmp_path / "apps" / "real.py").write_text("code", encoding="utf-8")
+    _write_doc(
+        tmp_path / "docs" / "handoff.md",
+        "handoff_doc",
+        depends_on="[apps/real.py]",
+    )
+
+    result = _run_ontos(tmp_path, "--json", "link-check")
+    envelope = json.loads(result.stdout)
+
+    assert result.returncode == envelope["exit_code"] == 0
+    assert envelope["data"]["result_status"] == "clean"

--- a/tests/commands/test_maintain.py
+++ b/tests/commands/test_maintain.py
@@ -244,6 +244,8 @@ def test_check_links_task_uses_shared_link_diagnostics(tmp_path, monkeypatch):
                 external_references=0,
                 duplicate_ids=0,
                 load_warnings=0,
+                file_dependencies=0,
+                unallowlisted_file_dependencies=0,
             ),
         )
 

--- a/tests/commands/test_maintain.py
+++ b/tests/commands/test_maintain.py
@@ -238,6 +238,7 @@ def test_check_links_task_uses_shared_link_diagnostics(tmp_path, monkeypatch):
             external_references=[],
             parse_failed_candidates=[],
             orphans=[],
+            file_dependencies=[],
             summary=SimpleNamespace(
                 broken_references=0,
                 orphans=0,
@@ -578,3 +579,25 @@ def test_promote_check_excludes_non_ready_from_ready_count(tmp_path, monkeypatch
     assert "1 ready for promotion" in result.message
     assert "2 candidates" in result.message
 
+
+
+def test_check_links_task_reports_unallowlisted_file_dependencies(tmp_path):
+    """(#140 review) Exit 1 caused by unallowlisted file deps must name the
+    cause in the message and list the offending deps in details."""
+    _init_project(tmp_path)
+    (tmp_path / "tools").mkdir()
+    (tmp_path / "tools" / "real.py").write_text("code", encoding="utf-8")
+    (tmp_path / "docs" / "handoff.md").write_text(
+        "---\nid: handoff_doc\ntype: atom\nstatus: active\n"
+        "depends_on: [tools/real.py]\n---\n",
+        encoding="utf-8",
+    )
+
+    ctx = _build_context(tmp_path, quiet=True)
+    result = _task_check_links(ctx)
+
+    assert result.status == "failed"
+    assert result.metrics["broken_links"] == 0
+    assert result.metrics["unallowlisted_file_dependencies"] == 1
+    assert "unallowlisted_file_deps=1" in result.message
+    assert any("tools/real.py" in line for line in result.details)

--- a/tests/core/test_config_phase3.py
+++ b/tests/core/test_config_phase3.py
@@ -178,3 +178,32 @@ class TestDictToConfig:
         """Unknown top-level sections raise ConfigError with section name."""
         with pytest.raises(ConfigError, match="hokks"):
             dict_to_config({"hokks": {"strict": True}})
+
+
+# (#134) allowed_external_dependency_paths type validation — mirrors the
+# allowed_orphan_paths checks above.
+
+def test_validate_types_rejects_non_list_allowed_external_dependency_paths():
+    with pytest.raises(ConfigError, match="must be list"):
+        _validate_types({"validation": {"allowed_external_dependency_paths": "apps/**"}})
+
+
+def test_validate_types_rejects_non_str_item_in_allowed_external_dependency_paths():
+    with pytest.raises(ConfigError, match=r"\[1\] must be str"):
+        _validate_types(
+            {"validation": {"allowed_external_dependency_paths": ["apps/**", 7]}}
+        )
+
+
+def test_allowed_external_dependency_paths_defaults_to_empty():
+    config = dict_to_config({})
+    assert config.validation.allowed_external_dependency_paths == []
+
+
+def test_allowed_external_dependency_paths_round_trips():
+    config = dict_to_config(
+        {"validation": {"allowed_external_dependency_paths": ["apps/**", "manifests/**"]}}
+    )
+    assert config.validation.allowed_external_dependency_paths == [
+        "apps/**", "manifests/**",
+    ]

--- a/tests/core/test_graph.py
+++ b/tests/core/test_graph.py
@@ -513,3 +513,131 @@ class TestCalculateDepths:
         # Cyclic nodes are treated as depth 0 to prevent infinite recursion
         assert depths["a"] >= 0
         assert depths["b"] >= 0
+
+
+class TestExternalDependencyAllowlist:
+    """(#134) Resolved-on-disk deps matching allowed_external_dependency_paths
+    are reported as EXTERNAL_FILE_DEPENDENCY at info severity; non-matching
+    ones keep today's OUT_OF_SCOPE_DEPENDENCY warning; missing paths stay
+    broken-link errors."""
+
+    def _docs(self, tmp_path, layout):
+        docs = {}
+        for doc_id, rel_path, depends_on in layout:
+            abs_path = tmp_path / rel_path
+            abs_path.parent.mkdir(parents=True, exist_ok=True)
+            abs_path.write_text(f"# {doc_id}\n")
+            docs[doc_id] = DocumentData(
+                id=doc_id,
+                type=DocumentType.ATOM,
+                status=DocumentStatus.ACTIVE,
+                filepath=abs_path,
+                frontmatter={"id": doc_id, "type": "atom"},
+                content="",
+                depends_on=list(depends_on),
+            )
+        return docs
+
+    def test_allowlisted_dep_is_info_with_context(self, tmp_path):
+        (tmp_path / "apps/audio/src").mkdir(parents=True, exist_ok=True)
+        (tmp_path / "apps/audio/src/embed.py").write_text("code")
+        docs = self._docs(
+            tmp_path,
+            [("handoff", "docs/handoff.md", ["apps/audio/src/embed.py"])],
+        )
+
+        graph, errors = build_graph(
+            docs,
+            workspace_root=tmp_path,
+            allowed_external_dependency_paths=["apps/**"],
+        )
+
+        assert len(errors) == 1
+        error = errors[0]
+        assert error.error_type.value == "external_file_dependency"
+        assert error.severity == "info"
+        assert error.context == {
+            "dep_value": "apps/audio/src/embed.py",
+            "resolved_path": "apps/audio/src/embed.py",
+            "allowlisted": True,
+        }
+
+    def test_non_allowlisted_dep_keeps_exact_out_of_scope_message(self, tmp_path):
+        (tmp_path / "tools").mkdir(parents=True, exist_ok=True)
+        (tmp_path / "tools/script.py").write_text("code")
+        docs = self._docs(
+            tmp_path,
+            [("handoff", "docs/handoff.md", ["tools/script.py"])],
+        )
+
+        graph, errors = build_graph(
+            docs,
+            workspace_root=tmp_path,
+            allowed_external_dependency_paths=["apps/**"],
+        )
+
+        assert len(errors) == 1
+        error = errors[0]
+        assert error.error_type.value == "out_of_scope_dependency"
+        assert error.severity == "warning"
+        # Message stays byte-identical to the pre-#134 text.
+        assert error.message == (
+            "External dependency resolved from disk: 'tools/script.py' "
+            "(declared in handoff) exists at "
+            f"'{tmp_path / 'tools/script.py'}' but is not a loaded document."
+        )
+        assert error.context["allowlisted"] is False
+
+    def test_missing_path_still_broken_link(self, tmp_path):
+        docs = self._docs(
+            tmp_path,
+            [("a", "docs/a.md", ["apps/does-not-exist.py"])],
+        )
+
+        graph, errors = build_graph(
+            docs,
+            workspace_root=tmp_path,
+            allowed_external_dependency_paths=["apps/**"],
+        )
+
+        assert len(errors) == 1
+        assert errors[0].error_type.value == "broken_link"
+
+    def test_glob_is_segment_local(self, tmp_path):
+        # apps/*.py must NOT match apps/sub/x.py (segment-local *).
+        (tmp_path / "apps/sub").mkdir(parents=True, exist_ok=True)
+        (tmp_path / "apps/sub/x.py").write_text("code")
+        docs = self._docs(
+            tmp_path,
+            [("a", "docs/a.md", ["apps/sub/x.py"])],
+        )
+
+        graph, errors = build_graph(
+            docs,
+            workspace_root=tmp_path,
+            allowed_external_dependency_paths=["apps/*.py"],
+        )
+
+        assert errors[0].error_type.value == "out_of_scope_dependency"
+
+    def test_symlink_matches_on_resolved_path(self, tmp_path):
+        # A dep declared through a symlink must be allowlisted by its
+        # RESOLVED location, not the symlink's apparent path.
+        (tmp_path / "real").mkdir(parents=True, exist_ok=True)
+        (tmp_path / "real/target.py").write_text("code")
+        (tmp_path / "apps").mkdir(parents=True, exist_ok=True)
+        (tmp_path / "apps/linked.py").symlink_to(tmp_path / "real/target.py")
+        docs = self._docs(
+            tmp_path,
+            [("a", "docs/a.md", ["apps/linked.py"])],
+        )
+
+        graph, errors = build_graph(
+            docs,
+            workspace_root=tmp_path,
+            allowed_external_dependency_paths=["apps/**"],
+        )
+
+        # Resolves to real/target.py which is NOT under apps/ -> not allowlisted.
+        assert errors[0].error_type.value == "out_of_scope_dependency"
+        assert errors[0].context["allowlisted"] is False

--- a/tests/core/test_link_diagnostics.py
+++ b/tests/core/test_link_diagnostics.py
@@ -280,3 +280,107 @@ def test_to_data_payload_summary_and_limit_modes(tmp_path: Path):
     assert summary["mode"] == "summary"
     assert summary["broken_references"] == []
     assert summary["summary"]["broken_references"] == 2
+
+
+# =============================================================================
+# (#134) file_dependencies re-bucketing and exit codes
+# =============================================================================
+
+
+def _file_dep_project(tmp_path: Path, allowlist: str = "") -> None:
+    extra = ""
+    if allowlist:
+        extra = f"\n[validation]\nallowed_external_dependency_paths={allowlist}\n"
+    _init_project(tmp_path, extra_config=extra)
+    (tmp_path / "apps").mkdir(exist_ok=True)
+    (tmp_path / "apps" / "real.py").write_text("code", encoding="utf-8")
+    (tmp_path / "tools").mkdir(exist_ok=True)
+    (tmp_path / "tools" / "other.py").write_text("code", encoding="utf-8")
+
+
+def test_allowlisted_file_dep_rebucketed_and_exit_0(tmp_path: Path):
+    _file_dep_project(tmp_path, allowlist="['apps/**']")
+    _write_doc(
+        tmp_path / "docs" / "handoff.md",
+        "handoff_doc",
+        depends_on="[apps/real.py]",
+    )
+
+    result = _run(tmp_path, ScanScope.LIBRARY)
+
+    assert result.summary.file_dependencies == 1
+    assert result.summary.unallowlisted_file_dependencies == 0
+    assert result.summary.broken_references == 0
+    assert result.summary.broken_frontmatter == 0
+    assert result.exit_code == 0
+    item = result.file_dependencies[0]
+    assert item.allowlisted is True
+    assert item.value == "apps/real.py"
+    assert item.resolved_path == "apps/real.py"
+    assert item.severity == "info"
+
+
+def test_unallowlisted_file_dep_keeps_exit_1(tmp_path: Path):
+    _file_dep_project(tmp_path, allowlist="['apps/**']")
+    _write_doc(
+        tmp_path / "docs" / "handoff.md",
+        "handoff_doc",
+        depends_on="[tools/other.py]",
+    )
+
+    result = _run(tmp_path, ScanScope.LIBRARY)
+
+    assert result.summary.file_dependencies == 1
+    assert result.summary.unallowlisted_file_dependencies == 1
+    assert result.summary.broken_references == 0
+    assert result.exit_code == 1
+
+
+def test_unconfigured_repo_file_dep_still_exit_1(tmp_path: Path):
+    # No allowlist configured: resolved-on-disk deps move buckets but keep
+    # the historical exit-1 semantics.
+    _file_dep_project(tmp_path)
+    _write_doc(
+        tmp_path / "docs" / "handoff.md",
+        "handoff_doc",
+        depends_on="[apps/real.py]",
+    )
+
+    result = _run(tmp_path, ScanScope.LIBRARY)
+
+    assert result.summary.unallowlisted_file_dependencies == 1
+    assert result.exit_code == 1
+
+
+def test_missing_dep_still_broken_reference(tmp_path: Path):
+    _file_dep_project(tmp_path, allowlist="['apps/**']")
+    _write_doc(
+        tmp_path / "docs" / "handoff.md",
+        "handoff_doc",
+        depends_on="[apps/missing.py]",
+    )
+
+    result = _run(tmp_path, ScanScope.LIBRARY)
+
+    assert result.summary.file_dependencies == 0
+    assert result.summary.broken_references == 1
+    assert result.exit_code == 1
+
+
+def test_to_data_payload_includes_file_dependencies(tmp_path: Path):
+    _file_dep_project(tmp_path, allowlist="['apps/**']")
+    _write_doc(
+        tmp_path / "docs" / "handoff.md",
+        "handoff_doc",
+        depends_on="[apps/real.py, tools/other.py]",
+    )
+
+    result = _run(tmp_path, ScanScope.LIBRARY)
+    payload = result.to_data_payload()
+
+    assert payload["summary"]["file_dependencies"] == 2
+    assert payload["summary"]["unallowlisted_file_dependencies"] == 1
+    items = {item["value"]: item for item in payload["file_dependencies"]}
+    assert items["apps/real.py"]["allowlisted"] is True
+    assert items["tools/other.py"]["allowlisted"] is False
+    assert items["tools/other.py"]["field"] == "depends_on"

--- a/tests/mcp/test_activation.py
+++ b/tests/mcp/test_activation.py
@@ -278,3 +278,73 @@ def test_mcp_groups_match_cli_grouping_for_same_records(tmp_path):
     expected = groups_to_payload(group_warning_records(records))
     assert payload["warning_groups"] == expected
     assert payload["warnings_total"] == len(records)
+
+
+# =============================================================================
+# (#134) Info bucket (allowlisted external file deps) on the MCP surface
+# =============================================================================
+
+
+def test_activate_emits_info_groups_separate_from_warnings(tmp_path):
+    root = create_workspace(tmp_path)
+    # Add an allowlisted external file dep to the fixture workspace.
+    (root / "apps").mkdir(exist_ok=True)
+    (root / "apps" / "real.py").write_text("code", encoding="utf-8")
+    config_path = root / ".ontos.toml"
+    config_path.write_text(
+        config_path.read_text(encoding="utf-8")
+        + "\n[validation]\nallowed_external_dependency_paths = ['apps/**']\n",
+        encoding="utf-8",
+    )
+    (root / "docs" / "with_file_dep.md").write_text(
+        "---\nid: with_file_dep\ntype: atom\nstatus: active\n"
+        "depends_on: [apps/real.py]\n---\nBody\n",
+        encoding="utf-8",
+    )
+    server = build_server(root)
+
+    activation = _call(server, "activate", {})
+
+    assert activation.isError is False
+    content = activation.structuredContent
+    assert content["info_total"] == 1
+    assert content["info_groups"][0]["rule_id"] == "external_file_dependency"
+    assert content["info_groups"][0]["by_severity"] == {"info": 1}
+    # Info never merges into the warning channel or its totals.
+    rule_ids = {group["rule_id"] for group in content["warning_groups"]}
+    assert "external_file_dependency" not in rule_ids
+
+
+def test_list_validation_warnings_pages_info_records(tmp_path):
+    root = create_workspace(tmp_path)
+    (root / "apps").mkdir(exist_ok=True)
+    (root / "apps" / "real.py").write_text("code", encoding="utf-8")
+    config_path = root / ".ontos.toml"
+    config_path.write_text(
+        config_path.read_text(encoding="utf-8")
+        + "\n[validation]\nallowed_external_dependency_paths = ['apps/**']\n",
+        encoding="utf-8",
+    )
+    (root / "docs" / "with_file_dep.md").write_text(
+        "---\nid: with_file_dep\ntype: atom\nstatus: active\n"
+        "depends_on: [apps/real.py]\n---\nBody\n",
+        encoding="utf-8",
+    )
+    server = build_server(root)
+    _call(server, "activate", {})
+
+    result = _call(server, "list_validation_warnings", {"severity": "info"})
+
+    assert result.isError is False
+    records = result.structuredContent["warnings"]
+    assert records
+    assert all(record["severity"] == "info" for record in records)
+    assert records[0]["rule_id"] == "external_file_dependency"
+
+
+def test_snapshot_issue_classifies_external_file_dependency_prefix():
+    issue = _snapshot_issue(
+        "External file dependency (allowlisted): 'apps/real.py' "
+        "(declared in handoff) resolved to 'apps/real.py'."
+    )
+    assert issue["rule_id"] == "external_file_dependency"


### PR DESCRIPTION
Fixes #134. Stacked on #139.

## Problem
`company-os` records provenance edges from lifecycle docs to real implementation files (`apps/**`, `manifests/**`, `.llm-dev/framework/templates/**`). Ontos reported all 188 of them as `out_of_scope_dependency` warnings and link-check counted them as `broken_frontmatter`/`broken_references` (driving exit 1), while `external_references` stayed 0 — intentional traceability presented as graph damage.

## Design
New config, mirroring the `allowed_orphan_paths` pattern (50c9e19) exactly:

```toml
[validation]
allowed_external_dependency_paths = ["apps/**", "manifests/**"]
```

Classification matrix for a `depends_on` value that looks like a path:
| target | classification | severity | exit-code effect |
|---|---|---|---|
| resolves to a loaded doc | normal edge | — | — |
| exists on disk, matches allowlist | **`external_file_dependency`** (new) | **info** | none |
| exists on disk, no match | `out_of_scope_dependency` (byte-identical message) | warning | exit 1 via new counter (unchanged behavior) |
| missing | `broken_link` | error | exit 1 |

The allowlist matches the **resolved** workspace-relative path (symlink containment preserved — gemini-B.1-F1 not weakened; test included).

## Key mechanics
- `ValidationError.context` carries `{dep_value, resolved_path, allowlisted}` — consumers stop parsing messages. Deliberately **not** serialized by `to_dict()`; the #119 record-shape parity tests stay byte-exact.
- New `ValidationResult.infos` bucket: info records never count as warnings, so allowlisted deps stop flipping activate to `usable_with_warnings`.
- link-check re-buckets resolved-on-disk deps into `data.file_dependencies` (+`summary.file_dependencies`/`unallowlisted_file_dependencies`); `broken_references` now means genuinely missing targets. Exit codes preserved exactly for unconfigured repos.
- activate CLI gains `validation.info/info_total/info_groups` + `summary.validation_info` under the #132 grouping budget (188 inline info records would have re-created the flood); MCP `ActivateResponse` gains `info_total`/`info_groups`, and `list_validation_warnings(severity="info")` pages full records.
- maintain metrics surface the new counters so the `broken_links` drop isn't silent.

## Compat
Additive everywhere except the intended re-bucketing. Note: ontos ≤4.6.0 strictly rejects configs containing the new key (same rollout tradeoff as `allowed_orphan_paths`) — CHANGELOG note lands with the 4.7.0 release PR.

## Tests
Graph allowlist matrix (incl. segment-local globs + symlink resolution), config type validation, re-bucketing + exit codes, CLI/MCP info-bucket e2e, snapshot-prefix classification. Full suite: 1427 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)