### PR TITLE
feat(health): unify cross-command counts + basis labels; release v4.7.0 (#133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,97 @@ All notable changes to this project will be documented in this file.
 
 > For the full historical changelog with Ontos frontmatter (from v0.1.0), see [`Ontos_CHANGELOG.md`](Ontos_CHANGELOG.md).
 
+## [4.7.0] - 2026-06-11
+
+Minor release closing Issues #131–#136 — the "Ontos feels unstable" RCA
+batch. Health/diagnostic surfaces are now bounded, mutually consistent,
+and fast on medium repos.
+
+### Added
+- **Warning grouping (#132)** — `ontos activate` returns grouped warning
+  summaries by default: `data.validation.warning_groups` (rule_id, count,
+  by_severity, ≤3 full-record samples), `warnings_total`, and
+  `warnings_truncated`. New flags `--warnings {summary,grouped,full}`,
+  `--warning-rule RULE_ID`, `--limit N`. The MCP `activate` tool gains a
+  `warnings: summary|grouped` parameter, and the new paginated
+  **`list_validation_warnings`** MCP tool (rule_id/severity/offset/limit)
+  pages complete records.
+- **External file dependencies (#134)** — New
+  `[validation] allowed_external_dependency_paths` config (workspace-relative
+  globs). A `depends_on` target that exists on disk and matches the allowlist
+  is classified `external_file_dependency` at **info** severity (new
+  `validation.info` / `info_groups` surfaces; never flips
+  `usable_with_warnings`). link-check re-buckets all resolved-on-disk deps
+  into `data.file_dependencies` with `summary.file_dependencies` /
+  `summary.unallowlisted_file_dependencies` counters.
+- **link-check output controls (#135)** — `--summary`, `--limit N`,
+  `--no-suggestions`, `--frontmatter-only`, `--no-orphans`; per-phase
+  `data.timings_ms`; stderr stage markers on human runs;
+  `findings_truncated` + `truncated_sections` indicators.
+- **Map provenance (#136)** — Context map frontmatter gains
+  `generator_version`, `scope`, and `documents_loaded`; the banner reports
+  the installed package version. `ontos doctor` warns when the map's
+  generator version is missing or doesn't match the installed CLI.
+- **Health basis labels (#133)** — `query --health` reports
+  `count_basis`/`orphan_basis`/`connectivity_basis` and echoes
+  `allowed_orphan_types`; doctor checks carry a structured `data` block
+  with their `count_basis`.
+
+### Changed
+- **link-check JSON envelope (#131, breaking)** — `ontos link-check --json`
+  now emits the standard command envelope; the legacy root-level payload is
+  gone. Top-level `status` is transport status; result quality lives in
+  `data.result_status` (`clean|warnings|failing`). **Shell exit codes 0/1/2
+  are unchanged** — exit-code-based CI needs no migration. JSON consumers:
+  `.summary` → `.data.summary`, `.broken_references` →
+  `.data.broken_references`, legacy root `.status` → `.data.result_status`.
+  Detect the new shape via top-level `schema_version` (now **3.4** for all
+  commands).
+- **Activate default output (#132, behavioral)** — `data.validation.warnings`
+  is `[]` unless `--warnings full`; consumers should check
+  `warnings_truncated`/`warnings_total`. `validation.errors` is always the
+  complete list, and status/exit semantics derive from full counts —
+  CI keyed on hard errors sees no change.
+- **link-check re-bucketing (#134, behavioral)** — resolved-on-disk
+  `depends_on` targets no longer count as `broken_references` /
+  `broken_frontmatter`; they appear under `file_dependencies` with an
+  `allowlisted` flag. Exit-1 semantics are preserved for unconfigured repos
+  via `unallowlisted_file_dependencies`; CI parsing broken counters should
+  read the new fields.
+- **`query --health` orphan counts (#133, bugfix)** — orphan detection now
+  uses the same `detect_orphans` + configured `allowed_orphan_types`/
+  `allowed_orphan_paths` as activate/link-check (previously a hard-coded
+  type list produced contradictory counts). Connectivity reports `null` +
+  `connectivity_basis: not_applicable_no_kernel_docs` when no kernel docs
+  exist instead of a misleading `0.0`.
+- **doctor (#133)** — `activation_health` delegates to the activation
+  pipeline (read-only), so its counts match `ontos activate` by
+  construction; the `validation` check is labeled as the bounded
+  frontmatter quick scan it is.
+- **map --strict --json (#131)** — `data` gains `result_status`, `strict`,
+  and grouped `diagnostics` (rule_id/count/by_severity/samples) so strict
+  failures carry triage data, not bare counts.
+
+### Fixed
+- **link-check performance (#135)** — ~200x faster on medium repos
+  (709-doc benchmark: 13+ min → 3.3 s). The known-ID body scan no longer
+  sorts the id set per line nor compiles a regex per (line × id); fuzzy
+  suggestion generation is index-backed, gated by lossless
+  `real_quick_ratio`/`quick_ratio` bounds, and memoized per broken value.
+  Results are byte-identical.
+- **Config discovery (#133)** — `load_project_config(repo_root=…)` starts
+  discovery at the named root instead of CWD, so commands invoked from
+  outside a project no longer silently load an unrelated ancestor config.
+
+### Compatibility notes
+- Ontos ≤ 4.6.0 **rejects** configs containing
+  `allowed_external_dependency_paths` (strict unknown-key validation, same
+  rollout tradeoff as `allowed_orphan_paths`): upgrade all CLI installs
+  before adopting the key.
+- MCP `ActivateResponse` schema changed (new required warning-budget fields,
+  new optional info fields); strict clients revalidate via `tools/list` on
+  reconnect.
+
 ## [4.6.0] - 2026-05-23
 
 Patch release closing Issue #119, the final v4.5.0 follow-up for activation

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Run `ontos serve` to start an MCP server that exposes your knowledge graph direc
 }
 ```
 
-**Cursor** uses the same direct-file pattern introduced in `v4.2`, and remains first-class in `v4.6` for the managed clients Ontos owns directly:
+**Cursor** uses the same direct-file pattern introduced in `v4.2`, and remains first-class in `v4.7` for the managed clients Ontos owns directly:
 
 - project scope: `.cursor/mcp.json`
 - user scope: `~/.cursor/mcp.json`
@@ -161,7 +161,7 @@ ontos mcp uninstall --client cursor --scope project
 ontos mcp print-config --client codex
 ```
 
-Rerunning `ontos mcp install --client cursor ...` refreshes the launcher path if Ontos moves on your shell `PATH`. Windows users should use `print-config`; managed install, uninstall, and doctor support remain POSIX-only in `v4.6`.
+Rerunning `ontos mcp install --client cursor ...` refreshes the launcher path if Ontos moves on your shell `PATH`. Windows users should use `print-config`; managed install, uninstall, and doctor support remain POSIX-only in `v4.7`.
 
 ### Documentation Health
 CI validation catches broken links, circular dependencies, and architectural violations before they become tribal knowledge buried in someone's head.
@@ -356,7 +356,7 @@ Ontos treats MCP integration as two separate concerns:
 Support is client-specific:
 
 - **First-class** — stable native config contract, so Ontos can ship `ontos mcp install --client ...`, `ontos mcp uninstall --client ...`, and `ontos doctor` coverage. Antigravity and Cursor are the first clients in this tier.
-- **Print-config only** — docs and a copy-pastable config snippet, but no Ontos-managed install / doctor promises in `v4.6`. Claude Code, Codex, and VS Code fit here.
+- **Print-config only** — docs and a copy-pastable config snippet, but no Ontos-managed install / doctor promises in `v4.7`. Claude Code, Codex, and VS Code fit here.
 - **Docs-only** — native config is not managed by Ontos in this release. Claude Desktop and Windsurf stay here.
 
 The managed MCP client config is separate from repo-local instruction artifacts such as `AGENTS.md` and `.cursorrules`.
@@ -402,7 +402,7 @@ Write tools are registered only when the server runs without `--read-only`. In r
 ### 5. Verify
 
 ```bash
-ontos --version   # Should show 4.6.x
+ontos --version   # Should show 4.7.x
 ontos serve       # Starts the stdio server (Ctrl+C to stop)
 ```
 
@@ -486,7 +486,7 @@ The server binds to one **primary workspace** (the `cwd` or `--workspace` path).
 Calling a core tool with a `workspace_id` that doesn't match the primary workspace returns `E_CROSS_WORKSPACE_NOT_SUPPORTED`. This is a deliberate safety boundary. To read another project's documents, change your `cwd` or run a second `ontos serve` instance.
 
 > [!NOTE]
-> Cross-workspace document reads and writes are not supported in v4.6.0.
+> Cross-workspace document reads and writes are not supported in v4.7.0.
 
 #### Example Workflow
 
@@ -594,18 +594,18 @@ Version 3 is when Ontos became public. The earlier versions live on in the desig
 
 | Version | Status | Highlights |
 |---------|--------|------------|
-| **v4.6.0** | Current | CLI `activate --json` warning/error metadata parity with MCP |
+| **v4.7.0** | Current | Grouped activation warnings, link-check JSON envelope + ~200x faster scans, external file dependency allowlist, cross-command health consistency |
+| **v4.6.0** | Previous | CLI `activate --json` warning/error metadata parity with MCP |
 | **v4.5.0** | Previous | Schema-safe bundle warnings, lifecycle type/status widening, MCP upgrade docs |
-| **v4.4.0** | Previous | Agentic activation resilience, MCP `activate`, `session_end`, frontmatter diagnostics |
 | **Future** | Next | HTTP / Streamable HTTP transport, daemon mode, security hardening |
 
-v3.0 transformed Ontos from repo-injected scripts into a pip-installable package. v3.1 made all CLI commands native Python. v3.2 added re-architecture support, environment detection, and activation resilience. v3.3 ships 62 audit-derived hardening fixes plus `link-check`, `rename`, unified JSON envelopes, and a canonical document loader. v3.3.1 reduced link-check false positives by 89% and added `promote_check` to the maintenance pipeline. v3.4 adds `--compact tiered` context maps for token-constrained agents. v4.0 adds an MCP server mode with 8 read-only tools, enabling native integration with AI IDEs like Claude Desktop and Cursor without CLI overhead. v4.1 expands MCP to 15 tools, a portfolio index with FTS5 search, advisory flock locking, and a shared rename orchestrator used by both CLI and MCP. v4.2.0 makes Cursor a first-class managed MCP client alongside Antigravity and adds `ontos mcp print-config` for Claude Code, Codex, and VS Code. v4.3.0 adds `ontos retrofit --obsidian`, a dry-run-first write path that lands computed `tags` and `aliases` on disk for Obsidian-compatible browsing. v4.4.0 adds `ontos activate`, MCP session activation state, `session_end`, precise frontmatter diagnostics, enum repair, and shared scan exclusions. v4.5.0 hardens activation/link-check diagnostics, widens lifecycle artifact type/status vocabulary, and documents MCP host restarts after upgrades. v4.6.0 makes CLI `activate --json` validation warnings/errors structured objects, matching MCP activation metadata. The next transport work remains on the roadmap.
+v3.0 transformed Ontos from repo-injected scripts into a pip-installable package. v3.1 made all CLI commands native Python. v3.2 added re-architecture support, environment detection, and activation resilience. v3.3 ships 62 audit-derived hardening fixes plus `link-check`, `rename`, unified JSON envelopes, and a canonical document loader. v3.3.1 reduced link-check false positives by 89% and added `promote_check` to the maintenance pipeline. v3.4 adds `--compact tiered` context maps for token-constrained agents. v4.0 adds an MCP server mode with 8 read-only tools, enabling native integration with AI IDEs like Claude Desktop and Cursor without CLI overhead. v4.1 expands MCP to 15 tools, a portfolio index with FTS5 search, advisory flock locking, and a shared rename orchestrator used by both CLI and MCP. v4.2.0 makes Cursor a first-class managed MCP client alongside Antigravity and adds `ontos mcp print-config` for Claude Code, Codex, and VS Code. v4.3.0 adds `ontos retrofit --obsidian`, a dry-run-first write path that lands computed `tags` and `aliases` on disk for Obsidian-compatible browsing. v4.4.0 adds `ontos activate`, MCP session activation state, `session_end`, precise frontmatter diagnostics, enum repair, and shared scan exclusions. v4.5.0 hardens activation/link-check diagnostics, widens lifecycle artifact type/status vocabulary, and documents MCP host restarts after upgrades. v4.6.0 makes CLI `activate --json` validation warnings/errors structured objects, matching MCP activation metadata. v4.7.0 closes the issue #131–#136 stability batch: grouped activation warnings with a paginated `list_validation_warnings` MCP tool, the standard JSON envelope plus output controls and ~200x faster scans for `link-check`, an `allowed_external_dependency_paths` allowlist with info-severity classification, context-map generator provenance, and basis-labeled, mutually consistent health counts across doctor/activate/query/link-check. The next transport work remains on the roadmap.
 
 ---
 
 ## Documentation
 
-> *Note: Documentation links below point to the latest source on GitHub. During release cutover, source docs may reflect `v4.6.0` before PyPI finishes publishing the same version.*
+> *Note: Documentation links below point to the latest source on GitHub. During release cutover, source docs may reflect `v4.7.0` before PyPI finishes publishing the same version.*
 
 - **[Ontos Manual](https://github.com/ohjonathan/Project-Ontos/blob/main/docs/reference/Ontos_Manual.md)**: Complete reference—installation, workflow, configuration, errors
 - **[Agent Instructions](https://github.com/ohjonathan/Project-Ontos/blob/main/docs/reference/Ontos_Agent_Instructions.md)**: Commands for AI agents

--- a/docs/logs/2026-06-11_fix-github-issues-131-136-warning-grouping-link-ch.md
+++ b/docs/logs/2026-06-11_fix-github-issues-131-136-warning-grouping-link-ch.md
@@ -1,0 +1,43 @@
+---
+id: log_20260611_fix-github-issues-131-136-warning-grouping-link-ch
+type: log
+status: active
+event_type: chore
+source: cli
+branch: feat/133-health-consistency
+created: 2026-06-11
+concepts: [validation, link-check, activation, health, mcp]
+impacts: []
+---
+
+# Fix GitHub issues 131-136: warning grouping, link-check envelope and perf, external file deps, health consistency, map provenance (PRs 137-141, v4.7.0)
+
+## Summary
+
+Closed the six open "Ontos feels unstable" RCA issues (#131–#136) as a
+stacked chain of five PRs (#137–#141) targeting v4.7.0, then applied a
+round of review fixes from Codex feedback.
+
+## Changes Made
+
+- #137: context map renders the installed package version and provenance
+  frontmatter (generator_version, scope, documents_loaded); doctor checks
+  generator provenance.
+- #138: activate groups warnings by rule_id with bounded samples by
+  default; new --warnings/--warning-rule/--limit flags; new paginated
+  list_validation_warnings MCP tool.
+- #139: link-check emits the standard JSON envelope (schema_version 3.4),
+  gains --summary/--limit/--no-suggestions/--frontmatter-only/--no-orphans,
+  per-phase timings, stderr progress; known-ID body scan and suggestion
+  engine optimized losslessly (709-doc run: 13+ min -> 3.3 s).
+- #140: [validation] allowed_external_dependency_paths allowlist; resolved
+  on-disk deps classified external_file_dependency at info severity;
+  link-check file_dependencies re-bucketing.
+- #141: shared core/health.py; query --health and doctor unified with the
+  activation pipeline counts; connectivity n/a marker; config discovery
+  contained to repo_root; v4.7.0 bump + CHANGELOG.
+
+## Testing
+
+Full suite green at each step (1354 -> 1433+ tests). Cross-command
+count-consistency integration test added as the #133 regression guarantee.

--- a/docs/reference/Migration_v3_to_v4.md
+++ b/docs/reference/Migration_v3_to_v4.md
@@ -160,7 +160,7 @@ pipx install --force 'ontos[mcp]'
 ### 2. Verify
 
 ```bash
-ontos --version  # Should show 4.3.x
+ontos --version  # Should show 4.7.x
 ontos doctor     # Check graph health
 ```
 
@@ -239,10 +239,10 @@ path when the Ontos launcher path changes on your shell `PATH`.
 ### Universal `print-config` Fallback
 
 `ontos mcp print-config --client ...` emits a complete config document without
-writing to disk. In `v4.6`, Claude Code, Codex, and VS Code are supported via
+writing to disk. In `v4.7`, Claude Code, Codex, and VS Code are supported via
 this fallback path rather than managed install / uninstall / doctor support.
 
-Managed MCP automation remains POSIX-only in `v4.6`; Windows users should use
+Managed MCP automation remains POSIX-only in `v4.7`; Windows users should use
 `print-config`.
 
 ### 4. Configure Your IDE (Optional)
@@ -302,7 +302,7 @@ ontos mcp uninstall --client cursor --scope project
 ontos mcp print-config --client codex
 ```
 
-Rerunning `ontos mcp install --client cursor ...` refreshes the launcher path if Ontos moves on your shell `PATH`. Managed install, uninstall, and doctor support are POSIX-only in `v4.6`; Windows users should use `print-config`.
+Rerunning `ontos mcp install --client cursor ...` refreshes the launcher path if Ontos moves on your shell `PATH`. Managed install, uninstall, and doctor support are POSIX-only in `v4.7`; Windows users should use `print-config`.
 
 ### Client Support Policy
 
@@ -313,7 +313,7 @@ Ontos now treats MCP enablement as two separate jobs:
 
 That philosophy should stay consistent across clients, while the automation level stays client-specific:
 
-- **First-class** clients get `ontos mcp install --client ...`, `ontos mcp uninstall --client ...`, and `ontos doctor` checks once their native config contract is stable. Antigravity and Cursor are the first examples in `v4.6`.
+- **First-class** clients get `ontos mcp install --client ...`, `ontos mcp uninstall --client ...`, and `ontos doctor` checks once their native config contract is stable. Antigravity and Cursor are the first examples in `v4.7`.
 - **Print-config only** clients keep explicit manual setup docs plus a copy-pastable fallback document. Claude Code, Codex, and VS Code fit here.
 - **Docs-only** clients remain manual in this release. Claude Desktop and Windsurf are the examples here.
 

--- a/docs/reference/Migration_v3_to_v4.md
+++ b/docs/reference/Migration_v3_to_v4.md
@@ -7,7 +7,7 @@ depends_on: [ontos_manual]
 
 # Migration Guide: v3.x → v4.x
 
-This guide covers the new capabilities in Ontos v4.0 through v4.6 and how to enable them. Existing CLI commands, configuration, and frontmatter files remain supported. The one machine-contract change is in v4.6: `ontos activate --json` now emits structured validation issue objects instead of bare warning/error strings.
+This guide covers the new capabilities in Ontos v4.0 through v4.7 and how to enable them. Existing CLI commands, configuration, and frontmatter files remain supported. Machine-contract changes: v4.6 made `ontos activate --json` emit structured validation issue objects instead of bare warning/error strings; v4.7 wraps `ontos link-check --json` in the standard command envelope (shell exit codes unchanged) and returns grouped activation warnings by default (`--warnings full` restores inline records).
 
 ## What's New in v4.0
 

--- a/docs/reference/Ontos_Manual.md
+++ b/docs/reference/Ontos_Manual.md
@@ -5,7 +5,7 @@ status: active
 depends_on: []
 ---
 
-# Ontos Manual v4.6
+# Ontos Manual v4.7
 
 *The complete reference for Project Ontos*
 
@@ -28,7 +28,7 @@ pip install 'ontos[mcp]'
 ontos serve
 ```
 
-> **v4.6 Note:** v4.0 added MCP server mode for native AI IDE integration. v4.1 added write tools, portfolio index, and advisory flock locking. v4.2 added Cursor MCP onboarding plus `print-config` fallback for the remaining supported client surfaces. v4.3 adds `ontos retrofit --obsidian`, the dry-run-first write path that lands computed `tags` and `aliases` in on-disk frontmatter for Obsidian. v4.4 adds agentic activation. v4.5 widens lifecycle artifact tagging and hardens activation diagnostics. v4.6 makes CLI `activate --json` validation metadata match MCP. See the [Migration Guide v3→v4](Migration_v3_to_v4.md). For v2.x users, see [Migration v2→v3](Migration_v2_to_v3.md).
+> **v4.7 Note:** v4.0 added MCP server mode for native AI IDE integration. v4.1 added write tools, portfolio index, and advisory flock locking. v4.2 added Cursor MCP onboarding plus `print-config` fallback for the remaining supported client surfaces. v4.3 adds `ontos retrofit --obsidian`, the dry-run-first write path that lands computed `tags` and `aliases` in on-disk frontmatter for Obsidian. v4.4 adds agentic activation. v4.5 widens lifecycle artifact tagging and hardens activation diagnostics. v4.6 makes CLI `activate --json` validation metadata match MCP. v4.7 groups activation warnings by default, wraps `link-check --json` in the standard envelope with output controls and ~200x faster scans, adds the `allowed_external_dependency_paths` allowlist, and makes health counts consistent (and basis-labeled) across doctor/activate/query/link-check. See the [Migration Guide v3→v4](Migration_v3_to_v4.md). For v2.x users, see [Migration v2→v3](Migration_v2_to_v3.md).
 
 ---
 
@@ -211,7 +211,7 @@ Answering `y` automatically:
 3. **Move file** from `proposals/` to `archive/proposals/`
 4. Add entry to `decision_history.md` with REJECTED outcome
 
-### Status Values (v4.6)
+### Status Values (v4.7)
 | Status | Meaning |
 |--------|---------|
 | `draft` | Work in progress |
@@ -790,7 +790,7 @@ ontos mcp uninstall --client cursor --scope project
 ontos mcp print-config --client codex
 ```
 
-Rerunning `ontos mcp install --client cursor ...` refreshes the launcher path if Ontos moves on your shell `PATH`. Managed install, uninstall, and doctor support remain POSIX-only in `v4.6`; Windows users should use `print-config`.
+Rerunning `ontos mcp install --client cursor ...` refreshes the launcher path if Ontos moves on your shell `PATH`. Managed install, uninstall, and doctor support remain POSIX-only in `v4.7`; Windows users should use `print-config`.
 
 #### Client Support Policy
 
@@ -801,8 +801,8 @@ Ontos treats MCP support as two layers:
 
 Apply the same philosophy across clients, but not the same installer blindly:
 
-- **First-class** clients have a stable native config contract, so Ontos can ship `ontos mcp install --client ...`, `ontos mcp uninstall --client ...`, and `ontos doctor` validation. Antigravity and Cursor currently fit here in `v4.6`.
-- **Print-config only** clients get a copy-pastable config document but no managed install / doctor promises in `v4.6`. Claude Code, Codex, and VS Code currently fit here.
+- **First-class** clients have a stable native config contract, so Ontos can ship `ontos mcp install --client ...`, `ontos mcp uninstall --client ...`, and `ontos doctor` validation. Antigravity and Cursor currently fit here in `v4.7`.
+- **Print-config only** clients get a copy-pastable config document but no managed install / doctor promises in `v4.7`. Claude Code, Codex, and VS Code currently fit here.
 - **Docs-only** clients stay manual in this release. Claude Desktop and Windsurf currently fit here.
 
 The managed MCP client config is separate from repo-local instruction artifacts such as `AGENTS.md` and `.cursorrules`.

--- a/docs/releases/v4.7.0.md
+++ b/docs/releases/v4.7.0.md
@@ -1,0 +1,111 @@
+---
+id: v470
+type: log
+status: active
+event_type: release
+source: cli
+branch: main
+concepts: [validation, link-check, activation, health, mcp, docs]
+impacts:
+  - ontos_manual
+---
+
+# Ontos v4.7.0
+
+v4.7.0 closes the "Ontos feels unstable" RCA batch — issues
+[#131](https://github.com/ohjonathan/Project-Ontos/issues/131),
+[#132](https://github.com/ohjonathan/Project-Ontos/issues/132),
+[#133](https://github.com/ohjonathan/Project-Ontos/issues/133),
+[#134](https://github.com/ohjonathan/Project-Ontos/issues/134),
+[#135](https://github.com/ohjonathan/Project-Ontos/issues/135), and
+[#136](https://github.com/ohjonathan/Project-Ontos/issues/136) — making
+health/diagnostic surfaces bounded, mutually consistent, and fast on
+medium repos.
+
+## Grouped activation warnings (#132)
+
+- `ontos activate` returns grouped warning summaries by default:
+  `data.validation.warning_groups` buckets by `rule_id` with counts,
+  per-severity tallies, and ≤3 full-record samples; `warnings_total` and
+  `warnings_truncated` make the budget machine-discoverable.
+- New flags: `--warnings {summary,grouped,full}`, `--warning-rule RULE_ID`,
+  `--limit N` (validated ≥1; invalid values fail inside the JSON envelope).
+- The MCP `activate` tool gains `warnings: summary|grouped`; the new
+  paginated **`list_validation_warnings`** tool (rule_id/severity/offset/
+  limit) pages complete records, including info-severity ones.
+- `validation.errors` is never grouped or truncated; status and exit
+  semantics derive from full counts.
+
+## link-check: standard envelope, output controls, ~200x faster (#131, #135)
+
+- `link-check --json` emits the standard command envelope. Top-level
+  `status` is transport status; result quality is `data.result_status`
+  (`clean|warnings|failing`). **Shell exit codes 0/1/2 are unchanged.**
+  Migration: `.summary` → `.data.summary`, root `.status` →
+  `.data.result_status`. `schema_version` is now **3.4** for all commands.
+- New flags: `--summary`, `--limit N` (bounds JSON *and* human sections),
+  `--no-suggestions`, `--frontmatter-only`, `--no-orphans`. Per-phase
+  `data.timings_ms`; stage markers stream to stderr on human runs.
+- Performance: the known-ID body scan no longer sorts the id set per line
+  nor compiles a regex per (line × id); suggestion generation is
+  index-backed, pruned by lossless `quick_ratio` bounds, and memoized.
+  709-doc benchmark: 13+ minutes → 3.3 seconds, byte-identical results.
+- `map --json` gains `data.result_status` (derived from validation counts,
+  so non-strict warning runs are labeled `warnings`, not `clean`),
+  `data.strict`, and grouped `data.diagnostics`.
+
+## External file dependencies (#134)
+
+```toml
+[validation]
+allowed_external_dependency_paths = ["apps/**", "manifests/**"]
+```
+
+- A `depends_on` target that exists on disk and matches the allowlist is
+  classified **`external_file_dependency` at info severity** — reported in
+  the new `validation.info` / `info_groups` surfaces and never flips
+  activation to `usable_with_warnings`. The allowlist matches the
+  *resolved* workspace-relative path, so symlinks cannot dodge it.
+- link-check re-buckets all resolved-on-disk deps into
+  `data.file_dependencies` (`allowlisted` flag per item) with
+  `summary.file_dependencies` / `summary.unallowlisted_file_dependencies`
+  counters. Exit-1 semantics are preserved for unconfigured repos;
+  `maintain` names unallowlisted file deps in its failure details.
+- **Compatibility:** ontos ≤ 4.6.0 rejects configs containing the new key
+  (strict unknown-key validation). Upgrade all CLI installs before
+  adopting it.
+
+## Consistent, basis-labeled health counts (#133)
+
+- `query --health` now uses the same `detect_orphans` + configured
+  `allowed_orphan_types`/`allowed_orphan_paths` as activate/link-check
+  (previously a hard-coded type list produced contradictory orphan
+  counts), and reports `count_basis`/`orphan_basis`/`connectivity_basis`
+  in JSON and text output.
+- Kernel-less workspaces report `connectivity: null` with
+  `not_applicable_no_kernel_docs` instead of a misleading `0.0`.
+- `doctor`'s `activation_health` delegates to the activation pipeline
+  (read-only), so its counts match `ontos activate` by construction; its
+  `validation` check is labeled as the bounded frontmatter quick scan it
+  is. Checks carry a structured `data` block with their `count_basis`.
+- link-check labels its orphan basis
+  (`graph_validation_excluding_external_dependents`) when docs-scope
+  orphans depended on from `.ontos-internal` are filtered.
+- `load_project_config(repo_root=…)` no longer walks above the named
+  root, so a child repo without `.ontos.toml` can never inherit an
+  unrelated ancestor config.
+
+## Context map provenance (#136)
+
+- The map banner reports the installed package version (previously the
+  config-format version `"3.0"` leaked into the display), and frontmatter
+  gains `generator_version`, `scope`, and `documents_loaded`.
+- `ontos doctor` warns when the map's generator version is missing or
+  doesn't match the installed CLI.
+
+## MCP schema notes
+
+`ActivateResponse` adds required warning-budget fields
+(`warnings_total`, `warnings_truncated`, `warning_groups`) and optional
+info fields (`info_total`, `info_groups`); `ValidationPayload` adds
+`info`. Strict clients revalidate via `tools/list` on reconnect.

--- a/ontos/__init__.py
+++ b/ontos/__init__.py
@@ -7,7 +7,7 @@ Package structure:
     ontos.ui   - I/O layer (CLI, output, prompts)
 """
 
-__version__ = "4.6.0"
+__version__ = "4.7.0"
 
 # Re-export commonly used items for convenience
 from ontos.core.context import SessionContext, FileOperation, PendingWrite

--- a/ontos/commands/doctor.py
+++ b/ontos/commands/doctor.py
@@ -23,6 +23,9 @@ class CheckResult:
     status: str  # "success", "failed", "warning"
     message: str
     details: Optional[str] = None
+    # (#133) Structured counts + count_basis labels so doctor's numbers can
+    # be reconciled with the surface they came from (e.g. activate).
+    data: Optional[dict] = None
 
 
 @dataclass
@@ -376,17 +379,19 @@ def check_activation_health(
     scope: Optional[str] = None,
     repo_root: Optional[Path] = None,
 ) -> CheckResult:
-    """(#117) Align doctor severity with activation/link-check health.
+    """(#117/#133) Align doctor counts with `ontos activate` by construction.
 
-    Runs the same snapshot + validation pipeline as `ontos activate` and
-    reports `failed` when any hard error-severity entry is present. Warnings
-    alone remain `warning` (today's behavior); a clean snapshot is `success`.
+    Delegates to the SAME activation pipeline (`run_activation` with
+    write_map=False — read-only) instead of running a parallel snapshot
+    validation, so doctor's warning/error counts can never drift from what
+    `ontos activate` reports. Hard errors → `failed`; warnings alone stay
+    `warning`; clean is `success`.
     """
     try:
-        from ontos.io.snapshot import create_snapshot
+        from ontos.commands.activate import run_activation
 
         root = resolve_project_root(repo_root=repo_root)
-        snapshot = create_snapshot(root, include_content=False, scope=scope)
+        code, payload = run_activation(scope, write_map=False, root=root)
     except Exception as exc:
         return CheckResult(
             name="activation_health",
@@ -395,31 +400,61 @@ def check_activation_health(
             details=str(exc),
         )
 
-    errors = snapshot.validation_result.errors
-    warnings_list = snapshot.validation_result.warnings
-    if errors:
-        details = "; ".join(
-            f"[{e.error_type.value}] {e.message}" for e in errors[:5]
+    summary = payload.get("summary", {})
+    error_count = summary.get("validation_errors", 0)
+    warning_count = summary.get("validation_warnings", 0)
+    load_issue_count = summary.get("load_issues", 0)
+    info_count = summary.get("validation_info", 0)
+    data = {
+        "validation_errors": error_count,
+        "validation_warnings": warning_count,
+        "validation_info": info_count,
+        "load_issues": load_issue_count,
+        "scope": payload.get("scope"),
+        "count_basis": "activation_pipeline",
+    }
+
+    if code != 0:
+        return CheckResult(
+            name="activation_health",
+            status="warning",
+            message="Activation context unavailable",
+            details=payload.get("reason"),
+            data=data,
         )
+
+    if error_count:
+        error_records = payload.get("validation", {}).get("errors", [])
+        details = "; ".join(
+            f"[{record.get('rule_id', 'unknown')}] {record.get('message', '')}"
+            for record in error_records[:5]
+        ) or None
         return CheckResult(
             name="activation_health",
             status="failed",
             message=(
-                f"{len(errors)} activation error(s), "
-                f"{len(warnings_list)} warning(s) — doctor exit aligns with hard errors"
+                f"{error_count} activation error(s), "
+                f"{warning_count} warning(s) — counts match `ontos activate` "
+                "(basis: activation pipeline)"
             ),
             details=details,
+            data=data,
         )
-    if warnings_list:
+    if warning_count or load_issue_count:
         return CheckResult(
             name="activation_health",
             status="warning",
-            message=f"{len(warnings_list)} activation warning(s); no hard errors",
+            message=(
+                f"{warning_count} activation warning(s); no hard errors — "
+                "counts match `ontos activate` (basis: activation pipeline)"
+            ),
+            data=data,
         )
     return CheckResult(
         name="activation_health",
         status="success",
         message="Activation clean (no errors or warnings)",
+        data=data,
     )
 
 
@@ -457,18 +492,29 @@ def check_validation(scope: Optional[str] = None, repo_root: Optional[Path] = No
             except Exception:
                 issues += 1
 
+        # (#133) This is a bounded heuristic, not full validation — label it
+        # as such so its count is never read against activation totals.
+        data = {
+            "count_basis": "frontmatter_quick_scan",
+            "files_checked": min(len(md_files), 50),
+        }
         if issues > 0:
             return CheckResult(
                 name="validation",
                 status="warning",
-                message=f"{issues} potential issues found",
-                details="Run 'ontos map --strict' for full validation"
+                message=(
+                    f"{issues} file(s) missing frontmatter "
+                    "(quick scan, first 50 files; full counts in activation_health)"
+                ),
+                details="Run 'ontos map --strict' for full validation",
+                data=data,
             )
 
         return CheckResult(
             name="validation",
             status="success",
-            message="No obvious issues"
+            message="No obvious issues (quick scan, first 50 files)",
+            data=data,
         )
 
     except Exception as e:

--- a/ontos/commands/query.py
+++ b/ontos/commands/query.py
@@ -9,7 +9,12 @@ from typing import Dict, List, Optional, Tuple, Any
 
 from ontos.core.types import DocumentData, DocumentType
 from ontos.core.graph import build_graph as core_build_graph, detect_cycles
-from ontos.core.config import get_git_last_modified
+from ontos.core.config import ValidationConfig, get_git_last_modified
+from ontos.core.health import (
+    BASIS_GRAPH_VALIDATION,
+    connectivity_summary,
+    orphan_summary,
+)
 from ontos.io.git import get_file_mtime as git_mtime_provider
 from ontos.io.config import load_project_config
 from ontos.io.files import find_project_root, load_documents, DocumentLoadResult
@@ -86,53 +91,61 @@ def query_stale(files_data: Dict[str, DocumentData], days: int) -> List[Tuple[st
     return sorted(stale, key=lambda x: -x[1])
 
 
-def query_health(files_data: Dict[str, DocumentData]) -> dict:
-    """Calculate graph health metrics using core graph primitives."""
-    graph, _ = core_build_graph(files_data)
+def query_health(
+    files_data: Dict[str, DocumentData],
+    *,
+    validation_config: Optional[Any] = None,
+    workspace_root: Optional[Path] = None,
+) -> dict:
+    """Calculate graph health metrics using core graph primitives.
+
+    (#133) Orphan detection delegates to the same ``detect_orphans`` call the
+    validator and link-check use, driven by the project's configured
+    ``allowed_orphan_types``/``allowed_orphan_paths`` — this command used to
+    hard-code a different type list and reimplement the loop inline, which is
+    why query --health reported different orphan counts than activate.
+    Connectivity reports ``None`` with a basis marker when no kernel docs
+    exist instead of a misleading 0.0.
+    """
+    graph, _ = core_build_graph(files_data, workspace_root=workspace_root)
     cycles = detect_cycles(graph)
-    
+
     by_type = defaultdict(int)
     for doc in files_data.values():
         doc_type = doc.type.value
         by_type[doc_type] += 1
-    
-    orphans = []
-    allowed_orphan_types = ['kernel', 'strategy', 'product', 'log']
-    for doc_id, node in graph.nodes.items():
-        if node.doc_type not in allowed_orphan_types:
-            if doc_id not in graph.reverse_edges or not graph.reverse_edges[doc_id]:
-                orphans.append(doc_id)
-    
+
+    if validation_config is None:
+        validation_config = ValidationConfig()
+    orphan_info = orphan_summary(
+        graph,
+        allowed_orphan_types=validation_config.allowed_orphan_types,
+        allowed_orphan_paths=validation_config.allowed_orphan_paths,
+        workspace_root=workspace_root,
+    )
+
     empty_impacts = []
     for doc_id, doc in files_data.items():
         if doc.type.value == 'log':
             if not doc.impacts:
                 empty_impacts.append(doc_id)
-    
-    kernels = [d for d, node in graph.nodes.items() if node.doc_type == 'kernel']
-    reachable = set()
-    
-    def traverse(node):
-        if node in reachable:
-            return
-        reachable.add(node)
-        for child in graph.reverse_edges.get(node, []):
-            traverse(child)
-    
-    for k in kernels:
-        traverse(k)
-    
-    connectivity = len(reachable) / len(files_data) * 100 if files_data else 0
-    
+
+    connectivity_info = connectivity_summary(graph, files_data)
+
     return {
         'total_docs': len(files_data),
         'by_type': dict(by_type),
-        'orphans': len(orphans),
-        'orphan_ids': orphans[:5],
+        'orphans': orphan_info['orphans'],
+        'orphan_ids': orphan_info['orphan_ids'],
+        'orphan_basis': orphan_info['orphan_basis'],
+        'allowed_orphan_types': orphan_info['allowed_orphan_types'],
         'empty_impacts': len(empty_impacts),
         'empty_impact_ids': empty_impacts[:5],
-        'connectivity': connectivity,
-        'reachable_from_kernel': len(reachable),
+        'connectivity': connectivity_info['connectivity'],
+        'reachable_from_kernel': connectivity_info['reachable_from_kernel'],
+        'kernel_docs': connectivity_info['kernel_docs'],
+        'connectivity_basis': connectivity_info['connectivity_basis'],
+        'count_basis': BASIS_GRAPH_VALIDATION,
         'cycles': len(cycles),
         'cycle_samples': cycles[:10],
     }
@@ -151,9 +164,15 @@ def format_health(health: dict) -> str:
     for t, count in sorted(health['by_type'].items()):
         lines.append(f"  {t}: {count}")
     
+    if health.get('connectivity') is None:
+        connectivity_line = "Connectivity: n/a (no kernel documents)"
+    else:
+        connectivity_line = (
+            f"Connectivity: {health['connectivity']:.1f}% reachable from kernel"
+        )
     lines.extend([
         "",
-        f"Connectivity: {health['connectivity']:.1f}% reachable from kernel",
+        connectivity_line,
         f"Orphans: {health['orphans']}",
         f"Cycles: {health.get('cycles', 0)}",
     ])
@@ -252,7 +271,16 @@ def _run_query_command(options: QueryOptions) -> Tuple[int, str]:
             output.success(f"All documents updated within {options.stale} days")
             
     elif options.health:
-        health = query_health(files_data)
+        try:
+            project_config = load_project_config(repo_root=root)
+            validation_config = project_config.validation
+        except Exception:
+            validation_config = None
+        health = query_health(
+            files_data,
+            validation_config=validation_config,
+            workspace_root=root,
+        )
         options.runtime_data = health
         output.plain(format_health(health))
         

--- a/ontos/commands/query.py
+++ b/ontos/commands/query.py
@@ -170,10 +170,16 @@ def format_health(health: dict) -> str:
         connectivity_line = (
             f"Connectivity: {health['connectivity']:.1f}% reachable from kernel"
         )
+    # (#133 review) Mirror the JSON basis labels so the human report also
+    # says which pipeline produced the counts.
+    allowed_types = health.get('allowed_orphan_types')
+    orphan_line = f"Orphans: {health['orphans']}"
+    if allowed_types is not None:
+        orphan_line += f" (allowed types: {', '.join(allowed_types) or 'none'})"
     lines.extend([
         "",
         connectivity_line,
-        f"Orphans: {health['orphans']}",
+        orphan_line,
         f"Cycles: {health.get('cycles', 0)}",
     ])
 
@@ -193,7 +199,10 @@ def format_health(health: dict) -> str:
     
     if health['empty_impact_ids']:
         lines.append(f"  → {', '.join(health['empty_impact_ids'])}")
-    
+
+    if health.get('count_basis'):
+        lines.append(f"Count basis: {health['count_basis']}")
+
     return '\n'.join(lines)
 
 

--- a/ontos/core/health.py
+++ b/ontos/core/health.py
@@ -1,0 +1,96 @@
+"""Shared health-summary helpers and count-basis labels (#133).
+
+Every health surface (doctor, activate, query --health, link-check, map)
+computes from the same primitives and labels the basis of its counts, so
+two commands reporting different numbers always explain why instead of
+reading as contradictory truths.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Optional, Sequence
+
+from ontos.core.graph import DependencyGraph, detect_orphans
+from ontos.core.types import DocumentData
+
+# Count-basis labels. A surface reporting counts must say which pipeline
+# produced them.
+BASIS_ACTIVATION_PIPELINE = "activation_pipeline"
+BASIS_GRAPH_VALIDATION = "graph_validation"
+BASIS_FRONTMATTER_QUICK_SCAN = "frontmatter_quick_scan"
+
+# Connectivity bases.
+CONNECTIVITY_FROM_KERNEL = "reverse_reachability_from_kernel"
+CONNECTIVITY_NOT_APPLICABLE = "not_applicable_no_kernel_docs"
+
+
+def connectivity_summary(
+    graph: DependencyGraph,
+    files_data: Dict[str, DocumentData],
+) -> Dict[str, Any]:
+    """Kernel-reachability connectivity with an explicit basis marker.
+
+    A workspace with no kernel documents reports ``connectivity: None`` and
+    ``connectivity_basis: not_applicable_no_kernel_docs`` instead of a bare
+    0.0 that reads as total graph failure (#133).
+    """
+    kernels = [
+        doc_id for doc_id, node in graph.nodes.items() if node.doc_type == "kernel"
+    ]
+
+    if not kernels:
+        return {
+            "connectivity": None,
+            "reachable_from_kernel": None,
+            "kernel_docs": 0,
+            "connectivity_basis": CONNECTIVITY_NOT_APPLICABLE,
+        }
+
+    reachable: set = set()
+
+    def traverse(node: str) -> None:
+        if node in reachable:
+            return
+        reachable.add(node)
+        for child in graph.reverse_edges.get(node, []):
+            traverse(child)
+
+    for kernel_id in kernels:
+        traverse(kernel_id)
+
+    connectivity = len(reachable) / len(files_data) * 100 if files_data else 0.0
+    return {
+        "connectivity": connectivity,
+        "reachable_from_kernel": len(reachable),
+        "kernel_docs": len(kernels),
+        "connectivity_basis": CONNECTIVITY_FROM_KERNEL,
+    }
+
+
+def orphan_summary(
+    graph: DependencyGraph,
+    *,
+    allowed_orphan_types: Sequence[str],
+    allowed_orphan_paths: Sequence[str] = (),
+    workspace_root: Optional[Path] = None,
+    sample_size: int = 5,
+) -> Dict[str, Any]:
+    """Orphan counts via the canonical detector, with the config echoed.
+
+    This is the same ``detect_orphans`` call the validator and link-check
+    use, so query --health can never disagree with them again (#133).
+    """
+    orphan_ids = detect_orphans(
+        graph,
+        set(allowed_orphan_types),
+        allowed_orphan_paths=list(allowed_orphan_paths),
+        workspace_root=workspace_root,
+    )
+    ordered = sorted(orphan_ids)
+    return {
+        "orphans": len(ordered),
+        "orphan_ids": ordered[:sample_size],
+        "orphan_basis": BASIS_GRAPH_VALIDATION,
+        "allowed_orphan_types": list(allowed_orphan_types),
+    }

--- a/ontos/core/link_diagnostics.py
+++ b/ontos/core/link_diagnostics.py
@@ -145,6 +145,9 @@ class LinkDiagnosticsResult:
     load_warnings: List[DocumentLoadIssue]
     timings_ms: Dict[str, int] = field(default_factory=dict)
     file_dependencies: List[FileDependencyReference] = field(default_factory=list)
+    # (#133) Basis label for the orphan counter: docs-scope runs that
+    # filtered out orphans depended on from .ontos-internal say so.
+    orphan_basis: str = "graph_validation"
 
     @property
     def result_status(self) -> str:
@@ -293,6 +296,11 @@ class LinkDiagnosticsResult:
                 ),
             },
             "timings_ms": dict(self.timings_ms),
+            "count_basis": {
+                "orphans": self.orphan_basis,
+                "broken_references": "frontmatter_plus_body",
+                "file_dependencies": "depends_on_resolved_on_disk",
+            },
             "findings_truncated": bool(truncated_sections),
             "truncated_sections": sorted(truncated_sections),
         }
@@ -548,6 +556,7 @@ def run_link_diagnostics(
 
     phase_start = time.perf_counter()
     orphans: List[OrphanDocument] = []
+    orphan_basis = "graph_validation"
     if include_orphans:
         _notify("Detecting orphans...")
         allowed_orphan_types = set(config.validation.allowed_orphan_types)
@@ -559,6 +568,11 @@ def run_link_diagnostics(
             workspace_root=repo_root,
         )
         if scope == ScanScope.DOCS and external_scope.external_depends_on_index:
+            # (#133 review) Docs-scope orphans depended on from
+            # .ontos-internal are filtered here but NOT by activate/query,
+            # which never load the external scope — so this surface labels
+            # its basis instead of silently disagreeing.
+            orphan_basis = "graph_validation_excluding_external_dependents"
             orphan_ids = [
                 orphan_id
                 for orphan_id in orphan_ids
@@ -628,6 +642,7 @@ def run_link_diagnostics(
         load_warnings=load_result.issues,
         timings_ms=timings_ms,
         file_dependencies=file_dependencies,
+        orphan_basis=orphan_basis,
     )
 
 

--- a/ontos/core/link_diagnostics.py
+++ b/ontos/core/link_diagnostics.py
@@ -571,13 +571,18 @@ def run_link_diagnostics(
             # (#133 review) Docs-scope orphans depended on from
             # .ontos-internal are filtered here but NOT by activate/query,
             # which never load the external scope — so this surface labels
-            # its basis instead of silently disagreeing.
-            orphan_basis = "graph_validation_excluding_external_dependents"
-            orphan_ids = [
+            # its basis instead of silently disagreeing. The label is set
+            # only when the filter actually removed an orphan: the external
+            # index also holds path-style deps that match no orphan id, and
+            # those must not claim an exclusion that never happened.
+            filtered_ids = [
                 orphan_id
                 for orphan_id in orphan_ids
                 if orphan_id not in external_scope.external_depends_on_index
             ]
+            if len(filtered_ids) != len(orphan_ids):
+                orphan_basis = "graph_validation_excluding_external_dependents"
+            orphan_ids = filtered_ids
 
         orphans = [
             OrphanDocument(

--- a/ontos/io/config.py
+++ b/ontos/io/config.py
@@ -41,7 +41,11 @@ def load_project_config(
         ConfigError: If config file exists but is malformed
     """
     if config_path is None:
-        config_path = find_config()
+        # (#133) When the caller names a repo root, discovery starts there —
+        # previously discovery always walked up from CWD, so the same command
+        # could silently load an unrelated ancestor config when invoked from
+        # outside the project.
+        config_path = find_config(repo_root) if repo_root is not None else find_config()
 
     if config_path is None:
         return default_config()

--- a/ontos/io/config.py
+++ b/ontos/io/config.py
@@ -41,11 +41,18 @@ def load_project_config(
         ConfigError: If config file exists but is malformed
     """
     if config_path is None:
-        # (#133) When the caller names a repo root, discovery starts there —
-        # previously discovery always walked up from CWD, so the same command
-        # could silently load an unrelated ancestor config when invoked from
-        # outside the project.
-        config_path = find_config(repo_root) if repo_root is not None else find_config()
+        # (#133) When the caller names a repo root, that root IS the project:
+        # use exactly repo_root/.ontos.toml or defaults. No upward walk —
+        # discovery above repo_root silently inherited an unrelated ancestor
+        # config (verified leak: a child repo without .ontos.toml picked up
+        # the parent's allowed_orphan_types, changing orphan counts).
+        if repo_root is not None:
+            candidate = Path(repo_root) / CONFIG_FILENAME
+            if not candidate.exists():
+                return default_config()
+            config_path = candidate
+        else:
+            config_path = find_config()
 
     if config_path is None:
         return default_config()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ontos"
-version = "4.6.0"
+version = "4.7.0"
 description = "Local-first documentation management for AI-assisted development"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/commands/test_health_count_consistency.py
+++ b/tests/commands/test_health_count_consistency.py
@@ -268,3 +268,29 @@ def test_human_health_output_carries_basis_labels(fixture_repo: Path) -> None:
     assert result.returncode == 0
     assert "Orphans: 1 (allowed types: atom)" in result.stdout
     assert "Count basis: graph_validation" in result.stdout
+
+
+def test_orphan_basis_stays_default_when_filter_removes_nothing(fixture_repo: Path) -> None:
+    """(#133 polish) An .ontos-internal doc whose deps are path-style (or
+    point at non-orphans) must not flip the orphan basis label — the
+    exclusion label is reserved for runs where an orphan was actually
+    filtered."""
+    _write(
+        fixture_repo / ".ontos-internal/internal_doc.md",
+        """
+        ---
+        id: internal_doc
+        type: atom
+        status: active
+        depends_on: [apps/real.py]
+        ---
+        Internal body with a path-style dep only.
+        """,
+    )
+
+    link_check = _payload(_run(fixture_repo, "--json", "link-check"))
+
+    # The docs-scope orphan is untouched by the external index...
+    assert link_check["data"]["summary"]["orphans"] == 1
+    # ...so the basis stays the shared default.
+    assert link_check["data"]["count_basis"]["orphans"] == "graph_validation"

--- a/tests/commands/test_health_count_consistency.py
+++ b/tests/commands/test_health_count_consistency.py
@@ -1,0 +1,223 @@
+"""(#133) Cross-command count-consistency regression.
+
+One fixture repo, four health surfaces — activate, query --health,
+link-check, doctor — must agree on warning/orphan counts (or label their
+basis). This is the regression guarantee that the contradictory numbers
+from the company-os RCA (657 vs 830 warnings, 241 vs 372 orphans) cannot
+come back.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run(root: Path, *args: str) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(PROJECT_ROOT)
+    return subprocess.run(
+        [sys.executable, "-m", "ontos", *args],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(dedent(content).lstrip(), encoding="utf-8")
+
+
+@pytest.fixture
+def fixture_repo(tmp_path: Path) -> Path:
+    """Workspace with every count class: orphans (allowed + flagged), an
+    allowlisted file dep, an unallowlisted file dep, a missing dep, logs
+    under an allowed orphan path, and no kernel docs."""
+    _write(
+        tmp_path / ".ontos.toml",
+        """
+        [ontos]
+        version = "3.0"
+
+        [validation]
+        allowed_orphan_types = ["atom"]
+        allowed_orphan_paths = ["docs/logs/**"]
+        allowed_external_dependency_paths = ["apps/**"]
+        """,
+    )
+    # Real files for dependency targets.
+    _write(tmp_path / "apps/real.py", "code\n")
+    _write(tmp_path / "tools/real.py", "code\n")
+
+    # An orphan strategy doc (strategy not in allowed types -> orphan warning).
+    _write(
+        tmp_path / "docs/strategy_orphan.md",
+        """
+        ---
+        id: strategy_orphan
+        type: strategy
+        status: active
+        ---
+        Body.
+        """,
+    )
+    # A log under the allowed orphan path -> never an orphan.
+    _write(
+        tmp_path / "docs/logs/2026-06-01_session.md",
+        """
+        ---
+        id: log_2026_06_01
+        type: log
+        status: complete
+        ---
+        Log body.
+        """,
+    )
+    # Atom doc with one allowlisted file dep, one unallowlisted file dep,
+    # and one genuinely missing dep.
+    _write(
+        tmp_path / "docs/handoff.md",
+        """
+        ---
+        id: handoff_doc
+        type: atom
+        status: active
+        depends_on: [apps/real.py, tools/real.py, genuinely_missing_doc]
+        ---
+        Handoff body.
+        """,
+    )
+    return tmp_path
+
+
+def _payload(result: subprocess.CompletedProcess) -> dict:
+    assert result.stdout, result.stderr
+    return json.loads(result.stdout)
+
+
+def test_health_surfaces_agree_on_counts(fixture_repo: Path) -> None:
+    activate = _payload(_run(fixture_repo, "--json", "activate", "--warnings", "full"))
+    doctor = _payload(_run(fixture_repo, "--json", "doctor"))
+    link_check = _payload(_run(fixture_repo, "--json", "link-check"))
+    query = _payload(_run(fixture_repo, "--json", "query", "--health"))
+
+    activate_summary = activate["data"]["summary"]
+    activate_warnings = activate["data"]["validation"]["warnings"]
+
+    # --- (1) doctor activation_health counts == activate counts (exact) ---
+    checks = {check["name"]: check for check in doctor["data"]["checks"]}
+    activation_check = checks["activation_health"]
+    assert activation_check["data"]["validation_errors"] == (
+        activate_summary["validation_errors"]
+    )
+    assert activation_check["data"]["validation_warnings"] == (
+        activate_summary["validation_warnings"]
+    )
+    assert activation_check["data"]["count_basis"] == "activation_pipeline"
+    assert "activation pipeline" in activation_check["message"]
+
+    # --- (2) orphan counts identical across activate / query / link-check ---
+    activate_orphans = [
+        w for w in activate_warnings if w.get("rule_id") == "orphan"
+    ]
+    query_data = query["data"]["results"] if "results" in query["data"] else query["data"]
+    link_orphans = link_check["data"]["summary"]["orphans"]
+    assert len(activate_orphans) == 1  # strategy_orphan only
+    assert link_orphans == 1
+    assert query_data["orphans"] == 1
+    assert query_data["orphan_ids"] == ["strategy_orphan"]
+    assert query_data["orphan_basis"] == "graph_validation"
+    assert query_data["allowed_orphan_types"] == ["atom"]
+
+    # --- (3) file dependency bucketing + exit codes ---
+    link_summary = link_check["data"]["summary"]
+    assert link_summary["file_dependencies"] == 2
+    assert link_summary["unallowlisted_file_dependencies"] == 1
+    # broken_references counts ONLY the genuinely missing doc.
+    assert link_summary["broken_references"] >= 1
+    broken_values = {
+        item["value"] for item in link_check["data"]["broken_references"]
+    }
+    assert "genuinely_missing_doc" in broken_values
+    assert "apps/real.py" not in broken_values
+    assert "tools/real.py" not in broken_values
+    assert link_check["exit_code"] == 1
+
+    # --- (4) activate info bucket carries exactly the allowlisted dep ---
+    assert activate_summary["validation_info"] == 1
+    info_records = activate["data"]["validation"]["info"]
+    assert info_records[0]["rule_id"] == "external_file_dependency"
+    assert "apps/real.py" in info_records[0]["message"]
+
+    # --- (5) connectivity reports not-applicable without kernel docs ---
+    assert query_data["connectivity"] is None
+    assert query_data["connectivity_basis"] == "not_applicable_no_kernel_docs"
+    assert query_data["kernel_docs"] == 0
+
+    # --- (6) every surface labels its count basis ---
+    assert query_data["count_basis"] == "graph_validation"
+    assert activation_check["data"]["count_basis"] == "activation_pipeline"
+    validation_check = checks["validation"]
+    assert validation_check["data"]["count_basis"] == "frontmatter_quick_scan"
+    assert "quick scan" in validation_check["message"]
+
+
+def test_orphan_counts_track_config_changes(fixture_repo: Path) -> None:
+    """Allowing strategy orphans must change ALL surfaces in lockstep."""
+    config_path = fixture_repo / ".ontos.toml"
+    config_path.write_text(
+        config_path.read_text(encoding="utf-8").replace(
+            'allowed_orphan_types = ["atom"]',
+            'allowed_orphan_types = ["atom", "strategy"]',
+        ),
+        encoding="utf-8",
+    )
+
+    activate = _payload(_run(fixture_repo, "--json", "activate", "--warnings", "full"))
+    link_check = _payload(_run(fixture_repo, "--json", "link-check"))
+    query = _payload(_run(fixture_repo, "--json", "query", "--health"))
+
+    activate_orphans = [
+        w for w in activate["data"]["validation"]["warnings"]
+        if w.get("rule_id") == "orphan"
+    ]
+    query_data = query["data"]["results"] if "results" in query["data"] else query["data"]
+    assert len(activate_orphans) == 0
+    assert link_check["data"]["summary"]["orphans"] == 0
+    assert query_data["orphans"] == 0
+
+
+def test_query_health_human_output_handles_no_kernel(fixture_repo: Path) -> None:
+    result = _run(fixture_repo, "query", "--health")
+    assert result.returncode == 0
+    assert "n/a (no kernel documents)" in result.stdout
+
+
+def test_query_health_connectivity_with_kernel_docs(fixture_repo: Path) -> None:
+    _write(
+        fixture_repo / "docs/kernel.md",
+        """
+        ---
+        id: kernel_doc
+        type: kernel
+        status: active
+        ---
+        Kernel body.
+        """,
+    )
+    query = _payload(_run(fixture_repo, "--json", "query", "--health"))
+    query_data = query["data"]["results"] if "results" in query["data"] else query["data"]
+    assert query_data["kernel_docs"] == 1
+    assert query_data["connectivity"] is not None
+    assert query_data["connectivity_basis"] == "reverse_reachability_from_kernel"

--- a/tests/commands/test_health_count_consistency.py
+++ b/tests/commands/test_health_count_consistency.py
@@ -221,3 +221,50 @@ def test_query_health_connectivity_with_kernel_docs(fixture_repo: Path) -> None:
     assert query_data["kernel_docs"] == 1
     assert query_data["connectivity"] is not None
     assert query_data["connectivity_basis"] == "reverse_reachability_from_kernel"
+
+
+def test_external_dependent_orphan_divergence_is_labeled(fixture_repo: Path) -> None:
+    """(#133 review) A docs-scope orphan depended on from .ontos-internal is
+    filtered by link-check but not by activate/query (which never load the
+    external scope). The counts legitimately differ — and link-check must
+    LABEL its basis so the difference is explained, not contradictory."""
+    _write(
+        fixture_repo / ".ontos-internal/internal_doc.md",
+        """
+        ---
+        id: internal_doc
+        type: atom
+        status: active
+        depends_on: [strategy_orphan]
+        ---
+        Internal body.
+        """,
+    )
+
+    activate = _payload(_run(fixture_repo, "--json", "activate", "--warnings", "full"))
+    link_check = _payload(_run(fixture_repo, "--json", "link-check"))
+    query = _payload(_run(fixture_repo, "--json", "query", "--health"))
+
+    activate_orphans = [
+        w for w in activate["data"]["validation"]["warnings"]
+        if w.get("rule_id") == "orphan"
+    ]
+    query_data = query["data"]["results"] if "results" in query["data"] else query["data"]
+
+    # activate/query still see the orphan (docs scope only)...
+    assert len(activate_orphans) == 1
+    assert query_data["orphans"] == 1
+    # ...link-check filters it because an internal doc depends on it,
+    # and says so via its basis label.
+    assert link_check["data"]["summary"]["orphans"] == 0
+    assert link_check["data"]["count_basis"]["orphans"] == (
+        "graph_validation_excluding_external_dependents"
+    )
+
+
+def test_human_health_output_carries_basis_labels(fixture_repo: Path) -> None:
+    """(#133 review) The text report mirrors the JSON basis labels."""
+    result = _run(fixture_repo, "query", "--health")
+    assert result.returncode == 0
+    assert "Orphans: 1 (allowed types: atom)" in result.stdout
+    assert "Count basis: graph_validation" in result.stdout

--- a/tests/io/test_config_phase3.py
+++ b/tests/io/test_config_phase3.py
@@ -148,3 +148,46 @@ class TestConfigExists:
         config_path = tmp_path / CONFIG_FILENAME
         config_path.write_text("[ontos]\n")
         assert config_exists(config_path) is True
+
+
+class TestRepoRootDiscovery:
+    """(#133) load_project_config(repo_root=X) must discover X/.ontos.toml
+    even when CWD is outside the project."""
+
+    def test_repo_root_drives_discovery_regardless_of_cwd(self, tmp_path, monkeypatch):
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / CONFIG_FILENAME).write_text(
+            "[ontos]\nversion = '3.0'\n\n[paths]\ndocs_dir = 'documents'\n",
+            encoding="utf-8",
+        )
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        monkeypatch.chdir(elsewhere)
+
+        config = load_project_config(repo_root=project)
+
+        assert config.paths.docs_dir == "documents"
+
+    def test_cwd_ancestor_config_not_picked_up_for_named_root(self, tmp_path, monkeypatch):
+        # An unrelated config above CWD must not leak into a repo_root load.
+        (tmp_path / CONFIG_FILENAME).write_text(
+            "[ontos]\nversion = '3.0'\n\n[paths]\ndocs_dir = 'WRONG'\n",
+            encoding="utf-8",
+        )
+        project = tmp_path / "nested" / "project"
+        project.mkdir(parents=True)
+        monkeypatch.chdir(tmp_path)
+
+        config = load_project_config(repo_root=project)
+
+        # project has no config -> defaults, NOT the ancestor's docs_dir...
+        # discovery from repo_root walks up too, so the ancestor IS found by
+        # upward search; the guarantee is that discovery STARTS at repo_root.
+        # For a project with its own config, the project config wins:
+        (project / CONFIG_FILENAME).write_text(
+            "[ontos]\nversion = '3.0'\n\n[paths]\ndocs_dir = 'RIGHT'\n",
+            encoding="utf-8",
+        )
+        config = load_project_config(repo_root=project)
+        assert config.paths.docs_dir == "RIGHT"

--- a/tests/io/test_config_phase3.py
+++ b/tests/io/test_config_phase3.py
@@ -169,10 +169,15 @@ class TestRepoRootDiscovery:
 
         assert config.paths.docs_dir == "documents"
 
-    def test_cwd_ancestor_config_not_picked_up_for_named_root(self, tmp_path, monkeypatch):
-        # An unrelated config above CWD must not leak into a repo_root load.
+    def test_ancestor_config_never_leaks_into_named_root(self, tmp_path, monkeypatch):
+        """(#133 review) A repo_root WITHOUT its own .ontos.toml gets pure
+        defaults — never an ancestor's config. Verified leak before the fix:
+        a child repo inherited the parent's allowed_orphan_types, changing
+        query --health orphan counts."""
         (tmp_path / CONFIG_FILENAME).write_text(
-            "[ontos]\nversion = '3.0'\n\n[paths]\ndocs_dir = 'WRONG'\n",
+            "[ontos]\nversion = '3.0'\n\n"
+            "[validation]\nallowed_orphan_types = ['kernel']\n\n"
+            "[paths]\ndocs_dir = 'WRONG'\n",
             encoding="utf-8",
         )
         project = tmp_path / "nested" / "project"
@@ -181,10 +186,11 @@ class TestRepoRootDiscovery:
 
         config = load_project_config(repo_root=project)
 
-        # project has no config -> defaults, NOT the ancestor's docs_dir...
-        # discovery from repo_root walks up too, so the ancestor IS found by
-        # upward search; the guarantee is that discovery STARTS at repo_root.
-        # For a project with its own config, the project config wins:
+        # Pure defaults — the ancestor's values must not appear.
+        assert config.paths.docs_dir == "docs"
+        assert config.validation.allowed_orphan_types == ["atom", "log"]
+
+        # With its own config, the project config wins:
         (project / CONFIG_FILENAME).write_text(
             "[ontos]\nversion = '3.0'\n\n[paths]\ndocs_dir = 'RIGHT'\n",
             encoding="utf-8",


### PR DESCRIPTION
Fixes #133. Stacked on #140. Final PR of the #131–#136 batch; includes the v4.7.0 version bump + CHANGELOG.

## Problem
The same workspace produced contradictory health numbers: doctor said 657 activation warnings while activate said 830; `query --health` said 241 orphans while activate/link-check said 372; connectivity read `0.0` with no explanation in kernel-less repos; doctor's "1 potential issues found" coexisted with 830 warnings.

## Root causes fixed
1. **`query --health` hard-coded its own orphan rules** (`['kernel','strategy','product','log']` + an inline reverse-edges loop) instead of using `detect_orphans` with the configured `allowed_orphan_types`/`allowed_orphan_paths` — the literal source of the 241-vs-372 split. Now delegates to the canonical detector via the new shared `ontos/core/health.py` helpers.
2. **doctor ran a different validation pipeline than activate** (`create_snapshot` vs `generate_context_map`). `check_activation_health` now delegates to `run_activation(write_map=False)` (read-only), so its counts match `ontos activate` **by construction** — and its message says so ("basis: activation pipeline").
3. **Unlabeled bases**: `query --health` gains `count_basis`/`orphan_basis`/`connectivity_basis` + `kernel_docs` + the echoed allowlist; doctor `CheckResult` gains a structured `data` block; the misleading "validation" check is relabeled as the 50-file frontmatter quick scan it is.
4. **Kernel-less connectivity**: `connectivity: null` + `connectivity_basis: "not_applicable_no_kernel_docs"` (human: `n/a (no kernel documents)`) instead of a bare `0.0` that reads as total graph failure.
5. **Latent config-discovery divergence**: `load_project_config(repo_root=…)` now starts discovery at the named root, not CWD.

## The regression guarantee
New `tests/commands/test_health_count_consistency.py`: one fixture repo (allowed/flagged orphans, allowlisted + unallowlisted + missing deps, logs under an orphan-path allowlist, no kernel docs), run through `activate` / `query --health` / `link-check` / `doctor` via subprocess, asserting: identical warning counts (activate ↔ doctor), identical orphan counts across all three orphan surfaces (including in lockstep after a config change), correct file-dependency bucketing/exit codes, the connectivity-N/A marker, and a `count_basis` label on every surface.

## Release
`__version__`/pyproject → **4.7.0**; CHANGELOG entry covering all six issues with migration notes (link-check envelope cutover with jq mapping, grouped-warnings default, re-bucketing note for CI, the ≤4.6.0 config-key rejection caveat, MCP schema changes).

Full suite: 1433 passed, 2 skipped. Verified end-to-end on a scratch repo: activate/query/doctor counts agree, doctor reports "counts match `ontos activate`", map banner shows generator 4.7.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)