### PR TITLE
docs: bring client-facing docs up to date for v4.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,9 +363,9 @@ The managed MCP client config is separate from repo-local instruction artifacts 
 
 ### 4. Available Tools
 
-The MCP server exposes up to 17 tools depending on server flags:
+The MCP server exposes up to 18 tools depending on server flags:
 
-**Core (10 tools — always available):**
+**Core (11 tools — always available):**
 
 | Tool | Purpose | Read-only |
 |------|---------|:---------:|
@@ -374,6 +374,7 @@ The MCP server exposes up to 17 tools depending on server flags:
 | `context_map` | Full context map (supports compact modes) | ✅ |
 | `get_document` | Read one document by ID or path | ✅ |
 | `list_documents` | Paginated listing with type/status filters | ✅ |
+| `list_validation_warnings` | Paginated full validation warning records (filter by rule/severity) — v4.7 | ✅ |
 | `export_graph` | Structured graph export (optional file output) | ⚠️ |
 | `query` | Dependency details for a single document | ✅ |
 | `health` | Server uptime, document count, version | ✅ |

--- a/docs/reference/Migration_v3_to_v4.md
+++ b/docs/reference/Migration_v3_to_v4.md
@@ -58,6 +58,7 @@ pip install 'ontos[mcp]'    # Adds mcp>=1.27.0 and pydantic>=2.0
 | `query` | Dependency details for a single document |
 | `health` | Server uptime, document count, index freshness, version |
 | `refresh` | Force cache rebuild after bulk changes |
+| `list_validation_warnings` | Paginated full validation warning records, filterable by rule/severity (v4.7) |
 
 ### Additional MCP Tools (v4.1+)
 
@@ -90,7 +91,7 @@ All write tools use advisory flock locking (`workspace_lock()`) for cross-proces
 
 All tools are read-only except `export_graph` with `export_to_file` (writes within workspace root) and the write tools above. In read-only mode, use the CLI fallback `ontos log -e "slug"` for session archives.
 
-### v4.4-v4.6 Activation and Diagnostics
+### v4.4-v4.7 Activation and Diagnostics
 
 `ontos activate` is additive and safe for existing workflows. It refreshes the context map when possible, returns `usable`, `usable_with_warnings`, or `not_usable`, and exits non-zero only when no actionable context can be produced.
 
@@ -108,6 +109,8 @@ Frontmatter diagnostics now include path, line when available, field, observed v
 v4.5 makes common lifecycle artifact tagging first-class. In addition to the core `kernel`, `strategy`, `product`, `atom`, and `log` hierarchy, Ontos accepts `reference`, `concept`, `handoff`, `tracker`, `retro`, `review`, `spec`, `report`, `adr`, and `policy`. Lifecycle workflow statuses such as `proposed`, `ready`, `completed`, `revised`, and `in-lifecycle` are also accepted so review and handoff documents keep their source semantics.
 
 v4.6 changes only the `activate --json` validation payload shape. `payload.data.validation.warnings` and `payload.data.validation.errors` are now lists of objects carrying `severity`, `message`, and, when available, `rule_id`, `document_id`, and `file_path`. Consumers that previously expected `list[str]` should read `record["message"]`.
+
+v4.7 groups activation warnings by default: `data.validation.warnings` is `[]` unless you pass `--warnings full`, with grouped summaries in `warning_groups` and totals in `warnings_total`/`warnings_truncated` (`validation.errors` is always complete). `link-check --json` now emits the standard command envelope — read counts from `.data.summary` and result quality from `.data.result_status`; shell exit codes are unchanged, and `schema_version` is `3.4`. Resolved-on-disk `depends_on` targets move from broken references to `data.file_dependencies`, controllable via `[validation] allowed_external_dependency_paths` (note: ontos ≤ 4.6.0 rejects configs containing this key — upgrade every CLI install before adopting it).
 
 ### File-Mtime Cache Invalidation
 

--- a/docs/reference/Ontos_Agent_Instructions.md
+++ b/docs/reference/Ontos_Agent_Instructions.md
@@ -7,8 +7,8 @@ depends_on: [ontos_manual]
 
 # Ontos Agent Instructions
 
-> **v4.3:** All CLI commands use `ontos <command>` (package installed via pip).
-> Agents can also connect via MCP server (`ontos serve`) for native integration — up to 15 tools including 4 write tools and portfolio search.
+> **v4.7:** All CLI commands use `ontos <command>` (package installed via pip).
+> Agents can also connect via MCP server (`ontos serve`) for native integration — up to 18 tools including 5 write tools and portfolio search.
 > `ontos retrofit --obsidian` is the CLI write path for landing computed `tags` and `aliases` into on-disk frontmatter for Obsidian.
 > Use `python3 -m ontos <command>` if not installed globally.
 > See [Ontos Manual](Ontos_Manual.md) for details.
@@ -35,7 +35,7 @@ ontos init --no-scaffold # Skip scaffold prompt
 If the IDE supports MCP and the Ontos server is configured:
 
 1. The IDE connects to `ontos serve` automatically on startup
-2. Call `activate` first; it marks the MCP session activated and returns status plus loaded IDs
+2. Call `activate` first; it marks the MCP session activated and returns status, loaded IDs, and grouped warning summaries (v4.7) — page full warning records with `list_validation_warnings` when needed
 3. Use `workspace_overview` to get project orientation (key documents, graph stats)
 4. Use `get_document` to read specific documents by ID
 5. Use `context_map` for the full context narrative
@@ -52,6 +52,7 @@ If a read tool is used before `activate`, the server includes `_ontos_warning` i
 | `context_map` | Full context map (supports compact modes) |
 | `get_document` | Read one document by ID or path |
 | `list_documents` | Browse documents with type/status filters |
+| `list_validation_warnings` | Page full validation warning records by rule/severity (v4.7) |
 | `export_graph` | Structured graph export |
 | `query` | Dependency details for one document |
 | `health` | Server health and index freshness |

--- a/docs/reference/Ontos_Manual.md
+++ b/docs/reference/Ontos_Manual.md
@@ -108,7 +108,7 @@ Say **"Ontos"** to your AI agent. It will:
 3. Load relevant files based on your request
     print("Loaded: [id1, id2]")
 
-`ontos activate --json` returns `usable`, `usable_with_warnings`, or `not_usable`. Warnings are non-blocking when the command can still produce actionable context.
+`ontos activate --json` returns `usable`, `usable_with_warnings`, or `not_usable`. Warnings are non-blocking when the command can still produce actionable context. Since v4.7 warnings are grouped by rule by default (`warning_groups` with counts and bounded samples); use `--warnings full` for inline records, `--warning-rule <rule_id>` to filter, and `--limit N` to cap inline output. The MCP equivalent pages full records through the `list_validation_warnings` tool.
     
 ### Query Graph
 Say **"Query Ontos"** to find connections:
@@ -654,7 +654,7 @@ ontos env --write --force
 -   **Node.js:** `package.json`
 -   **Generic:** `.tool-versions` (asdf), `Makefile`, `Dockerfile`
 
-### 10.2 Link Check (v3.3)
+### 10.2 Link Check (v3.3, expanded v4.7)
 
 The `link-check` command scans all documents for broken references, duplicate IDs, and orphaned documents.
 
@@ -662,18 +662,43 @@ The `link-check` command scans all documents for broken references, duplicate ID
 # Check for broken references
 ontos link-check
 
-# JSON output for CI
+# JSON output for CI (standard envelope since v4.7; counts under .data.summary)
 ontos link-check --json
 
 # Limit scan scope
 ontos link-check --scope docs
+
+# v4.7 output controls
+ontos link-check --summary            # counters only, skips suggestions
+ontos link-check --limit 20           # cap each findings list (JSON and human)
+ontos link-check --no-suggestions     # skip fix-suggestion generation
+ontos link-check --frontmatter-only   # skip body reference scanning
+ontos link-check --no-orphans         # skip orphan detection (removes exit 2)
 ```
+
+Since v4.7 the JSON output uses the standard command envelope: top-level
+`status` is transport status, result quality lives in `data.result_status`
+(`clean` | `warnings` | `failing`), and per-phase timings appear under
+`data.timings_ms`. Shell exit codes are unchanged.
+
+`depends_on` entries that resolve to real files outside the doc scope are
+reported under `data.file_dependencies` instead of broken references. Mark
+intentional doc-to-file edges with workspace-relative globs:
+
+```toml
+[validation]
+allowed_external_dependency_paths = ["apps/**", "manifests/**"]
+```
+
+Allowlisted entries become info-severity `external_file_dependency` records
+and never affect exit codes; unallowlisted ones keep the historical exit-1
+behavior.
 
 **Exit codes:**
 | Code | Meaning |
 |------|---------|
 | `0`  | No issues found |
-| `1`  | Broken references or duplicates detected |
+| `1`  | Broken references, duplicates, or unallowlisted file dependencies detected |
 | `2`  | Orphan-only findings (no broken references or duplicates) |
 
 ### 10.3 Rename (v3.3)
@@ -816,6 +841,7 @@ The managed MCP client config is separate from repo-local instruction artifacts 
 | `context_map` | Full context map markdown | `compact`: basic, rich, tiered, or full |
 | `get_document` | Read one document with full frontmatter and metadata | `document_id` or `path`, `include_content` |
 | `list_documents` | Paginated listing of canonical documents | `type`, `status`, `offset`, `limit` |
+| `list_validation_warnings` | Paginated full validation warning records (v4.7) | `rule_id`, `severity`, `offset`, `limit` |
 | `export_graph` | Structured graph export (nodes, edges, summary) | `summary_only`, `export_to_file` |
 | `query` | Dependency details for a single document | `entity_id` |
 | `health` | Server uptime, document count, index freshness | — |


### PR DESCRIPTION
Pre-tag docs polish: MCP tool tables across README / manual / migration guide / agent instructions gain `list_validation_warnings` (core count 10→11, max surface corrected to 18); the manual documents the v4.7 link-check output controls, JSON envelope, and `allowed_external_dependency_paths`; the migration guide covers the v4.7 contract changes and the ≤4.6.0 config-key caveat; agent instructions describe the grouped-warnings activation flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)